### PR TITLE
fix: Add updated time to EntryPreviewResponse

### DIFF
--- a/app/api/v1/endpoints/tags.py
+++ b/app/api/v1/endpoints/tags.py
@@ -609,6 +609,7 @@ async def get_entries_by_tag(
                 content=(entry.content[:200] + "..." if len(entry.content or "") > 200 else entry.content or ""),
                 journal_id=entry.journal_id,
                 created_at=entry.created_at,
+                updated_at=entry.updated_at,
                 entry_date=entry.entry_date,
                 entry_datetime_utc=entry.entry_datetime_utc,
                 entry_timezone=entry.entry_timezone

--- a/app/schemas/entry.py
+++ b/app/schemas/entry.py
@@ -68,6 +68,7 @@ class EntryPreviewResponse(TimestampMixin):
     content: str  # Truncated by endpoint
     journal_id: uuid.UUID
     created_at: datetime
+    updated_at: datetime
     entry_date: date
     entry_datetime_utc: datetime
     entry_timezone: str

--- a/tests/unit/core/test_scoped_cache.py
+++ b/tests/unit/core/test_scoped_cache.py
@@ -115,3 +115,4 @@ class TestScopedCacheOperations:
         mock_cache.delete.assert_any_call("test_namespace:validation:scope-123")
         mock_cache.delete.assert_any_call("test_namespace:info:scope-123")
 
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entry preview responses now include the `updated_at` timestamp, allowing users to see when entries were last modified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->