### PR TITLE
chore: version bump to beta.19

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -26,10 +26,10 @@ on:
       old_version:
         description: "Old version to upgrade from (Docker tag)"
         required: false
-        default: "0.1.0-beta.17"
+        default: "0.1.0-beta.18"
 
 env:
-  OLD_VERSION: ${{ github.event.inputs.old_version || '0.1.0-beta.17' }}
+  OLD_VERSION: ${{ github.event.inputs.old_version || '0.1.0-beta.18' }}
   NEW_VERSION: ci-latest
 
 jobs:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,6 @@
 Journiv App Backend - A private journal application.
 """
 
-__version__ = "0.1.0-beta.18"
+__version__ = "0.1.0-beta.19"
 __author__ = "Swalab Tech"
 __description__ = "Private Journal"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "journiv"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.19"
 description = "Journiv - Private Journal"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -841,7 +841,7 @@ wheels = [
 
 [[package]]
 name = "journiv"
-version = "0.1.0b17"
+version = "0.1.0b19"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project version to 0.1.0-beta.19 across configuration and package metadata.
  * Adjusted CI workflow default/fallback version input to 0.1.0-beta.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->