### PR TITLE
feat: add support for adding media to moment

### DIFF
--- a/app/api/v1/endpoints/entries.py
+++ b/app/api/v1/endpoints/entries.py
@@ -20,7 +20,6 @@ from app.core.exceptions import (
 from app.core.logging_config import log_error, log_user_action, log_warning
 from app.core.media_signing import attach_signed_urls, attach_signed_urls_to_delta
 from app.models.entry import EntryMedia
-from app.models.integration import Integration, IntegrationProvider
 from app.models.user import User
 from app.schemas.entry import (
     EntryCreate,
@@ -33,6 +32,7 @@ from app.schemas.entry import (
 )
 from app.schemas.tag import TagResponse
 from app.services.entry_service import EntryService
+from app.services.media_service import MediaService
 from app.services.tag_service import TagService
 
 router = APIRouter(prefix="/entries", tags=["entries"])
@@ -61,12 +61,7 @@ def _build_entry_responses(
             continue
         media_by_entry[media.entry_id].append(media)
 
-    immich_integration = session.exec(
-        select(Integration)
-        .where(Integration.user_id == user_id)
-        .where(Integration.provider == IntegrationProvider.IMMICH)
-    ).first()
-    immich_base_url = immich_integration.base_url if immich_integration else None
+    immich_base_url = MediaService(session).get_immich_base_url(user_id)
 
     if len(entries) != len(responses):
         raise ValueError(f"Entry response mismatch: {len(entries)} entries vs {len(responses)} responses")
@@ -588,15 +583,15 @@ async def add_media_to_entry(
     session: Annotated[Session, Depends(get_session)]
 ):
     """Add media (image/video/audio) to an entry."""
+    if media_data.moment_id is not None:
+        raise HTTPException(status_code=400, detail="moment_id is not allowed for entry media endpoint")
+    if media_data.entry_id is not None and media_data.entry_id != entry_id:
+        raise HTTPException(status_code=400, detail="entry_id does not match request path")
+    media_data.entry_id = entry_id
     entry_service = EntryService(session)
     try:
         media = entry_service.add_media_to_entry(entry_id, current_user.id, media_data)
-        immich_integration = session.exec(
-            select(Integration)
-            .where(Integration.user_id == current_user.id)
-            .where(Integration.provider == IntegrationProvider.IMMICH)
-        ).first()
-        immich_base_url = immich_integration.base_url if immich_integration else None
+        immich_base_url = MediaService(session).get_immich_base_url(current_user.id)
 
         response = EntryMediaResponse.model_validate(media)
         response = attach_signed_urls(
@@ -636,12 +631,7 @@ async def get_entry_media(
     """Get all media attached to an entry."""
     entry_service = EntryService(session)
     try:
-        immich_integration = session.exec(
-            select(Integration)
-            .where(Integration.user_id == current_user.id)
-            .where(Integration.provider == IntegrationProvider.IMMICH)
-        ).first()
-        immich_base_url = immich_integration.base_url if immich_integration else None
+        immich_base_url = MediaService(session).get_immich_base_url(current_user.id)
 
         media = entry_service.get_entry_media(entry_id, current_user.id)
 
@@ -649,10 +639,12 @@ async def get_entry_media(
         for media_item in media:
             try:
                 response = EntryMediaResponse.model_validate(media_item)
-                response = attach_signed_urls(
+                response = EntryMediaResponse.model_validate(
+                    attach_signed_urls(
                     response,
                     str(current_user.id),
                     external_base_url=immich_base_url,
+                    )
                 )
                 signed_media.append(response)
             except Exception as exc:

--- a/app/api/v1/endpoints/media.py
+++ b/app/api/v1/endpoints/media.py
@@ -21,6 +21,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import FileResponse, StreamingResponse
+from sqlalchemy import or_
 from sqlmodel import Session, col, select
 from starlette.background import BackgroundTask
 
@@ -43,7 +44,7 @@ from app.core.media_signing import (
 from app.core.signing import verify_media_signature
 from app.integrations.service import fetch_proxy_asset
 from app.models.user import User
-from app.schemas.entry import EntryMediaResponse
+from app.schemas.entry import EntryMediaResponse, MediaResponse, MomentMediaResponse
 from app.schemas.media import (
     ImmichImportJobResponse,
     ImmichImportRequest,
@@ -56,6 +57,11 @@ from app.schemas.media import (
 from app.services import entry_service as entry_service_module
 from app.services import media_service as media_service_module
 from app.services.import_job_service import ImportJobService
+from app.services.media_service import (
+    ImmichIntegrationInactiveError,
+    ImmichIntegrationNotConnectedError,
+)
+from app.services.moment_service import MomentNotFoundError
 
 
 async def _close_httpx_stream(response: httpx.Response) -> None:
@@ -198,7 +204,7 @@ def verify_signed_media_request(
 
 @router.post(
     "/upload",
-    response_model=EntryMediaResponse,
+    response_model=MediaResponse,
     status_code=status.HTTP_201_CREATED,
     responses={
         400: {"description": "Invalid file or validation failed"},
@@ -212,7 +218,8 @@ def verify_signed_media_request(
 async def upload_media(
     current_user: Annotated[User, Depends(get_current_user_detached)],
     file: Annotated[UploadFile, File()],
-    entry_id: Annotated[uuid.UUID, Form()],
+    entry_id: Annotated[Optional[uuid.UUID], Form()] = None,
+    moment_id: Annotated[Optional[uuid.UUID], Form()] = None,
     alt_text: Annotated[Optional[str], Form()] = None,
 ):
     """
@@ -223,10 +230,16 @@ async def upload_media(
     media_service = _get_media_service()
 
     try:
+        if entry_id is None and moment_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Either entry_id or moment_id must be provided",
+            )
         result = await media_service.upload_media(
             file=file,
             user_id=current_user.id,
             entry_id=entry_id,
+            moment_id=moment_id,
             alt_text=alt_text
         )
 
@@ -251,7 +264,10 @@ async def upload_media(
                     exc_info=True
                 )
 
-        response = EntryMediaResponse.model_validate(media_record)
+        if moment_id and not entry_id:
+            response = MomentMediaResponse.model_validate(media_record)
+        else:
+            response = EntryMediaResponse.model_validate(media_record)
         return attach_signed_urls(
             response,
             str(current_user.id),
@@ -273,10 +289,17 @@ async def upload_media(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e)
         ) from None
-    except EntryNotFoundError:
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        ) from None
+    except (EntryNotFoundError, MomentNotFoundError):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Entry not found"
+            detail="Entry or moment not found"
         ) from None
     except Exception as e:
         error_logger.error(
@@ -786,28 +809,15 @@ async def import_from_immich_async(
     - LINK_ONLY: Creates placeholder media and processes metadata asynchronously
     - COPY: Creates placeholder media and processes downloads asynchronously
     """
-    from app.models.integration import ImportMode, Integration, IntegrationProvider
+    from app.models.integration import ImportMode
     from app.services.import_job_service import ImportJobService
 
     try:
         # 1. Verify Immich integration exists and is active
-        immich_integration = session.exec(
-            select(Integration)
-            .where(Integration.user_id == current_user.id)
-            .where(Integration.provider == IntegrationProvider.IMMICH)
-        ).first()
-
-        if not immich_integration:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Immich integration not connected. Please connect in Settings."
-            )
-
-        if not immich_integration.is_active:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Immich integration is inactive. Please reconnect in Settings."
-            )
+        media_service = _get_media_service()
+        immich_integration = media_service.require_active_immich_integration(
+            session, current_user.id
+        )
 
         # 2. Verify entry exists
         entry_service = _get_entry_service(session)
@@ -932,11 +942,13 @@ async def import_from_immich_async(
         )
 
         signed_media = [
-            attach_signed_urls(
-                EntryMediaResponse.model_validate(record),
-                str(current_user.id),
-                include_incomplete=True,
-                external_base_url=immich_integration.base_url,
+            EntryMediaResponse.model_validate(
+                attach_signed_urls(
+                    EntryMediaResponse.model_validate(record),
+                    str(current_user.id),
+                    include_incomplete=True,
+                    external_base_url=immich_integration.base_url,
+                )
             )
             for record in placeholder_media
         ]
@@ -967,6 +979,11 @@ async def import_from_immich_async(
             media=signed_media,
         )
 
+    except (ImmichIntegrationNotConnectedError, ImmichIntegrationInactiveError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except HTTPException:
         raise
     except Exception as e:
@@ -1047,27 +1064,24 @@ async def repair_immich_thumbnails(
     Repair missing thumbnails for Immich media.
     """
     from app.models.entry import Entry, EntryMedia
-    from app.models.integration import Integration, IntegrationProvider
+    from app.models.moment import Moment
 
     try:
         # Verify Immich integration exists and is active
-        immich_integration = session.exec(
-            select(Integration)
-            .where(Integration.user_id == current_user.id)
-            .where(Integration.provider == IntegrationProvider.IMMICH)
-        ).first()
-
-        if not immich_integration or not immich_integration.is_active:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Immich integration not connected or inactive"
-            )
+        media_service = _get_media_service()
+        media_service.require_active_immich_integration(session, current_user.id)
 
         # Find EntryMedia records that need thumbnail repair
         media_to_repair = session.exec(
             select(EntryMedia)
-            .join(Entry, col(Entry.id) == col(EntryMedia.entry_id))
-            .where(Entry.user_id == current_user.id)
+            .outerjoin(Entry, col(Entry.id) == col(EntryMedia.entry_id))
+            .outerjoin(Moment, col(Moment.id) == col(EntryMedia.moment_id))
+            .where(
+                or_(
+                    col(Entry.user_id) == current_user.id,
+                    col(Moment.user_id) == current_user.id,
+                )
+            )
             .where(EntryMedia.external_provider == "immich")
             .where(col(EntryMedia.external_asset_id).is_not(None))
             .where(
@@ -1112,6 +1126,11 @@ async def repair_immich_thumbnails(
             "scheduled_count": len(media_to_repair)
         }
 
+    except (ImmichIntegrationNotConnectedError, ImmichIntegrationInactiveError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except HTTPException:
         raise
     except Exception as e:

--- a/app/api/v1/endpoints/moments.py
+++ b/app/api/v1/endpoints/moments.py
@@ -18,16 +18,18 @@ from app.models.moment import Moment, MomentMoodActivity
 from app.models.user import User
 from app.models.user_mood_preference import UserMoodPreference
 from app.schemas.activity import ActivityResponse
-from app.schemas.entry import EntryPreviewResponse
+from app.schemas.entry import EntryPreviewResponse, MomentMediaResponse
 from app.schemas.moment import (
     MomentCalendarItem,
     MomentCreate,
+    MomentMediaThumbnail,
     MomentMoodActivityResponse,
     MomentPageResponse,
     MomentResponse,
     MomentUpdate,
 )
 from app.schemas.mood import MoodResponse
+from app.services.media_service import MediaService
 from app.services.moment_service import MomentNotFoundError, MomentService
 
 router = APIRouter(prefix="/moments", tags=["moments"])
@@ -79,6 +81,9 @@ def _build_moment_response(
     session: Session,
     moment: Moment,
     current_user: User,
+    *,
+    media_count: int = 0,
+    media: List[MomentMediaThumbnail] | None = None,
 ) -> MomentResponse:
     entry_preview = None
     if moment.entry_id:
@@ -116,6 +121,8 @@ def _build_moment_response(
         location_data=moment.location_data,
         weather_data=moment.weather_data,
         mood_activity=mood_activity,
+        media_count=media_count,
+        media=media or [],
         created_at=moment.created_at,
         updated_at=moment.updated_at,
     )
@@ -125,6 +132,9 @@ def _build_moment_responses(
     session: Session,
     moments: List[Moment],
     current_user: User,
+    *,
+    media_counts: dict[uuid.UUID, int] | None = None,
+    media_map: dict[uuid.UUID, List[MomentMediaThumbnail]] | None = None,
 ) -> List[MomentResponse]:
     if not moments:
         return []
@@ -183,6 +193,8 @@ def _build_moment_responses(
                 location_data=moment.location_data,
                 weather_data=moment.weather_data,
                 mood_activity=links_map.get(moment.id, []),
+                media_count=(media_counts or {}).get(moment.id, 0),
+                media=(media_map or {}).get(moment.id, []),
                 created_at=moment.created_at,
                 updated_at=moment.updated_at,
             )
@@ -265,12 +277,15 @@ async def get_moments(
     cursor_id: Annotated[uuid.UUID | None, Query()] = None,
     start_date: Annotated[date | None, Query()] = None,
     end_date: Annotated[date | None, Query()] = None,
+    include_media: Annotated[str | None, Query()] = None,
 ):
     if (cursor_logged_at is None) ^ (cursor_id is None):
         raise HTTPException(
             status_code=400,
             detail="cursor_logged_at and cursor_id must be provided together",
         )
+    if include_media not in (None, "thumbnails"):
+        raise HTTPException(status_code=400, detail="include_media must be 'thumbnails' when provided")
     moment_service = MomentService(session)
     moments, next_cursor_logged_at, next_cursor_id = moment_service.get_moments(
         current_user.id,
@@ -280,7 +295,25 @@ async def get_moments(
         start_date=start_date,
         end_date=end_date,
     )
-    items = _build_moment_responses(session, moments, current_user)
+
+    media_counts: dict[uuid.UUID, int] = {}
+    media_map: dict[uuid.UUID, List[MomentMediaThumbnail]] = {}
+    if include_media == "thumbnails" and moments:
+        moment_ids = [moment.id for moment in moments]
+        media_service = MediaService(session)
+        media_counts, media_map = media_service.get_moment_media_thumbnails(
+            session,
+            current_user.id,
+            moment_ids,
+        )
+
+    items = _build_moment_responses(
+        session,
+        moments,
+        current_user,
+        media_counts=media_counts if include_media == "thumbnails" else None,
+        media_map=media_map if include_media == "thumbnails" else None,
+    )
     return MomentPageResponse(
         items=items,
         next_cursor_logged_at=next_cursor_logged_at,
@@ -328,3 +361,39 @@ async def get_moment_calendar(
                 moment_count=1,
             )
     return list(summary.values())
+
+
+@router.get(
+    "/{moment_id}/media",
+    response_model=List[MomentMediaResponse],
+    responses={
+        401: {"description": "Not authenticated"},
+        403: {"description": "Account inactive"},
+        404: {"description": "Moment not found"},
+        500: {"description": "Internal server error"},
+    }
+)
+async def get_moment_media(
+    moment_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_current_user)],
+    session: Annotated[Session, Depends(get_session)]
+):
+    """Get all media attached to a moment."""
+    try:
+        moment = session.exec(
+            select(Moment).where(Moment.id == moment_id, Moment.user_id == current_user.id)
+        ).first()
+        if not moment:
+            raise HTTPException(status_code=404, detail="Moment not found")
+
+        media_service = MediaService(session)
+        return media_service.get_signed_moment_media(
+            session,
+            current_user.id,
+            moment_id,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log_error(exc)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc

--- a/app/core/media_signing.py
+++ b/app/core/media_signing.py
@@ -15,7 +15,7 @@ from app.core.signing import generate_media_signature
 from app.models.entry import EntryMedia
 from app.models.enums import UploadStatus
 from app.models.integration import IntegrationProvider
-from app.schemas.entry import EntryMediaResponse, MediaOrigin
+from app.schemas.entry import EntryMediaResponse, MediaOrigin, MediaResponse
 from app.utils.quill_delta import transform_delta_media
 
 # Shared cache instance to avoid creating new Redis connections on every request
@@ -91,11 +91,11 @@ def signed_url_for_immich(
 
 
 def attach_signed_urls(
-    response: EntryMediaResponse,
+    response: MediaResponse,
     user_id: str,
     include_incomplete: bool = False,
     external_base_url: Optional[str] = None,
-) -> EntryMediaResponse:
+) -> MediaResponse:
     """
     Attach signed URLs to media response.
     """

--- a/app/schemas/entry.py
+++ b/app/schemas/entry.py
@@ -182,6 +182,11 @@ class EntryMediaBase(BaseModel):
     upload_status: UploadStatus = UploadStatus.PENDING
     file_metadata: Optional[str] = None
 
+
+class MediaBase(EntryMediaBase):
+    """Shared media base schema."""
+
+
 class EntryMediaExternalFields(BaseModel):
     """External provider fields (internal use)."""
     external_provider: Optional[str] = None
@@ -193,13 +198,21 @@ class EntryMediaExternalFields(BaseModel):
 
 class EntryMediaCreate(EntryMediaBase, EntryMediaExternalFields):
     """Entry media creation schema."""
-    entry_id: uuid.UUID
+    entry_id: Optional[uuid.UUID] = None
+    moment_id: Optional[uuid.UUID] = None
     checksum: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_link_target(self) -> "EntryMediaCreate":
+        if self.entry_id is None and self.moment_id is None:
+            raise ValueError("entry_id or moment_id is required")
+        return self
 
 
 class EntryMediaCreateRequest(EntryMediaBase):
     """Entry media creation schema for public API."""
-    entry_id: uuid.UUID
+    entry_id: Optional[uuid.UUID] = None
+    moment_id: Optional[uuid.UUID] = None
     checksum: Optional[str] = None
 
 
@@ -219,12 +232,11 @@ class EntryMediaExternalResponseFields(BaseModel):
     external_metadata: Optional[Dict[str, Any]] = Field(default=None, exclude=True)
 
 
-class EntryMediaResponse(EntryMediaBase, EntryMediaExternalResponseFields, TimestampMixin):
-    """Entry media response schema."""
+class MediaResponseBase(MediaBase, EntryMediaExternalResponseFields, TimestampMixin):
+    """Shared media response schema."""
     file_path: Optional[str] = Field(default=None, exclude=True)
     thumbnail_path: Optional[str] = Field(default=None, exclude=True)
     id: uuid.UUID
-    entry_id: uuid.UUID
     created_at: datetime
     checksum: Optional[str] = None
     processing_error: Optional[str] = None
@@ -234,7 +246,7 @@ class EntryMediaResponse(EntryMediaBase, EntryMediaExternalResponseFields, Times
     signed_thumbnail_expires_at: Optional[int] = None
     origin: Optional[MediaOrigin] = None
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_source_presence(self):
         """Ensure media has either local or external source."""
         if self.upload_status in {UploadStatus.PENDING, UploadStatus.FAILED}:
@@ -251,3 +263,18 @@ class EntryMediaResponse(EntryMediaBase, EntryMediaExternalResponseFields, Times
             raise ValueError("Media must have either a local file or an external source")
 
         return self
+
+
+class EntryMediaResponse(MediaResponseBase):
+    """Entry media response schema."""
+    entry_id: uuid.UUID
+    moment_id: Optional[uuid.UUID] = None
+
+
+class MomentMediaResponse(MediaResponseBase):
+    """Moment media response schema."""
+    moment_id: uuid.UUID
+    entry_id: Optional[uuid.UUID] = None
+
+
+MediaResponse = EntryMediaResponse | MomentMediaResponse

--- a/app/schemas/moment.py
+++ b/app/schemas/moment.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+from app.models.enums import MediaType
 from app.schemas.activity import ActivityResponse
 from app.schemas.base import TimestampMixin
 from app.schemas.entry import EntryBase, EntryPreviewResponse, EntryUpdate
@@ -67,6 +68,12 @@ class MomentMoodActivityResponse(TimestampMixin):
     activity: Optional[ActivityResponse] = None
 
 
+class MomentMediaThumbnail(BaseModel):
+    id: uuid.UUID
+    media_type: MediaType
+    signed_thumbnail_url: Optional[str] = None
+
+
 class MomentResponse(TimestampMixin):
     id: uuid.UUID
     user_id: uuid.UUID
@@ -80,6 +87,8 @@ class MomentResponse(TimestampMixin):
     location_data: Optional[Dict[str, Any]] = None
     weather_data: Optional[Dict[str, Any]] = None
     mood_activity: List[MomentMoodActivityResponse] = Field(default_factory=list)
+    media_count: int = 0
+    media: List[MomentMediaThumbnail] = Field(default_factory=list)
 
 
 class MomentCalendarItem(BaseModel):

--- a/app/services/media_service.py
+++ b/app/services/media_service.py
@@ -29,18 +29,22 @@ from app.core.exceptions import (
     MediaNotFoundError,
 )
 from app.core.logging_config import log_error, log_file_upload, log_info, log_warning
-from app.core.media_signing import signed_url_for_journiv
+from app.core.media_signing import attach_signed_urls, signed_url_for_journiv
 from app.models.entry import Entry, EntryMedia
 from app.models.enums import MediaType, UploadStatus
 from app.models.integration import Integration, IntegrationProvider
 from app.models.journal import Journal
+from app.models.moment import Moment
+from app.schemas.entry import MomentMediaResponse
 from app.schemas.media import (
     MediaBatchSignError,
     MediaBatchSignRequest,
     MediaBatchSignResponse,
     MediaBatchSignResult,
 )
+from app.schemas.moment import MomentMediaThumbnail
 from app.services.media_storage_service import MediaStorageService
+from app.services.moment_service import MomentNotFoundError
 from app.utils.import_export.media_handler import MediaHandler
 
 try:
@@ -52,6 +56,14 @@ except ImportError:
 # Structured logging
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+
+class ImmichIntegrationNotConnectedError(Exception):
+    """Raised when Immich integration is not connected."""
+
+
+class ImmichIntegrationInactiveError(Exception):
+    """Raised when Immich integration is inactive."""
 
 
 class MediaService:
@@ -122,6 +134,25 @@ class MediaService:
             raise EntryNotFoundError("Entry not found")
         return entry
 
+    def _get_moment_for_user(
+        self,
+        session: Session,
+        moment_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> Moment:
+        statement = (
+            select(Moment)
+            .where(
+                Moment.id == moment_id,
+                Moment.user_id == user_id,
+            )
+        )
+        moment = session.exec(statement).first()
+        if not moment:
+            log_warning(f"Moment not found for user {user_id}: {moment_id}")
+            raise MomentNotFoundError("Moment not found")
+        return moment
+
     def _get_media_path(self, filename: str, media_type: MediaType | str) -> Path:
         """Get the full path for a media file."""
         media_type_lower = self._normalize_media_type(media_type)
@@ -169,6 +200,118 @@ class MediaService:
         else:
             # Unknown media types cannot generate thumbnails
             return None
+
+    def _get_immich_base_url(self, session: Session, user_id: uuid.UUID) -> str | None:
+        immich_integration = session.exec(
+            select(Integration)
+            .where(Integration.user_id == user_id)
+            .where(Integration.provider == IntegrationProvider.IMMICH)
+        ).first()
+        return immich_integration.base_url if immich_integration else None
+
+    def get_immich_base_url(self, user_id: uuid.UUID) -> str | None:
+        session = self._get_session(self.session)
+        return self._get_immich_base_url(session, user_id)
+
+    def get_immich_integration(self, session: Session, user_id: uuid.UUID) -> Integration | None:
+        return session.exec(
+            select(Integration)
+            .where(Integration.user_id == user_id)
+            .where(Integration.provider == IntegrationProvider.IMMICH)
+        ).first()
+
+    def require_active_immich_integration(self, session: Session, user_id: uuid.UUID) -> Integration:
+        integration = self.get_immich_integration(session, user_id)
+        if not integration:
+            raise ImmichIntegrationNotConnectedError(
+                "Immich integration not connected. Please connect in Settings."
+            )
+        if not integration.is_active:
+            raise ImmichIntegrationInactiveError(
+                "Immich integration is inactive. Please reconnect in Settings."
+            )
+        return integration
+
+    def get_signed_moment_media(
+        self,
+        session: Session,
+        user_id: uuid.UUID,
+        moment_id: uuid.UUID,
+        *,
+        include_incomplete: bool = False,
+    ) -> list[MomentMediaResponse]:
+        media_items = session.exec(
+            select(EntryMedia)
+            .join(Moment, col(EntryMedia.moment_id) == Moment.id)
+            .where(
+                col(EntryMedia.moment_id) == moment_id,
+                Moment.user_id == user_id,
+            )
+        ).all()
+        immich_base_url = self._get_immich_base_url(session, user_id)
+        signed_media: list[MomentMediaResponse] = []
+        for media_item in media_items:
+            try:
+                response = MomentMediaResponse.model_validate(media_item)
+                response = MomentMediaResponse.model_validate(
+                    attach_signed_urls(
+                        response,
+                        str(user_id),
+                        include_incomplete=include_incomplete,
+                        external_base_url=immich_base_url,
+                    )
+                )
+                signed_media.append(response)
+            except Exception as exc:
+                log_warning(
+                    exc,
+                    message="Failed to sign moment media item",
+                    user_id=str(user_id),
+                    moment_id=str(moment_id),
+                    media_id=str(getattr(media_item, "id", "")),
+                )
+        return signed_media
+
+    def get_moment_media_thumbnails(
+        self,
+        session: Session,
+        user_id: uuid.UUID,
+        moment_ids: list[uuid.UUID],
+    ) -> tuple[dict[uuid.UUID, int], dict[uuid.UUID, list[MomentMediaThumbnail]]]:
+        if not moment_ids:
+            return {}, {}
+        media_items = session.exec(
+            select(EntryMedia)
+            .join(Moment, col(EntryMedia.moment_id) == Moment.id)
+            .where(
+                col(EntryMedia.moment_id).in_(moment_ids),
+                Moment.user_id == user_id,
+            )
+            .order_by(col(EntryMedia.created_at).desc())
+        ).all()
+        immich_base_url = self._get_immich_base_url(session, user_id)
+        media_counts: dict[uuid.UUID, int] = {}
+        media_map: dict[uuid.UUID, list[MomentMediaThumbnail]] = {}
+        for media_item in media_items:
+            if media_item.moment_id is None:
+                continue
+            media_counts[media_item.moment_id] = media_counts.get(media_item.moment_id, 0) + 1
+            if media_item.moment_id not in media_map:
+                response = MomentMediaResponse.model_validate(media_item)
+                response = attach_signed_urls(
+                    response,
+                    str(user_id),
+                    include_incomplete=True,
+                    external_base_url=immich_base_url,
+                )
+                media_map[media_item.moment_id] = [
+                    MomentMediaThumbnail(
+                        id=response.id,
+                        media_type=response.media_type,
+                        signed_thumbnail_url=response.signed_thumbnail_url,
+                    )
+                ]
+        return media_counts, media_map
 
     def _detect_mime(self, file_content: bytes) -> str:
         """Detect MIME type from bytes, used for uploaded content."""
@@ -507,7 +650,8 @@ class MediaService:
         self,
         file: UploadFile,
         user_id: uuid.UUID,
-        entry_id: uuid.UUID,
+        entry_id: Optional[uuid.UUID] = None,
+        moment_id: Optional[uuid.UUID] = None,
         alt_text: Optional[str] = None,
         session: Optional[Session] = None
     ) -> Dict[str, Any]:
@@ -520,6 +664,7 @@ class MediaService:
             file: The uploaded file
             user_id: ID of the user uploading the file
             entry_id: ID of the entry to attach media to
+            moment_id: ID of the moment to attach media to
             alt_text: Optional alt text for the media
             session: Optional database session for creating media record
 
@@ -530,8 +675,10 @@ class MediaService:
             FileTooLargeError: If file exceeds size limit
             FileValidationError: If file validation fails
             InvalidFileTypeError: If file type is not supported
-            EntryNotFoundError: If entry doesn't exist
+            EntryNotFoundError: If entry or moment doesn't exist
         """
+        if entry_id is None and moment_id is None:
+            raise ValueError("entry_id or moment_id is required")
         # 1. Check file size before reading (if provided by upload implementation)
         await self._check_file_size(file)
 
@@ -558,6 +705,8 @@ class MediaService:
 
         temp_file = None
         temp_path = None
+        resolved_entry_id = entry_id
+        resolved_moment_id = moment_id
 
         # Outer try-finally ensures temp file cleanup on ANY exception
         try:
@@ -596,9 +745,32 @@ class MediaService:
             self._validate_streamed_upload(file_size, filename, header_bytes)
             media_type = self._detect_media_type(header_bytes)
 
-            # 4. Verify entry exists and belongs to user (short-lived session)
+            # 4. Verify entry/moment exists and belongs to user (short-lived session)
             with get_session_context() as validation_session:
-                self._get_entry_for_user(validation_session, entry_id, user_id)
+                if entry_id is not None:
+                    self._get_entry_for_user(validation_session, entry_id, user_id)
+                    linked_moment = validation_session.exec(
+                        select(Moment).where(
+                            Moment.entry_id == entry_id,
+                            Moment.user_id == user_id,
+                        )
+                    ).first()
+                    if linked_moment and resolved_moment_id is None:
+                        resolved_moment_id = linked_moment.id
+                    if resolved_moment_id is not None:
+                        moment = self._get_moment_for_user(
+                            validation_session, resolved_moment_id, user_id
+                        )
+                        if moment.entry_id and moment.entry_id != entry_id:
+                            raise ValueError("moment_id does not match entry_id")
+                        if moment.entry_id is None and linked_moment is None:
+                            raise ValueError("moment_id does not match entry_id")
+                    if linked_moment and resolved_moment_id and linked_moment.id != resolved_moment_id:
+                        raise ValueError("entry_id does not match moment_id")
+                elif moment_id is not None:
+                    moment = self._get_moment_for_user(validation_session, moment_id, user_id)
+                    if moment.entry_id is not None:
+                        resolved_entry_id = moment.entry_id
 
             # 5. Save file
             if use_temp_fallback:
@@ -631,45 +803,104 @@ class MediaService:
             # This prevents duplicate media within the same entry
             checksum = media_info.get("checksum")
             if checksum and isinstance(checksum, str) and checksum.strip():
-                existing_entry_media = db_session.exec(
-                    select(EntryMedia).where(
-                        EntryMedia.entry_id == entry_id,
-                        EntryMedia.checksum == checksum
-                    )
-                ).first()
+                existing_entry_media = None
+                if resolved_entry_id is not None:
+                    existing_entry_media = db_session.exec(
+                        select(EntryMedia).where(
+                            EntryMedia.entry_id == resolved_entry_id,
+                            EntryMedia.checksum == checksum
+                        )
+                    ).first()
+                if existing_entry_media is None and resolved_moment_id is not None:
+                    existing_entry_media = db_session.exec(
+                        select(EntryMedia).where(
+                            EntryMedia.moment_id == resolved_moment_id,
+                            EntryMedia.checksum == checksum
+                        )
+                    ).first()
 
                 if existing_entry_media:
                     log_info(
-                        "Media already associated with entry, returning existing record",
+                        "Media already associated with target, returning existing record",
                         user_id=str(user_id),
-                        entry_id=str(entry_id),
+                        entry_id=str(resolved_entry_id) if resolved_entry_id else None,
+                        moment_id=str(resolved_moment_id) if resolved_moment_id else None,
                         checksum=checksum[:16] if (checksum and len(checksum) >= 16) else checksum,
                         media_id=str(existing_entry_media.id)
                     )
-                    full_file_path_result = str(self.media_storage_service.get_full_path(existing_entry_media.file_path))
-                    db_session.expunge(existing_entry_media)
-                    media_record = existing_entry_media
+                    updated = False
+                    media_target = existing_entry_media
+                    if resolved_entry_id and media_target.entry_id is None:
+                        conflict = db_session.exec(
+                            select(EntryMedia).where(
+                                EntryMedia.entry_id == resolved_entry_id,
+                                EntryMedia.checksum == checksum,
+                            )
+                        ).first()
+                        if conflict and conflict.id != media_target.id:
+                            media_target = conflict
+                        else:
+                            media_target.entry_id = resolved_entry_id
+                            updated = True
+                    if resolved_moment_id and media_target.moment_id is None:
+                        conflict = db_session.exec(
+                            select(EntryMedia).where(
+                                EntryMedia.moment_id == resolved_moment_id,
+                                EntryMedia.checksum == checksum,
+                            )
+                        ).first()
+                        if conflict and conflict.id != media_target.id:
+                            media_target = conflict
+                        else:
+                            media_target.moment_id = resolved_moment_id
+                            updated = True
+                    if updated:
+                        db_session.add(media_target)
+                        db_session.commit()
+                        db_session.refresh(media_target)
+                    full_file_path_result = str(self.media_storage_service.get_full_path(media_target.file_path))
+                    db_session.expunge(media_target)
+                    media_record = media_target
 
             # Only process new media if no existing record was found
             if media_record is None:
-                # If file was deduplicated, try to find existing media with same checksum
+                # Try to find existing media with the same checksum for this user
                 existing_media = None
-                if media_info.get("was_deduplicated"):
+                if checksum:
                     stmt = (
                         select(EntryMedia)
-                        .join(Entry)
-                        .join(Journal)
+                        .outerjoin(Entry, col(EntryMedia.entry_id) == Entry.id)
+                        .outerjoin(Journal, col(Entry.journal_id) == Journal.id)
+                        .outerjoin(Moment, col(EntryMedia.moment_id) == Moment.id)
                         .where(
-                            EntryMedia.checksum == media_info["checksum"],
-                            Journal.user_id == user_id
+                            col(EntryMedia.checksum) == checksum,
+                            or_(
+                                Journal.user_id == user_id,
+                                Moment.user_id == user_id,
+                            ),
                         )
                     )
                     existing_media = db_session.exec(stmt).first()
 
                 if existing_media:
+                    if (
+                        not media_info.get("was_deduplicated")
+                        and media_info.get("file_path")
+                        and media_info.get("file_path") != existing_media.file_path
+                    ):
+                        try:
+                            self.media_storage_service.delete_media(
+                                relative_path=media_info["file_path"],
+                                checksum=media_info["checksum"],
+                                user_id=str(user_id),
+                                force=True,
+                            )
+                        except (RuntimeError, OSError) as delete_exc:
+                            log_warning(f"Failed to cleanup duplicate uploaded file: {delete_exc}")
                     # Reuse existing media metadata, create new record for this entry
                     media_record = EntryMedia(
-                        entry_id=entry_id,
+                        entry_id=resolved_entry_id,
+                        moment_id=resolved_moment_id,
                         media_type=existing_media.media_type,
                         file_path=existing_media.file_path,
                         original_filename=media_info["original_filename"],
@@ -696,7 +927,8 @@ class MediaService:
                 else:
                     # Create new media record
                     media_record = EntryMedia(
-                        entry_id=entry_id,
+                        entry_id=resolved_entry_id,
+                        moment_id=resolved_moment_id,
                         media_type=media_type,
                         file_path=media_info["file_path"],
                         original_filename=media_info["original_filename"],
@@ -729,21 +961,31 @@ class MediaService:
                     db_session.rollback()
                     # Check if this is the duplicate entry_media constraint violation
                     error_str = str(exc)
-                    if "uq_entry_media_entry_checksum" in error_str:
+                    if "uq_entry_media_entry_checksum" in error_str or "uq_entry_media_moment_checksum" in error_str:
                         # Race condition: media was created by concurrent request
                         checksum_value = media_info.get("checksum")
                         if checksum_value:
-                            existing = db_session.exec(
-                                select(EntryMedia).where(
-                                    EntryMedia.entry_id == entry_id,
-                                    EntryMedia.checksum == checksum_value
-                                )
-                            ).first()
+                            existing = None
+                            if resolved_entry_id is not None:
+                                existing = db_session.exec(
+                                    select(EntryMedia).where(
+                                        EntryMedia.entry_id == resolved_entry_id,
+                                        EntryMedia.checksum == checksum_value
+                                    )
+                                ).first()
+                            if existing is None and resolved_moment_id is not None:
+                                existing = db_session.exec(
+                                    select(EntryMedia).where(
+                                        EntryMedia.moment_id == resolved_moment_id,
+                                        EntryMedia.checksum == checksum_value
+                                    )
+                                ).first()
                             if existing:
                                 log_info(
                                     "Media already associated with entry (race condition), using existing record",
                                     user_id=str(user_id),
-                                    entry_id=str(entry_id),
+                                    entry_id=str(resolved_entry_id) if resolved_entry_id else None,
+                                    moment_id=str(resolved_moment_id) if resolved_moment_id else None,
                                     checksum=checksum_value[:16] if len(checksum_value) >= 16 else checksum_value,
                                     media_id=str(existing.id)
                                 )
@@ -756,7 +998,8 @@ class MediaService:
                             log_warning(
                                 "IntegrityError for entry_media constraint but existing record not found",
                                 user_id=str(user_id),
-                                entry_id=str(entry_id),
+                                entry_id=str(resolved_entry_id) if resolved_entry_id else None,
+                                moment_id=str(resolved_moment_id) if resolved_moment_id else None,
                                 checksum=checksum_value[:16] if checksum_value and len(checksum_value) >= 16 else None
                             )
 
@@ -816,9 +1059,17 @@ class MediaService:
             raise MediaNotFoundError("Invalid media ID format") from None
 
         session = self._get_session(self.session)
-        statement = select(EntryMedia).join(Entry).where(
-            EntryMedia.id == media_uuid,
-            Entry.user_id == uuid.UUID(user_id),
+        statement = (
+            select(EntryMedia)
+            .outerjoin(Entry, col(EntryMedia.entry_id) == Entry.id)
+            .outerjoin(Moment, col(EntryMedia.moment_id) == Moment.id)
+            .where(
+                EntryMedia.id == media_uuid,
+                or_(
+                    Entry.user_id == uuid.UUID(user_id),
+                    Moment.user_id == uuid.UUID(user_id),
+                ),
+            )
         )
 
         media = session.exec(statement).first()
@@ -1209,9 +1460,17 @@ class MediaService:
         Raises:
             MediaNotFoundError: If media not found or user doesn't have access
         """
-        statement = select(EntryMedia).join(Entry).where(
-            EntryMedia.id == media_id,
-            Entry.user_id == user_id,
+        statement = (
+            select(EntryMedia)
+            .outerjoin(Entry, col(EntryMedia.entry_id) == Entry.id)
+            .outerjoin(Moment, col(EntryMedia.moment_id) == Moment.id)
+            .where(col(EntryMedia.id) == media_id)
+            .where(
+                or_(
+                    Entry.user_id == user_id,
+                    Moment.user_id == user_id,
+                )
+            )
         )
         media = session.exec(statement).first()
         if not media:
@@ -1524,14 +1783,20 @@ class MediaService:
                     EntryMedia.thumbnail_path,
                     EntryMedia.media_type,
                 )
-                .join(Entry)
+                .outerjoin(Entry, col(EntryMedia.entry_id) == Entry.id)
+                .outerjoin(Moment, col(EntryMedia.moment_id) == Moment.id)
                 .where(
                     or_(
                         col(EntryMedia.id).in_(item_ids_to_query),
                         col(EntryMedia.external_asset_id).in_(query_ids_str)
                     )
                 )
-                .where(Entry.user_id == current_user_id)
+                .where(
+                    or_(
+                        Entry.user_id == current_user_id,
+                        Moment.user_id == current_user_id,
+                    )
+                )
             ).all()
             logger.info(f"Batch sign found {len(rows)} matching rows")
             logger.debug(f"Batch sign found matching rows: {rows}")

--- a/app/services/moment_service.py
+++ b/app/services/moment_service.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import date, datetime
 from typing import List, Optional, Tuple
 
-from sqlalchemy import String, cast, or_
+from sqlalchemy import String, cast, or_, update
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlmodel import Session, col, delete, select
 
@@ -14,7 +14,7 @@ from app.core.exceptions import EntryNotFoundError, ValidationError
 from app.core.logging_config import log_error, log_info
 from app.core.time_utils import ensure_utc, local_date_for_user, utc_now
 from app.models.activity import Activity
-from app.models.entry import Entry
+from app.models.entry import Entry, EntryMedia
 from app.models.moment import Moment, MomentMoodActivity
 from app.models.mood import Mood
 from app.schemas.entry import EntryCreate
@@ -299,6 +299,14 @@ class MomentService:
             moment.logged_at = created_entry.entry_datetime_utc
             moment.logged_date = created_entry.entry_date
             moment.logged_timezone = created_entry.entry_timezone
+            self.session.exec(
+                update(EntryMedia)
+                .where(
+                    col(EntryMedia.moment_id) == moment.id,
+                    col(EntryMedia.entry_id).is_(None),
+                )
+                .values(entry_id=created_entry.id, updated_at=utc_now())
+            )
 
         if moment_data.logged_at is not None:
             moment.logged_at = ensure_utc(moment_data.logged_at)


### PR DESCRIPTION
#58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload media to moments as well as entries; new endpoint to fetch media for a moment
  * Option to include media thumbnails in moment listings
  * Signed media references returned for moment and entry media (unified response surface)

* **Improvements**
  * Validation requires media be linked to an entry or a moment; upload responses distinguish moment vs entry media
  * Media signing and external integration flows centralized with clearer 400 errors
  * Better deduplication, reassociation and error handling during uploads

* **Bug Fixes**
  * Rejects mismatched or invalid entry/moment IDs on media add/update paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->