### PR TITLE
fix(media) delete media files on disk on entry or journal delete

### DIFF
--- a/app/api/v1/endpoints/entries.py
+++ b/app/api/v1/endpoints/entries.py
@@ -290,7 +290,7 @@ async def delete_entry(
     """
     entry_service = EntryService(session)
     try:
-        entry_service.delete_entry(entry_id, current_user.id)
+        await entry_service.delete_entry(entry_id, current_user.id)
         log_user_action(current_user.email, "Deleted entry", request_id=None)
     except EntryNotFoundError:
         raise HTTPException(status_code=404, detail="Entry not found")

--- a/app/api/v1/endpoints/journals.py
+++ b/app/api/v1/endpoints/journals.py
@@ -179,7 +179,7 @@ async def delete_journal(
     """
     journal_service = JournalService(session)
     try:
-        journal_service.delete_journal(journal_id, current_user.id)
+        await journal_service.delete_journal(journal_id, current_user.id)
         log_user_action(current_user.email, f"deleted journal {journal_id}", request_id=None)
     except JournalNotFoundError:
         raise HTTPException(status_code=404, detail="Journal not found")


### PR DESCRIPTION
fixes #143 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entry and journal deletion now properly removes all associated media files and their stored data in addition to database records.
  * Improved error handling ensures media cleanup completes reliably, allowing deletion operations to succeed even if individual file removals encounter issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->