### PR TITLE
fix: add support for oidc only #91

### DIFF
--- a/app/api/v1/endpoints/instance_config.py
+++ b/app/api/v1/endpoints/instance_config.py
@@ -32,4 +32,6 @@ async def get_instance_config() -> InstanceConfigResponse:
         allowed_file_extensions=settings.allowed_file_extensions,
         disable_signup=settings.disable_signup,
         immich_base_url=settings.immich_base_url,
+        oidc_enabled=settings.oidc_enabled,
+        oidc_only=settings.oidc_only,
     )

--- a/app/schemas/instance.py
+++ b/app/schemas/instance.py
@@ -12,3 +12,5 @@ class InstanceConfigResponse(BaseModel):
     allowed_file_extensions: Optional[List[str]] = None
     disable_signup: bool
     immich_base_url: Optional[str] = None
+    oidc_enabled: bool  # Whether OIDC authentication is available
+    oidc_only: bool  # Whether OIDC is the only allowed authentication method

--- a/env.template
+++ b/env.template
@@ -170,6 +170,11 @@ DOMAIN_NAME=
 # email verification (e.g., MS Entra ID). Set the following to false to disable this requirement.
 # OIDC_REQUIRE_VERIFIED_EMAIL=true
 
+# OIDC-only mode: When enabled, disable password authentication and only allow OIDC login.
+# Users can still be created via OIDC auto-provisioning (controlled by OIDC_AUTO_PROVISION).
+# Existing password users can still log in via OIDC if their email matches.
+# OIDC_ONLY=false
+
 
 
 # ============================================================================


### PR DESCRIPTION
fixes #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC-only mode disables password-based registration for new users (first account setup still allowed).
  * OIDC auto-provisioning can create accounts for users signing in via OIDC, with bootstrap handling for the first user.
  * Instance configuration endpoint now exposes OIDC enablement and OIDC-only status.

* **Documentation**
  * Added env configuration notes describing OIDC-only mode and auto-provisioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->