### PR TITLE
Feature/add support for file based secrets

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,9 +6,9 @@ import logging
 import os
 import secrets
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, cast
 
-from pydantic import field_validator, model_validator, ValidationInfo, Field
+from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 try:


### PR DESCRIPTION
## Description
This PR adds support for Docker [Compose secrets](https://docs.docker.com/compose/how-tos/use-secrets/) using the *_FILE convention in the Journiv backend configuration. Instead of requiring services to read secret files themselves, the settings layer now resolves *_FILE environment variables early during configuration loading and injects the file contents into the corresponding “normal” settings fields. This means the rest of the application can keep using the same settings names and business logic as before.

The implementation uses Pydantic Settings’ _[settings_customise_sources](https://docs.pydantic.dev/latest/api/pydantic_settings/#pydantic_settings.BaseSettings.settings_customise_sources)_ hook to intercept configuration sources during initialization, check whether *_FILE variables exist, and load their values before other validation and downstream logic run. This keeps the approach generic and reusable: adding support for additional secrets later should only require adding the relevant *_FILE field(s), without changing business logic.

At the moment, *_FILE support was added for the secret key, OIDC client secret, and the Postgres password. Logging around this is currently emitted at warning level, because info messages were not visible during testing (I think the logger is not yet initialised when this logs happen)

## Documentation
I could not find where the documentation is maintained; it might live in a separate repository. For reference, below is a minimal Compose usage example showing how to enable file-based secrets using the *_FILE convention:
```yaml
services:
  journiv:
    image: swalabtech/journiv-app:latest
    environment:
      SECRET_KEY_FILE: /run/secrets/journiv_secret_key
      OIDC_CLIENT_SECRET_FILE: /run/secrets/oidc_client_secret
      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
    secrets:
      - journiv_secret_key
      - oidc_client_secret
      - postgres_password

secrets:
  journiv_secret_key:
    file: ./secrets/journiv_secret_key
  oidc_client_secret:
    file: ./secrets/oidc_client_secret
  postgres_password:
    file: ./secrets/postgres_password
```

## Testing
I attempted to run the tests locally via Docker Compose but was unsuccessful. The container fails when executing the test command with:
```
Executing custom command: pytest
/app/scripts/docker-entrypoint.sh: 33: exec: pytest: Permission denied
```
This appears to be a permission issue with the entrypoint or test command; hopefully the CI pipelines will pass, but this may require follow-up.

Let me know if I did something wrong, this is my first PR on Github.

Fixes #333 
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Tests pass locally
- [ ] New tests added for new functionality
- [x] Manual testing completed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [x] No breaking changes (or clearly documented)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support loading sensitive configuration (DB password, app secret, OIDC client secret) from external files referenced by new config fields.
  * File-based secrets follow precedence that preserves direct/init settings over file values.
  * Added warnings/logging when a direct value conflicts with a file reference or when a referenced file cannot be read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->