### PR TITLE
fix: mood endpoint to fix openapi serialization

### DIFF
--- a/app/api/v1/endpoints/moments.py
+++ b/app/api/v1/endpoints/moments.py
@@ -279,7 +279,7 @@ async def get_moments(
     end_date: Annotated[date | None, Query()] = None,
     include_media: Annotated[str | None, Query()] = None,
     journal_id: Annotated[uuid.UUID | None, Query()] = None,
-    mood_ids: Annotated[List[uuid.UUID] | None, Query()] = None,
+    mood_ids: List[uuid.UUID] = Query(default_factory=list),  # noqa: B008
     search: Annotated[str | None, Query()] = None,
 ):
     if (cursor_logged_at is None) ^ (cursor_id is None):
@@ -298,7 +298,7 @@ async def get_moments(
         start_date=start_date,
         end_date=end_date,
         journal_id=journal_id,
-        mood_ids=mood_ids,
+        mood_ids=mood_ids if mood_ids else None,
         search=search,
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved mood-based filtering input for the moments API: the endpoint now consistently accepts a list of moods while preserving previous behavior when no moods are supplied, ensuring responses remain unchanged for existing clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->