### PR TITLE
feat: Add support for streaming large video with signed url #320

### DIFF
--- a/app/api/v1/endpoints/instance_config.py
+++ b/app/api/v1/endpoints/instance_config.py
@@ -27,5 +27,9 @@ async def get_instance_config() -> InstanceConfigResponse:
     """
     return InstanceConfigResponse(
         import_export_max_file_size_mb=settings.import_export_max_file_size_mb,
+        max_file_size_mb=settings.max_file_size_mb,
+        allowed_media_types=settings.allowed_media_types,
+        allowed_file_extensions=settings.allowed_file_extensions,
         disable_signup=settings.disable_signup,
+        immich_base_url=settings.immich_base_url,
     )

--- a/app/core/media_signing.py
+++ b/app/core/media_signing.py
@@ -1,0 +1,176 @@
+"""
+Helpers for signing and validating media URLs.
+"""
+from __future__ import annotations
+
+import time
+from typing import Optional
+from urllib.parse import urlencode
+
+from app.core.config import settings
+from app.core.signing import generate_media_signature
+from app.models.enums import UploadStatus
+from app.models.integration import IntegrationProvider
+from app.schemas.entry import EntryMediaResponse, MediaOrigin
+
+
+def _build_signed_url(path: str, query: dict[str, str | int]) -> str:
+    """Build a signed URL from path and query parameters."""
+    if not path:
+        raise ValueError("path cannot be empty")
+    query_string = urlencode(query)
+    return f"{path}?{query_string}"
+
+
+def build_signed_query(
+    media_type: str,
+    variant: str,
+    media_id: str,
+    user_id: str,
+    expires_at: int,
+) -> dict[str, str | int]:
+    signature = generate_media_signature(
+        media_type,
+        variant,
+        media_id,
+        user_id,
+        expires_at,
+        settings.secret_key,
+    )
+    return {"uid": user_id, "exp": expires_at, "sig": signature}
+
+
+def signed_url_for_journiv(
+    media_id: str,
+    user_id: str,
+    variant: str,
+    expires_at: int,
+) -> str:
+    """Generate a signed URL for Journiv-hosted media (internal or proxied external)."""
+    if not media_id or not str(media_id).strip():
+        raise ValueError("media_id cannot be empty")
+    if not user_id or not str(user_id).strip():
+        raise ValueError("user_id cannot be empty")
+
+    path = (
+        f"/api/v1/media/{media_id}/thumbnail/signed"
+        if variant == "thumbnail"
+        else f"/api/v1/media/{media_id}/signed"
+    )
+    return _build_signed_url(
+        path,
+        build_signed_query("journiv", variant, media_id, user_id, expires_at),
+    )
+
+
+def signed_url_for_immich(
+    asset_id: str,
+    user_id: str,
+    variant: str,
+    expires_at: int,
+) -> str:
+    """Generate a signed URL for Immich-hosted media (proxied through Journiv)."""
+    if not asset_id or not str(asset_id).strip():
+        raise ValueError("asset_id cannot be empty")
+    if not user_id or not str(user_id).strip():
+        raise ValueError("user_id cannot be empty")
+
+    path = f"/api/v1/integrations/{IntegrationProvider.IMMICH.value}/proxy/{asset_id}/{variant}"
+    return _build_signed_url(
+        path,
+        build_signed_query(IntegrationProvider.IMMICH.value, variant, asset_id, user_id, expires_at),
+    )
+
+
+def attach_signed_urls(
+    response: EntryMediaResponse,
+    user_id: str,
+    include_incomplete: bool = False,
+    external_base_url: Optional[str] = None,
+) -> EntryMediaResponse:
+    """
+    Attach signed URLs to media response.
+    """
+    # Validate inputs
+    if not user_id or not str(user_id).strip():
+        raise ValueError("user_id cannot be empty")
+
+    # Set origin metadata for Immich media
+    if response.external_provider == IntegrationProvider.IMMICH.value and response.external_asset_id:
+        response.origin = MediaOrigin(
+            source=IntegrationProvider.IMMICH.value,
+            external_id=response.external_asset_id,
+            external_url=_build_external_url(external_base_url, response.external_asset_id),
+        )
+    elif response.external_provider is None and response.file_path:
+        response.origin = MediaOrigin(source="internal")
+
+    # Skip URL generation for failed uploads
+    if response.upload_status == UploadStatus.FAILED:
+        return response
+
+    # Skip URL generation for pending uploads unless explicitly included
+    if not include_incomplete and response.upload_status == UploadStatus.PENDING:
+        return response
+
+    now = int(time.time())
+
+    # Determine TTL based on media type (videos get longer TTL for streaming)
+    # Safely handle potential non-string media_type
+    media_type_str = str(response.media_type).lower() if response.media_type else ""
+    is_video = media_type_str == "video"
+    ttl_seconds = (
+        settings.media_signed_url_video_ttl_seconds if is_video
+        else settings.media_signed_url_ttl_seconds
+    )
+
+    # Generate unified Journiv signed URLs for ALL media (internal and external)
+    # The /media/{uuid}/signed endpoint automatically proxies to Immich for external media
+    expires_at = now + ttl_seconds
+
+    if response.id is None:
+         # Should not happen for persisted entries, but safeguard against invalid objects
+        raise ValueError("Cannot generate signed URL for media with no ID")
+
+    response.signed_url = signed_url_for_journiv(
+        str(response.id),
+        user_id,
+        "original",
+        expires_at,
+    )
+    response.signed_url_expires_at = expires_at
+
+    # Generate thumbnail URL if available
+    # For Immich: always generate (proxied from Immich)
+    # For internal: only if thumbnail_path exists
+    if response.external_provider == IntegrationProvider.IMMICH.value or response.thumbnail_path:
+        thumb_expires_at = now + settings.media_thumbnail_signed_url_ttl_seconds
+        response.signed_thumbnail_url = signed_url_for_journiv(
+            str(response.id),
+            user_id,
+            "thumbnail",
+            thumb_expires_at,
+        )
+        response.signed_thumbnail_expires_at = thumb_expires_at
+
+    return response
+
+
+def _build_external_url(base_url: Optional[str], asset_id: str) -> Optional[str]:
+    if not base_url:
+        return None
+    normalized = base_url.rstrip('/')
+    return f"{normalized}/photos/{asset_id}"
+
+
+def is_signature_expired(expires_at: int, grace_seconds: int, now: Optional[int] = None) -> bool:
+    """
+    Check if a signature has expired.
+    """
+    if grace_seconds < 0:
+        raise ValueError("grace_seconds must be non-negative")
+    if grace_seconds > 300:
+        raise ValueError("grace_seconds cannot exceed 300 seconds")
+
+    current = now if now is not None else int(time.time())
+    return expires_at + grace_seconds < current

--- a/app/integrations/schemas.py
+++ b/app/integrations/schemas.py
@@ -258,6 +258,10 @@ class IntegrationAssetResponse(BaseModel):
         ...,
         description="Relative URL to thumbnail proxy endpoint"
     )
+    original_url: Optional[str] = Field(
+        default=None,
+        description="Signed URL to original asset proxy endpoint"
+    )
 
     class Config:
         from_attributes = True

--- a/app/integrations/service.py
+++ b/app/integrations/service.py
@@ -23,13 +23,13 @@ Extension Points:
 """
 from inspect import isawaitable
 from typing import Optional, Dict, Any
