### PR TITLE
fix: day one moment media #397

### DIFF
--- a/app/data_transfer/dayone/mappers.py
+++ b/app/data_transfer/dayone/mappers.py
@@ -408,7 +408,12 @@ class DayOneToJournivMapper:
                 return f"DAYONE_VIDEO:{identifier}"
             if identifier in photo_ids:
                 return f"DAYONE_PHOTO:{identifier}"
-            return identifier
+            log_warning(
+                "Unresolved Day One moment identifier; defaulting to photo",
+                identifier=identifier,
+                context="dayone_moment_link",
+            )
+            return f"DAYONE_PHOTO:{identifier}"
 
         pattern = re.compile(r"!\[[^\]]*\]\(dayone-moment://([A-Za-z0-9-]+)\)")
         updated = pattern.sub(repl, text)


### PR DESCRIPTION
fixes #397 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Day One import now detects Day One "moment" media links (photos and videos) in both Markdown and plain text and converts them into standardized placeholders so media references are preserved during import.
  * Improved handling of embedded multimedia tokens to ensure photos and videos are recognized and consistently transformed for seamless transfer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->