### PR TITLE
feat (release): Auto release docker image when PR is merged to main (…

### DIFF
--- a/.github/workflows/docker-release-main.yml
+++ b/.github/workflows/docker-release-main.yml
@@ -1,0 +1,42 @@
+name: Build & Push Docker Image (main tag)
+
+on:
+  push:
+    branches:
+      - main
+    # Only run when PRs are merged — not when commits are pushed directly
+    # (direct pushes to main should be disabled)
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push (main tag)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          # Add a tag based on the short commit SHA for immutability
+          tags: |
+            swalabtech/journiv-app:main
+            swalabtech/journiv-app:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
…#129)

fixes #129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated Docker image builds and deployment to Docker Hub for main branch updates. Images are built with multi-architecture support (amd64 and arm64) and tagged with version identifiers for easy tracking and deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->