### PR TITLE
feat: Fix #18 support disabling new account creation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,10 @@ ENVIRONMENT=production  # Options: development, staging, production
 # Example: DOMAIN_NAME=journiv.myhomelab.com
 DOMAIN_NAME=
 
+# When true, all new account creation (email or OIDC) is blocked.
+# When enabled, only existing users can log in (OIDC_AUTO_PROVISION is ignored).
+DISABLE_SIGNUP=false
+
 # =============================================================================
 # Security Settings (CRITICAL - MUST CONFIGURE FOR PRODUCTION)
 # =============================================================================
@@ -71,12 +75,12 @@ DATABASE_URL="sqlite:///./journiv.db"
 # PostgreSQL example (optional, for multi-user deployments)
 # DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
-# Alternative: Set individual components (used in Docker)
-POSTGRES_USER=journiv
-POSTGRES_PASSWORD=  # MUST SET SECURE PASSWORD
-POSTGRES_DB=journiv_prod
-POSTGRES_HOST=db
-POSTGRES_PORT=5432
+# Alternative: Set individual components (used in Docker).
+# POSTGRES_USER=journiv
+# POSTGRES_PASSWORD=  # MUST SET SECURE PASSWORD
+# POSTGRES_DB=journiv_prod
+# POSTGRES_HOST=db
+# POSTGRES_PORT=5432
 
 
 # =============================================================================
@@ -128,8 +132,7 @@ OIDC_REDIRECT_URI=https://${DOMAIN_NAME}:${APP_PORT}/api/v1/auth/oidc/callback
 # OAuth2 scopes to request (space-separated)
 OIDC_SCOPES="openid email profile"
 
-# Auto-provision new users from OIDC (create account on first login)
-# Set to false to require manual user registration before OIDC login
+# Allow automatic OIDC user creation on first login (ignored when DISABLE_SIGNUP=true)
 OIDC_AUTO_PROVISION=true
 
 # DEVELOPMENT ONLY: Disable SSL verification for self-signed certificates

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -96,6 +96,10 @@ class Settings(BaseSettings):
     log_file: Optional[str] = None
     log_dir: str = "/data/logs"
 
+    # Disable signup
+    disable_signup: bool = Field(
+        default_factory=lambda: os.getenv("DISABLE_SIGNUP", "false").lower() == "true"
+    )
 
     # Rate limiting
     rate_limiting_enabled: bool = Field(

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlmodel import Session, select
+from app.core.config import settings
 
 from app.core.exceptions import (
     UserNotFoundError,
@@ -63,6 +64,13 @@ class UserService:
             return external_identity is not None
         except ValueError:
             return False
+
+    def is_signup_disabled(self) -> bool:
+        """Check if signup is disabled from app settings.
+        Returns:
+            bool: True if signup is disabled, False otherwise.
+        """
+        return settings.disable_signup
 
     def create_user(self, user_data: UserCreate) -> User:
         """Create a new user."""


### PR DESCRIPTION
Fixes #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global configuration option to disable new user signups, blocking both email registration and OIDC-based account creation.
  * Existing accounts continue to be able to sign in when signups are disabled; OIDC automatic provisioning is ignored while disabled.

* **Documentation**
  * Updated configuration descriptions to clarify the signup-disable flag and OIDC auto-provisioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->