### PR TITLE
fix: format wait time

### DIFF
--- a/app/api/v1/endpoints/version.py
+++ b/app/api/v1/endpoints/version.py
@@ -12,7 +12,7 @@ from app.core.database import get_session
 from app.core.logging_config import log_info, log_warning
 from app.models.user import User
 from app.schemas.version import VersionInfoResponse, ForceVersionCheckResponse
-from app.services.version_checker import VersionChecker
+from app.services.version_checker import VersionChecker, format_wait_time
 
 router = APIRouter(prefix="/instance/version", tags=["version"])
 
@@ -87,11 +87,10 @@ async def force_version_check(
     # Handle rate limiting
     if result.get("rate_limited"):
         retry_after = result.get("retry_after_seconds", 3600)
-        minutes = retry_after // 60
 
         return ForceVersionCheckResponse(
             success=False,
-            message=f"Rate limited. Please wait {minutes} minute(s) before checking again.",
+            message=f"Rate limited. Please wait {format_wait_time(retry_after)} before checking again.",
             version_info=VersionInfoResponse(**info) if info.get("latest_version") else None,
             retry_after_seconds=retry_after
         )

--- a/app/schemas/license.py
+++ b/app/schemas/license.py
@@ -61,7 +61,7 @@ class LicenseInfoResponse(BaseModel):
     """
 
     is_active: bool = Field(..., description="Whether license is currently active")
-    tier: str = Field(..., description="License tier (none, supporter, believer)")
+    tier: Optional[str] = Field(None, description="License tier (none, supporter, believer)")
     license_type: str = Field(..., description="License type: 'subscription' or 'lifetime'")
     subscription_expires_at: Optional[str] = Field(None, description="Subscription expiration timestamp (ISO format). NULL for lifetime licenses.")
     install_id: str = Field(..., description="Hardware-bound installation identifier for license binding")

--- a/app/services/version_checker.py
+++ b/app/services/version_checker.py
@@ -31,6 +31,38 @@ from app.plus.exceptions import (
 )
 
 
+def format_wait_time(seconds: int) -> str:
+    """
+    Format wait time in a user-friendly way.
+
+    Args:
+        seconds: Number of seconds to wait
+
+    Returns:
+        Human-readable string like "1 day(s) and 2 hour(s)" or "3 hour(s) and 15 minute(s)"
+    """
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+
+    if hours == 0 and minutes == 0:
+        minutes = 1
+
+    if hours >= 24:
+        days = hours // 24
+        remaining_hours = hours % 24
+        if remaining_hours > 0:
+            return f"{days} day(s) and {remaining_hours} hour(s)"
+        else:
+            return f"{days} day(s)"
+    elif hours > 0:
+        if minutes > 0:
+            return f"{hours} hour(s) and {minutes} minute(s)"
+        else:
+            return f"{hours} hour(s)"
+    else:
+        return f"{minutes} minute(s)"
+
+
 class VersionChecker:
     """
     Service for checking Journiv version updates from Plus server.
@@ -249,7 +281,7 @@ class VersionChecker:
                 "rate_limited": True,
                 "retry_after_seconds": e.retry_after,
                 "status_code": 429,
-                "error_message": f"Rate limited. Please wait {e.retry_after // 60} minutes."
+                "error_message": f"Rate limited. Please wait {format_wait_time(e.retry_after)}."
             }
 
         except PlusRegistrationError as e:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate-limit messages now display retry waits in a human-friendly format (minutes, hours, or days).

* **API Changes**
  * License response's tier field is now optional, allowing responses without a tier value.

* **Behavior**
  * Version check messages standardized to use the new human-friendly wait-time format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->