+import uuid
 
 from pydantic import HttpUrl
 from sqlmodel import Session, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
-from app.core.encryption import encrypt_token
 from app.core.time_utils import utc_now
 from app.integrations import immich
 from app.models.integration import Integration, IntegrationProvider, ImportMode
@@ -42,6 +42,58 @@ from app.integrations.schemas import (
 from app.models.user import User
 
 from app.core.logging_config import log_info, log_error, log_warning, log_debug
+import httpx
+import asyncio
+from app.core.encryption import encrypt_token, decrypt_token
+from app.core.scoped_cache import ScopedCache
+
+_proxy_client: Optional[httpx.AsyncClient] = None
+_proxy_lock = asyncio.Lock()
+_proxy_timeout = httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
+_proxy_limits = httpx.Limits(max_connections=50, max_keepalive_connections=20)
+
+
+async def _get_proxy_client() -> httpx.AsyncClient:
+    """Reuse a single client to avoid connection churn under thumbnail bursts."""
+    global _proxy_client
+    if _proxy_client is None:
+        async with _proxy_lock:
+            if _proxy_client is None:
+                _proxy_client = httpx.AsyncClient(
+                    verify=True,
+                    follow_redirects=True,
+                    timeout=_proxy_timeout,
+                    limits=_proxy_limits,
+                    transport=httpx.AsyncHTTPTransport(retries=2),
+                )
+    return _proxy_client
+
+
+async def close_proxy_client() -> None:
+    """
+    Close the global proxy client to release network resources.
+
+    This function should be called during application shutdown, typically from
+    a FastAPI lifespan context manager or shutdown event handler.
+
+    Example:
+        @asynccontextmanager
+        async def lifespan(app: FastAPI):
+            yield
+            await close_proxy_client()
+    """
+    global _proxy_client
+    if _proxy_client is not None:
+        await _proxy_client.aclose()
+        _proxy_client = None
+
+
+def _get_integration_cache() -> Optional[ScopedCache]:
+    """Get the scoped cache for integration credentials."""
+    if not settings.redis_url:
+        return None
+    return ScopedCache(namespace="integration_creds")
+
 
 # ================================================================================
 # ASYNC COMPAT HELPERS
@@ -281,6 +333,11 @@ async def disconnect_integration(
 
     log_info(f"Disconnected {provider} for user {user.id} (integration {integration.id})")
 
+    # Invalidate cache
+    cache = _get_integration_cache()
+    if cache:
+        cache.delete(scope_id=str(user.id), cache_type=f"{provider.value}")
+
 
 async def list_integration_assets(
     session: Session | AsyncSession,
@@ -471,3 +528,102 @@ async def update_integration_settings(
 
     # Return updated status
     return await get_integration_status(session, user, provider)
+
+
+async def fetch_proxy_asset(
+    session: Session | AsyncSession,
+    user_id: uuid.UUID,
+    provider: IntegrationProvider,
+    asset_id: str,
+    variant: str,  # "thumbnail" or "original"
+    range_header: Optional[str] = None,
+) -> httpx.Response:
+    """
+    Fetch an asset stream from the provider.
+
+    Handles credential retrieval (cache/DB), decryption, and request building.
+    Returns the open httpx.Response object (headers unused).
+
+    IMPORTANT: The caller is responsible for ensuring the response is closed.
+    You must call `response.aclose()` or stream the content fully.
+    Failure to do so will leak connections.
+    """
+    integration_base_url = None
+    access_token_encrypted = None
+
+    # 1. Try Cache First
+    cache = _get_integration_cache()
+    if cache:
+        cached_creds = cache.get(scope_id=str(user_id), cache_type=f"{provider.value}")
+        if cached_creds and cached_creds.get("is_active"):
+            integration_base_url = cached_creds.get("base_url")
+            access_token_encrypted = cached_creds.get("token")
+
+    # 2. If not in cache, fetch from DB
+    if not integration_base_url or not access_token_encrypted:
+        # Use existing session (async or sync)
+        integration = (await _exec(
+            session,
+            select(Integration)
+            .where(Integration.user_id == user_id)
+            .where(Integration.provider == provider)
+        )).first()
+
+        if not integration:
+            raise ValueError(f"{provider} integration not found. Please connect first.")
+
+        if not integration.is_active:
+            raise ValueError(f"{provider} integration is disabled. Please reconnect.")
+
+        integration_base_url = integration.base_url
+        access_token_encrypted = integration.access_token_encrypted
+
+        # 3. Populate Cache
+        if cache:
+            cache.set(
+                scope_id=str(user_id),
+                cache_type=f"{provider.value}",
+                value={
+                    "base_url": integration_base_url,
+                    "token": access_token_encrypted,
+                    "is_active": True
+                },
+                ttl_seconds=300 # Cache for 5 minutes
+            )
+
+    # Decrypt token
+    try:
+        api_key = decrypt_token(access_token_encrypted)
+    except Exception as e:
+        raise ValueError("Failed to decrypt integration credentials") from e
+
+    # Build URL
+    if provider == IntegrationProvider.IMMICH:
+        import re
+        if not re.match(r'^[a-zA-Z0-9_-]+$', asset_id):
+            raise ValueError("Invalid asset ID format")
+
+        if variant == "thumbnail":
+            url = f"{integration_base_url}/api/assets/{asset_id}/thumbnail"
+        elif variant == "original":
+            url = f"{integration_base_url}/api/assets/{asset_id}/original"
+        else:
+            raise ValueError(f"Unknown variant {variant}")
+    else:
+        raise ValueError(f"Proxy not implemented for {provider}")
+
+    # Prepare headers
+    headers = {"x-api-key": api_key}
+    if range_header and variant == "original":
+        headers["Range"] = range_header
+
+    # Make request
+    client = await _get_proxy_client()
+    try:
+        request = client.build_request("GET", url, headers=headers)
+        # The timeout is already configured on the client itself at initialization
+        response = await client.send(request, stream=True)
+        return response
+    except Exception as e:
+        log_error(f"Proxy request failed: {e}", user_id=user_id)
+        raise

--- a/app/schemas/dto.py
+++ b/app/schemas/dto.py
@@ -46,7 +46,10 @@ class MediaDTO(BaseModel):
     # Additional metadata
     file_metadata: Optional[str] = Field(None, description="JSON metadata string")
     thumbnail_path: Optional[str] = Field(None, description="Path to thumbnail")
-    upload_status: str = Field(default="completed", description="Upload status: pending, processing, completed, failed")
+    upload_status: str = Field(
+        default="completed",
+        description="Upload status: pending, processing, completed, failed"
+    )
 
     # Timestamps (inherited from BaseModel)
     created_at: datetime = Field(..., description="Media creation time in UTC")

--- a/app/schemas/instance.py
+++ b/app/schemas/instance.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from pydantic import BaseModel
 
 
@@ -5,4 +7,8 @@ class InstanceConfigResponse(BaseModel):
     """Public instance configuration safe for frontend consumption."""
 
     import_export_max_file_size_mb: int
+    max_file_size_mb: int
+    allowed_media_types: Optional[List[str]] = None
+    allowed_file_extensions: Optional[List[str]] = None
     disable_signup: bool
+    immich_base_url: Optional[str] = None

--- a/app/schemas/media.py
+++ b/app/schemas/media.py
@@ -58,6 +58,44 @@ class ImmichImportAsset(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
 
 
+class MediaSignedUrlResponse(BaseModel):
+    """Response schema for short-lived signed media URLs."""
+    signed_url: str
+    expires_at: int
+
+
+class MediaBatchSignItem(BaseModel):
+    """Single batch signing request item."""
+    id: str
+    variant: str
+
+
+class MediaBatchSignRequest(BaseModel):
+    """Batch signing request payload."""
+    items: list[MediaBatchSignItem] = Field(..., min_length=1, max_length=100)
+
+
+class MediaBatchSignResult(BaseModel):
+    """Batch signing result for a single item."""
+    id: str
+    variant: str
+    signed_url: str
+    expires_at: int
+
+
+class MediaBatchSignError(BaseModel):
+    """Batch signing error for a single item."""
+    id: str
+    variant: str
+    error: str
+
+
+class MediaBatchSignResponse(BaseModel):
+    """Batch signing response payload."""
+    results: list[MediaBatchSignResult] = Field(default_factory=list)
+    errors: list[MediaBatchSignError] = Field(default_factory=list)
+
+
 class ImmichImportRequest(BaseModel):
     """Request to import assets from Immich."""
     asset_ids: list[str] = Field(..., min_length=1, max_length=100)

--- a/app/services/entry_service.py
+++ b/app/services/entry_service.py
@@ -15,7 +15,7 @@ from app.core.time_utils import utc_now, local_date_for_user, ensure_utc, to_utc
 from app.models.entry import Entry, EntryMedia
 from app.models.entry_tag_link import EntryTagLink
 from app.models.journal import Journal
-from app.schemas.entry import EntryCreate, EntryUpdate, EntryMediaCreate
+from app.schemas.entry import EntryCreate, EntryUpdate, EntryMediaCreate, EntryMediaCreateRequest
 
 DEFAULT_ENTRY_PAGE_LIMIT = 50
 MAX_ENTRY_PAGE_LIMIT = 100
@@ -471,7 +471,12 @@ class EntryService:
         statement = statement.order_by(Entry.entry_datetime_utc.desc())
         return list(self.session.exec(statement))
 
-    def add_media_to_entry(self, entry_id: uuid.UUID, user_id: uuid.UUID, media_data: EntryMediaCreate) -> EntryMedia:
+    def add_media_to_entry(
+        self,
+        entry_id: uuid.UUID,
+        user_id: uuid.UUID,
+        media_data: EntryMediaCreate | EntryMediaCreateRequest
+    ) -> EntryMedia:
         """Add media to an entry."""
         # Verify the entry belongs to the user
         self._get_owned_entry(entry_id, user_id)
@@ -491,11 +496,11 @@ class EntryService:
             upload_status=media_data.upload_status,
             file_metadata=media_data.file_metadata,
             checksum=media_data.checksum,
-            external_provider=media_data.external_provider,
-            external_asset_id=media_data.external_asset_id,
-            external_url=media_data.external_url,
-            external_created_at=media_data.external_created_at,
-            external_metadata=media_data.external_metadata,
+            external_provider=getattr(media_data, "external_provider", None),
+            external_asset_id=getattr(media_data, "external_asset_id", None),
+            external_url=getattr(media_data, "external_url", None),
+            external_created_at=getattr(media_data, "external_created_at", None),
+            external_metadata=getattr(media_data, "external_metadata", None),
         )
 
         try:

--- a/env.template
+++ b/env.template
@@ -260,6 +260,18 @@ DOMAIN_NAME=
 # Allowed file extensions (comma-separated)
 # ALLOWED_FILE_EXTENSIONS=.jpg,.jpeg,.png,.gif,.webp,.heic,.mp4,.avi,.mov,.webm,.m4v,.mp3,.wav,.ogg,.m4a,.aac
 
+# Signed media URL TTL in seconds (for images and general media)
+# MEDIA_SIGNED_URL_TTL_SECONDS=120
+
+# Signed video URL TTL in seconds (for video streaming, longer to support playback of large files)
+# MEDIA_SIGNED_URL_VIDEO_TTL_SECONDS=3600
+
+# Signed thumbnail URL TTL in seconds (used for caching thumbnails)
+# MEDIA_THUMBNAIL_SIGNED_URL_TTL_SECONDS=86400
+
+# Grace period in seconds for signed media URL expiration checks
+# MEDIA_SIGNED_URL_GRACE_SECONDS=60
+
 
 # ============================================================================
 # LOGGING

--- a/tests/integration/test_dayone_import_e2e.py
+++ b/tests/integration/test_dayone_import_e2e.py
@@ -198,13 +198,19 @@ class TestDayOneImportE2E:
 
         for media in entry_media:
             assert media["media_type"] == "image"
-            assert media["file_path"] is not None
+            assert "file_path" not in media  # Should be excluded
             assert media["checksum"] is not None
             # Verify original filename is preserved
             assert media["original_filename"] is not None
             assert ".jpg" in media["original_filename"]
-            # Ensure media stored under expected directory
-            assert "images/" in media["file_path"]
+
+            # Verify media is accessible by signing it (replaces file_path check)
+            api_client.wait_for_media_ready(api_user.access_token, media["id"])
+            sign_response = api_client.request(
+                "GET", f"/media/{media['id']}/sign",
+                token=api_user.access_token
+            ).json()
+            assert sign_response["signed_url"]
             # Existence check depends on test environment storage setup
             # Markdown content should use Journiv media shortcode format
             assert f"![[media:{media['id']}]]" in content

--- a/tests/test_immich_provider.py
+++ b/tests/test_immich_provider.py
@@ -1,0 +1,58 @@
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from app.integrations import immich
+from app.models.integration import Integration, IntegrationProvider
+from app.models.user import User
+
+class TestImmichProvider:
+
+    @pytest.mark.asyncio
+    async def test_list_assets_requests_sorted_live_response(self):
+        """Test that list_assets requests descending order from API."""
+        # Setup Mocks
+        mock_user = User(id="00000000-0000-0000-0000-000000000000")
+        mock_integration = Integration(
+            id="00000000-0000-0000-0000-000000000000",
+            user_id="00000000-0000-0000-0000-000000000000",
+            provider=IntegrationProvider.IMMICH,
+            is_active=True,
+            base_url="http://immich",
+            access_token_encrypted="enc",
+            external_user_id="immich-user-1",
+        )
+
+        response_json = {
+            "assets": {"items": [], "total": 0}
+        }
+
+        # Mock dependencies
+        with patch("app.integrations.immich._get_cache") as mock_cache_get:
+            mock_cache = MagicMock()
+            mock_cache.get.return_value = None # Force live fetch
+            mock_cache_get.return_value = mock_cache
+
+
+            with patch("app.integrations.immich._get_client") as mock_client_get:
+                mock_client = AsyncMock()
+                # Ensure the response object is a regular MagicMock, not Async
+                mock_response = MagicMock()
+                mock_response.json.return_value = response_json
+                mock_response.raise_for_status = MagicMock()
+
+                mock_client.post.return_value = mock_response
+                mock_client_get.return_value = mock_client
+
+                with patch("app.integrations.immich.decrypt_token", return_value="key"):
+                    # Execute
+                    await immich.list_assets(
+                        session=MagicMock(),
+                        user=mock_user,
+                        integration=mock_integration,
+                        page=1
+                    )
+
+                    # Verify API call included order: desc
+                    call_kwargs = mock_client.post.call_args.kwargs
+                    assert call_kwargs['json']['order'] == 'desc'

--- a/tests/unit/test_media_service_immich.py
+++ b/tests/unit/test_media_service_immich.py
@@ -1,0 +1,268 @@
+
+import pytest
+import uuid
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+from sqlmodel import Session, select
+from app.services.media_service import MediaService
+from app.models.entry import EntryMedia, Entry
+from app.models.integration import Integration, IntegrationProvider
+from app.models.enums import UploadStatus, MediaType
+from app.schemas.media import MediaBatchSignRequest, MediaBatchSignItem
+
+@pytest.fixture
+def mock_session():
+    return MagicMock(spec=Session)
+
+@pytest.fixture
+def mock_settings():
+    with patch("app.services.media_service.settings") as mock:
+        mock.media_signed_url_ttl_seconds = 3600
+        mock.media_thumbnail_signed_url_ttl_seconds = 3600
+        yield mock
+
+@pytest.fixture
+def media_service(mock_session, mock_settings):
+    service = MediaService(session=mock_session)
+    # Mock settings on the service instance directly as well since it might be accessed there
+    service.settings = mock_settings
+    return service
+
+@pytest.fixture
+def user_id():
+    return uuid.uuid4()
+
+@pytest.fixture
+def entry_id():
+    return uuid.uuid4()
+
+@pytest.fixture
+def active_immich_integration(user_id):
+    integration = Integration(
+        user_id=user_id,
+        provider=IntegrationProvider.IMMICH,
+        base_url="http://immich.test",
+        access_token_encrypted="encrypted",
+        external_user_id="immich-user",
+        is_active=True
+    )
+    return integration
+
+def create_mock_media(
+    media_id, entry_id, user_id,
+    provider="immich",
+    asset_id="asset-1",
+    status=UploadStatus.COMPLETED,
+    file_path=None,
+    thumbnail_path=None,
+    media_type=MediaType.IMAGE
+):
+    # Determine what select().all() should return
+    # Query in batch_sign_media returns tuple:
+    # (id, upload_status, external_provider, external_asset_id, file_path, thumbnail_path, media_type)
+    return (
+        media_id,
+        status,
+        provider,
+        asset_id,
+        file_path,
+        thumbnail_path,
+        media_type
+    )
+
+@pytest.mark.asyncio
+async def test_batch_sign_immich_link_only_success(
+    media_service, mock_session, user_id, entry_id, active_immich_integration
+):
+    """Test signing for Immich Link-Only media (completed, no file path)."""
+    media_id = uuid.uuid4()
+
+    # Mock database response for media
+    # Link-only: provider=immich, asset_id=set, file_path=None, status=COMPLETED
+    mock_row = create_mock_media(
+        media_id, entry_id, user_id,
+        provider="immich",
+        asset_id="asset-link-only",
+        status=UploadStatus.COMPLETED,
+        file_path=None,
+        thumbnail_path=None
+    )
+
+    # Setup session mocks
+    mock_session.exec.return_value.all.return_value = [mock_row]
+    # Mock integration query
+    mock_session.exec.return_value.first.return_value = active_immich_integration
+
+    # Request
+    request = MediaBatchSignRequest(items=[
+        MediaBatchSignItem(id=str(media_id), variant="original")
+    ])
+
+    # Execute
+    with patch("app.services.media_service.signed_url_for_journiv") as mock_sign:
+        mock_sign.return_value = "signed-url"
+        response = await media_service.batch_sign_media(request, user_id, mock_session)
+
+    # Verify
+    assert len(response.results) == 1
+    assert len(response.errors) == 0
+    assert response.results[0].id == str(media_id)
+    assert response.results[0].signed_url == "signed-url"
+
+@pytest.mark.asyncio
+async def test_batch_sign_immich_link_only_processing(
+    media_service, mock_session, user_id, entry_id, active_immich_integration
+):
+    """Test signing for Immich Link-Only media that is still processing."""
+    media_id = uuid.uuid4()
+
+    # Link-only placeholder: status=PROCESSING
+    mock_row = create_mock_media(
+        media_id, entry_id, user_id,
+        provider="immich",
+        asset_id="asset-link-only-pending",
+        status=UploadStatus.PROCESSING,
+        file_path=None
+    )
+
+    mock_session.exec.return_value.all.return_value = [mock_row]
+    mock_session.exec.return_value.first.return_value = active_immich_integration
+
+    request = MediaBatchSignRequest(items=[
+        MediaBatchSignItem(id=str(media_id), variant="original")
+    ])
+
+    response = await media_service.batch_sign_media(request, user_id, mock_session)
+
+    # Verify error
+    assert len(response.results) == 0
+    assert len(response.errors) == 1
+    assert response.errors[0].id == str(media_id)
+    assert response.errors[0].error == "Media not ready"
+
+@pytest.mark.asyncio
+async def test_batch_sign_immich_copy_mode_success(
+    media_service, mock_session, user_id, entry_id, active_immich_integration
+):
+    """Test signing for Immich Copy-Mode media (downloaded and completed)."""
+    media_id = uuid.uuid4()
+
+    # Copy-mode: file_path set, status=COMPLETED
+    mock_row = create_mock_media(
+        media_id, entry_id, user_id,
+        provider="immich",
+        asset_id="asset-copy",
+        status=UploadStatus.COMPLETED,
+        file_path="/path/to/file.jpg",
+        thumbnail_path="thumbs/thumb.jpg"
+    )
+
+    mock_session.exec.return_value.all.return_value = [mock_row]
+    mock_session.exec.return_value.first.return_value = active_immich_integration
+
+    request = MediaBatchSignRequest(items=[
+        MediaBatchSignItem(id=str(media_id), variant="original"),
+        MediaBatchSignItem(id=str(media_id), variant="thumbnail")
+    ])
+
+    with patch("app.services.media_service.signed_url_for_journiv") as mock_sign:
+        mock_sign.return_value = "signed-url"
+        response = await media_service.batch_sign_media(request, user_id, mock_session)
+
+    # Verify both succeed
+    assert len(response.results) == 2
+    assert len(response.errors) == 0
+
+@pytest.mark.asyncio
+async def test_batch_sign_immich_copy_mode_processing(
+    media_service, mock_session, user_id, entry_id, active_immich_integration
+):
+    """Test signing for Immich Copy-Mode placeholder (still downloading)."""
+    media_id = uuid.uuid4()
+
+    # Copy-mode placeholder: status=PROCESSING, file_path=None (usually) or set but processing
+    # Even if file_path is set, status=PROCESSING must fail
+    mock_row = create_mock_media(
+        media_id, entry_id, user_id,
+        provider="immich",
+        asset_id="asset-copy-pending",
+        status=UploadStatus.PROCESSING,
+        file_path=None  # Placeholder usually has None
+    )
+
+    mock_session.exec.return_value.all.return_value = [mock_row]
+    mock_session.exec.return_value.first.return_value = active_immich_integration
+
+    request = MediaBatchSignRequest(items=[
+        MediaBatchSignItem(id=str(media_id), variant="original")
+    ])
+
+    response = await media_service.batch_sign_media(request, user_id, mock_session)
+
+    assert len(response.results) == 0
+    assert len(response.errors) == 1
+    assert response.errors[0].error == "Media not ready"
+
+@pytest.mark.asyncio
+async def test_batch_sign_immich_copy_mode_thumbnail_missing(
+    media_service, mock_session, user_id, entry_id, active_immich_integration
+):
+    """Test signing for Immich Copy-Mode where thumbnail is missing."""
+    media_id = uuid.uuid4()
+
+    # Copy-mode: file_path set (local), but thumbnail_path is None
+    mock_row = create_mock_media(
+        media_id, entry_id, user_id,
+        provider="immich",
+        asset_id="asset-copy-no-thumb",
+        status=UploadStatus.COMPLETED,
+        file_path="/path/to/file.jpg",
+        thumbnail_path=None
+    )
+
+    mock_session.exec.return_value.all.return_value = [mock_row]
+    mock_session.exec.return_value.first.return_value = active_immich_integration
+
+    # Request thumbnail
+    request = MediaBatchSignRequest(items=[
+        MediaBatchSignItem(id=str(media_id), variant="thumbnail")
+    ])
+
+    response = await media_service.batch_sign_media(request, user_id, mock_session)
+
+    # Should fail because local thumbnail is missing
+    assert len(response.results) == 0
+    assert len(response.errors) == 1
+    assert response.errors[0].error == "Thumbnail not available"
+
+@pytest.mark.asyncio
+async def test_batch_sign_immich_link_only_thumbnail_proxy(
+    media_service, mock_session, user_id, entry_id, active_immich_integration
+):
+    """Test signing for Immich Link-Only thumbnail (should succeed without local thumb)."""
+    media_id = uuid.uuid4()
+
+    # Link-only: file_path=None, thumbnail_path=None
+    mock_row = create_mock_media(
+        media_id, entry_id, user_id,
+        provider="immich",
+        asset_id="asset-link-only",
+        status=UploadStatus.COMPLETED,
+        file_path=None,
+        thumbnail_path=None
+    )
+
+    mock_session.exec.return_value.all.return_value = [mock_row]
+    mock_session.exec.return_value.first.return_value = active_immich_integration
+
+    request = MediaBatchSignRequest(items=[
+        MediaBatchSignItem(id=str(media_id), variant="thumbnail")
+    ])
+
+    with patch("app.services.media_service.signed_url_for_journiv") as mock_sign:
+        mock_sign.return_value = "signed-url"
+        response = await media_service.batch_sign_media(request, user_id, mock_session)
+
+    # Should succeed - will be proxied
+    assert len(response.results) == 1
+    assert len(response.errors) == 0


### PR DESCRIPTION
- Adds support for streaming large videos with streaming response which solve the crashes on browser happening before when it was loading really large video in memory as blob to display it.
- Introduced signed media URLs.
- Standardize media (internal or external) to use same signed endpoint.
- Immich proxy endpoint are still present and signed because immich picker needs it to allow picking immich assets while creating an entry when there is no Journiv media record yet.
- Correctly name immich copied thumbnail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Media access now secured with signed URLs featuring configurable expiration times
  * Batch signing capability for multiple media items at once
  * Enhanced Immich integration with proxy media support and improved asset handling
  * New instance configuration options: file size limits, allowed media types, extensions, and Immich base URL

* **Improvements**
  * More granular control over media URL validity periods with grace period settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->