### PR TITLE
draft dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,15 +3,16 @@
   "name": "Journiv Development",
   "build": {
     "dockerfile": "../Dockerfile",
-    "context": ".."
+    "context": "..",
+    "target": "dev"
   },
   "workspaceFolder": "/app",
 
   // Use shared development environment file
   "runArgs": ["--env-file", "${localWorkspaceFolder}/.env.dev"],
 
-  // Post-start command to ensure directories exist and setup shell
-  "postStartCommand": "mkdir -p /data/media /data/logs && (command -v starship >/dev/null 2>&1 || (curl -sS https://starship.rs/install.sh | sh -s -- -y && echo 'eval \"$(starship init bash)\"' >> ~/.bashrc))",
+  // Post-start command to ensure directories exist, install git-lfs, and setup shell
+  "postStartCommand": "sudo apk add --no-cache git-lfs && git lfs install && mkdir -p /data/media /data/logs && (command -v starship >/dev/null 2>&1 || (curl -sS https://starship.rs/install.sh | sh -s -- -y && echo 'eval \"$(starship init bash)\"' >> ~/.bashrc))",
 
   // Override the default CMD to not start the server automatically
   "overrideCommand": true,
@@ -139,6 +140,6 @@
     "source=${localWorkspaceFolder}/data,target=/data,type=bind"
   ],
 
-  // Explicitly disable features
+  // No additional features needed (git-lfs installed via postStartCommand)
   "features": {}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,3 +92,19 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8000/api/v1/health || exit 1
 
 CMD ["/app/scripts/docker-entrypoint.sh"]
+
+# =========================
+# Stage 3: Development
+# =========================
+FROM runtime AS dev
+
+# Switch back to root to install sudo and configure permissions
+USER root
+
+# Install sudo and give appuser permission to use apk for package management
+# particularly needed for git-lfs installation
+RUN apk add --no-cache sudo \
+  && echo "appuser ALL=(ALL) NOPASSWD: /sbin/apk" >> /etc/sudoers
+
+# Switch back to appuser for development work
+USER appuser


### PR DESCRIPTION
## Change: SQLite dev service from pre-built image to local build

### Problem
The SQLite development service (app) in docker-compose.dev.yml was using a pre-built image (`swalabtech/journiv-app:latest`), which caused issues with VS Code devcontainer setup. When attempting to use devcontainers, the build process failed because devcontainer features (like git and github-cli) couldn't be properly layered onto the pulled image.

### Solution
Changed the SQLite service to use `build: .` instead of pulling the pre-built image, making it consistent with the PostgreSQL service configuration.

### Impact Analysis

**For pure Docker users:**
- **First-time setup**: ~5-10 minutes to build (vs ~30-60 seconds to pull)
- **Day-to-day development**: No change - hot reload still works identically
- **Subsequent starts**: No change - cached image starts in ~5-10 seconds
- **When dependencies update**: Requires rebuild (but uses layer caching)

**Benefits:**
1. **Devcontainer compatibility**: Now works with VS Code devcontainers and GitHub Codespaces
2. **Consistency**: Both SQLite and PostgreSQL services now use the same build approach
3. **Local modification**: Developers can modify the Dockerfile if needed
4. **No external dependency**: Doesn't require Docker Hub access or network connectivity
5. **Better for contributors**: More transparent and easier to customize

**Trade-offs:**
- Slightly slower initial setup (one-time cost)
- Requires local disk space for built image
- Need to rebuild when Dockerfile or requirements change

### Conclusion
The one-time build cost is acceptable given the improved developer experience, consistency, and devcontainer support. The day-to-day development workflow remains unchanged.