### PR TITLE
fix: init app_version to semantic version always

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -46,6 +46,7 @@ setup_logging()
 async def lifespan(app: FastAPI):
     """Application lifespan events."""
     log_info("Starting up Journiv Service...")
+    log_info(f"Journiv version: {settings.app_version}")
     try:
         init_db()
         log_info("Database initialization completed!")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application now displays version information at startup
  * Improved version management to ensure the reported version consistently matches the code version

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->