### PR TITLE
Only require redis with oidc

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -48,9 +48,9 @@ async def lifespan(app: FastAPI):
         init_db()
         log_info("Database initialization completed!")
 
-        # Initialize cache for OIDC state management
-        app.state.cache = create_cache(settings.redis_url)
-        log_info("Cache initialization completed!")
+        if settings.oidc_enabled:
+            app.state.cache = create_cache(settings.redis_url)
+            log_info("Cache initialization completed!")
     except Exception as exc:
         log_error(exc)
         raise

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,17 @@
 services:
-  redis:
-    image: redis:7
-    container_name: journiv-redis
-    restart: unless-stopped
-    volumes:
-      - redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   journiv:
     image: swalabtech/journiv-app:latest
     container_name: journiv
     ports:
-      - "${APP_PORT:-8000}:8000"
+      # if you want to expose on a different port, change the left hand side of colon to the port
+      # you want to expose on do not change the 8000 on the right hand side
+      - "8000:8000"
     environment:
-      # Required
-      - SECRET_KEY=${SECRET_KEY}
-      - DOMAIN_NAME=${DOMAIN_NAME:-}
-
-      # Basic config
-      - ENVIRONMENT=production
-      - DEBUG=false
-
-      # Optional: disable new signups
-      - DISABLE_SIGNUP=${DISABLE_SIGNUP:-false}
-
+      - SECRET_KEY=your-secret-key-here # (REQUIRED) Replace with a strong secret key
+      - DOMAIN_NAME=192.168.1.1 # (REQUIRED) Your server IP or domain
     volumes:
       - journiv_data:/data
-    depends_on:
-      redis:
-        condition: service_healthy
     restart: unless-stopped
 
 volumes:
   journiv_data:
-  redis_data:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Simplified Docker deployment by removing Redis service, reducing infrastructure complexity
  - Updated application port mapping to fixed port 8000 for consistent deployment
  - Streamlined deployment configuration with explicit environment values and clearer requirements
  - Made Redis optional in system configuration, improving deployment flexibility
  - Refined OIDC feature validation and cache initialization logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->