### PR TITLE
fix: expose env setting through API for frontend #292

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -4,7 +4,8 @@ API v1 router.
 from fastapi import APIRouter
 from app.api.v1.endpoints import (
     auth, users, journals, entries, moods, prompts, tags,
-    analytics, media, health, security, oidc, admin, version, license, location, weather
+    analytics, media, health, security, oidc, admin, version, license, location, weather,
+    instance_config
 )
 # Import/Export routers
 from app.api.v1.endpoints.export_data import router as export_router
@@ -28,6 +29,7 @@ api_router.include_router(import_router)
 api_router.include_router(health.router)
 api_router.include_router(security.router)
 api_router.include_router(version.router)
+api_router.include_router(instance_config.router)
 api_router.include_router(admin.router)
 api_router.include_router(license.router)
 api_router.include_router(location.router)

--- a/app/api/v1/endpoints/instance_config.py
+++ b/app/api/v1/endpoints/instance_config.py
@@ -1,0 +1,31 @@
+"""
+Instance configuration endpoints.
+"""
+from fastapi import APIRouter
+
+from app.core.config import settings
+from app.schemas.instance import InstanceConfigResponse
+
+router = APIRouter(prefix="/instance", tags=["instance"])
+
+
+@router.get(
+    "/config",
+    response_model=InstanceConfigResponse,
+    summary="Get public instance configuration",
+    responses={
+        200: {"description": "Instance configuration retrieved successfully"},
+        500: {"description": "Internal server error"},
+    }
+)
+async def get_instance_config() -> InstanceConfigResponse:
+    """
+    Get public instance configuration.
+
+    Returns non-sensitive instance configuration settings for the frontend,
+    including import/export file size limits and signup status.
+    """
+    return InstanceConfigResponse(
+        import_export_max_file_size_mb=settings.import_export_max_file_size_mb,
+        disable_signup=settings.disable_signup,
+    )

--- a/app/schemas/instance.py
+++ b/app/schemas/instance.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class InstanceConfigResponse(BaseModel):
+    """Public instance configuration safe for frontend consumption."""
+
+    import_export_max_file_size_mb: int
+    disable_signup: bool

--- a/tests/integration/test_instance_config_endpoints.py
+++ b/tests/integration/test_instance_config_endpoints.py
@@ -1,0 +1,8 @@
+def test_instance_config_returns_public_settings(api_client):
+    response = api_client.request("GET", "/instance/config", expected=(200,))
+    payload = response.json()
+
+    assert "import_export_max_file_size_mb" in payload
+    assert "disable_signup" in payload
+    assert isinstance(payload["import_export_max_file_size_mb"], int)
+    assert isinstance(payload["disable_signup"], bool)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new instance configuration endpoint providing non-sensitive settings. The endpoint exposes instance file upload size limits and signup status availability for frontend consumption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->