### PR TITLE
Add E2E smoke test workflow for CI/CD

### DIFF
--- a/.github/workflows/e2e-smoke-test.yml
+++ b/.github/workflows/e2e-smoke-test.yml
@@ -62,6 +62,13 @@ jobs:
 
           echo "✅ Environment file created"
 
+      - name: Cleanup previous docker leftovers
+        run: |
+          echo "🧹 Cleaning up any previous Docker containers and volumes..."
+          APP_VERSION=latest docker compose -f docker-compose.prod.sqlite.yml down -v 2>/dev/null || true
+          docker volume prune -f || true
+          echo "✅ Cleanup complete"
+
       - name: Start Journiv with Docker Compose
         run: |
           echo "🚀 Starting Journiv services with APP_VERSION=latest..."
@@ -144,5 +151,6 @@ jobs:
         if: always()
         run: |
           echo "🧹 Cleaning up..."
-          APP_VERSION=latest docker compose -f docker-compose.prod.sqlite.yml down -v
+          APP_VERSION=latest docker compose -f docker-compose.prod.sqlite.yml down -v || true
+          docker volume prune -f || true
           echo "✅ Cleanup complete"


### PR DESCRIPTION
This commit adds a simple GitHub Actions workflow that:
- Builds the Journiv Docker image
- Spins up services using docker-compose.prod.sqlite.yml
- Waits for the backend to become healthy
- Tests the /api/v1/health endpoint
- Fails if container doesn't start or health check fails

The workflow:
- Runs on every push to main and all pull requests
- Uses docker compose (v2) not docker-compose (v1)
- Includes retry logic with up to 30 attempts
- Provides detailed logging for debugging
- Cleans up containers after tests

This is the foundation for future enhancements like:
- Database matrix testing (SQLite/Postgres)
- Upgrade path testing
- Data seeding and migration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated end-to-end smoke test workflow that runs on pushes and pull requests. It builds the app image, starts services in a test environment, polls the health endpoint with retries and diagnostic dumps, captures recent logs on success (and full logs plus auxiliary service logs on failure), and always performs teardown/cleanup for reliable verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->