### PR TITLE
fix: pin plus python version dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ COPY app/ app/
 
 # Validate Plus module presence in release builds
 RUN if [ "$REQUIRE_PLUS_FEATURES" = "true" ]; then \
-      ls -lh /app/app/plus/plus_features*.so; \
+      ls -lh /app/app/plus/plus_features.cpython-312-*.so; \
     fi
 
 # Copy database migration files


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build validation process to enforce Python 3.12 compatibility requirements for the Plus module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->