### PR TITLE
fix: handle paths starting with slashes for daylio import

### DIFF
--- a/app/data_transfer/utils/zip_utils.py
+++ b/app/data_transfer/utils/zip_utils.py
@@ -100,6 +100,10 @@ def safe_extract_zip(
             # This is safe because we still validate the path doesn't escape the extract directory
             normalized_filename = info.filename.lstrip("/")
 
+            # Reject empty filenames after normalization
+            if not normalized_filename:
+                raise ValueError(f"ZIP contains invalid empty filename: {info.filename}")
+
             # Check for path traversal after normalization
             if ".." in normalized_filename.split("/"):
                 raise ValueError(f"ZIP contains unsafe path: {info.filename}")


### PR DESCRIPTION
#58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP extraction safety by normalizing entry filenames (e.g., stripping leading slashes), validating names for emptiness, path traversal and NUL characters, and ensuring destination paths and file-type checks use the normalized names so extraction stays within the target directory and handles specially formatted entries correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->