### PR TITLE
feat: allow choosing a different role for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ USER appuser
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD sh -c 'case "${SERVICE_ROLE:-app}" in \
+  CMD sh -c 'case "${SERVICE_ROLE:-${SERVICE_ROLE_HEALTHCHECK:-app}}" in \
   celery-worker) /opt/venv/bin/python -m celery -A app.core.celery_app inspect ping -d "celery@$(hostname)" --timeout=5 | grep -q "pong" ;; \
   celery-beat) test -f /tmp/celerybeat.pid && kill -0 "$(cat /tmp/celerybeat.pid)" ;; \
   admin-cli) exit 0 ;; \


### PR DESCRIPTION
Right now I am running journiv worker with a custom command to customize the concurrency parameter so I can not set the `SERVICE_ROLE` environment variable but I still want to use the built-in healthcheck hence this PR.

Thank you for creating this application :D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced health check configuration flexibility with optional service role customization, while maintaining backward compatibility with existing deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->