### PR TITLE
Remove prompt parameter from OIDC request

### DIFF
--- a/app/api/v1/endpoints/oidc.py
+++ b/app/api/v1/endpoints/oidc.py
@@ -105,7 +105,6 @@ async def oidc_login(request: Request):
         code_challenge=challenge,
         code_challenge_method="S256",
         nonce=nonce,
-        prompt="login"
     )
 
 


### PR DESCRIPTION
Removed 'prompt' parameter from OIDC request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the OAuth authentication flow to improve the login experience by streamlining authentication prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->