### PR TITLE
fix: allow geolocation microphone and camera on same origin

### DIFF
--- a/app/core/csp_config.py
+++ b/app/core/csp_config.py
@@ -232,9 +232,9 @@ class CSPConfig:
 
     def _get_permissions_policy(self) -> str:
         permissions = [
-            "geolocation=()",
-            "microphone=()",
-            "camera=()",
+            "geolocation=(self)",
+            "microphone=(self)",
+            "camera=(self)",
             "payment=()",
             "usb=()",
             "magnetometer=()",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enabled geolocation, microphone, and camera permissions for the application, allowing these features to function when needed on the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->