### PR TITLE
fix: Remove plus module from workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,30 +47,6 @@ jobs:
           pip install -r requirements/base.txt
           pip install -r requirements/test.txt
 
-      - name: Download Plus native modules (latest release)
-        env:
-          GH_TOKEN: ${{ secrets.PLUS_FEATURES_REPO_TOKEN }}
-          PLUS_FEATURES_REPO: journiv/journiv-plus-features
-        run: |
-          set -eo pipefail
-
-          if [ -z "$GH_TOKEN" ]; then
-            echo "ERROR: PLUS_FEATURES_REPO_TOKEN secret not set"
-            exit 1
-          fi
-
-          DOWNLOAD_DIR=$(mktemp -d)
-          trap "rm -rf $DOWNLOAD_DIR" EXIT
-          gh release download latest -R "$PLUS_FEATURES_REPO" -p "*.so" -D "$DOWNLOAD_DIR"
-
-          mkdir -p app/plus
-          mv "$DOWNLOAD_DIR"/*.so app/plus/
-          if ! ls app/plus/*.so 1> /dev/null 2>&1; then
-            echo "ERROR: No .so files were downloaded"
-            exit 1
-          fi
-          ls -lh app/plus/
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,27 +38,6 @@ jobs:
           pip install -r requirements/base.txt
           pip install -r requirements/test.txt
 
-      - name: Download Plus native modules (latest release)
-        env:
-          GH_TOKEN: ${{ secrets.PLUS_FEATURES_REPO_TOKEN }}
-          PLUS_FEATURES_REPO: journiv/journiv-plus-features
-        run: |
-          set -eo pipefail
-
-          if [ -z "$GH_TOKEN" ]; then
-            echo "ERROR: PLUS_FEATURES_REPO_TOKEN secret not set"
-            exit 1
-          fi
-
-          DOWNLOAD_DIR=$(mktemp -d)
-          trap "rm -rf $DOWNLOAD_DIR" EXIT
-          gh release download latest -R "$PLUS_FEATURES_REPO" -p "*.so" -D "$DOWNLOAD_DIR"
-
-          mkdir -p app/plus
-          mv "$DOWNLOAD_DIR"/*.so app/plus/
-          # Ensure .so files exist for imports, even if not fully used in mocks
-          ls -lh app/plus/
-
       - name: Run unit and CLI tests
         env:
           SECRET_KEY: test-secret-key


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed native module download step from both integration test and unit test workflows. Tests now execute directly without the preliminary external module acquisition phase, resulting in streamlined CI/CD pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->