### PR TITLE
fix: send content delta hydrated with signed url

### DIFF
--- a/app/api/v1/endpoints/entries.py
+++ b/app/api/v1/endpoints/entries.py
@@ -6,7 +6,7 @@ import uuid
 from typing import Annotated, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.api.dependencies import get_current_user
 from app.core.database import get_session
@@ -16,6 +16,8 @@ from app.core.exceptions import (
     ValidationError,
 )
 from app.core.logging_config import log_error, log_user_action
+from app.core.media_signing import attach_signed_urls_to_delta
+from app.models.moment import MomentMedia
 from app.models.user import User
 from app.schemas.entry import (
     EntryCreate,
@@ -29,16 +31,65 @@ router = APIRouter(prefix="/entries", tags=["entries"])
 logger = logging.getLogger(__name__)
 
 
-def _build_entry_responses(
+def _hydrate_entry_deltas(
+    session: Session,
     entries: List,
+    user_id: uuid.UUID,
 ) -> List[EntryResponse]:
-    return [EntryResponse.model_validate(entry) for entry in entries]
+    """Build entry responses with content_delta hydrated with signed media URLs."""
+    responses = [EntryResponse.model_validate(entry) for entry in entries]
+
+    # Collect all moment_ids that have content_delta needing hydration
+    moment_ids = {
+        r.moment_id for r in responses
+        if r.content_delta is not None and r.moment_id is not None
+    }
+    if not moment_ids:
+        return responses
+
+    # Batch-load all media for the relevant moments
+    media_items = list(session.exec(
+        select(MomentMedia).where(MomentMedia.moment_id.in_(moment_ids))  # type: ignore[union-attr]
+    ).all())
+
+    # Group by moment_id
+    media_by_moment: dict[uuid.UUID, list[MomentMedia]] = {}
+    for media in media_items:
+        media_by_moment.setdefault(media.moment_id, []).append(media)
+
+    user_id_str = str(user_id)
+    for response in responses:
+        if response.content_delta is None or response.moment_id is None:
+            continue
+        moment_media = media_by_moment.get(response.moment_id, [])
+        if not moment_media:
+            continue
+        delta_dict = (
+            response.content_delta.model_dump()
+            if hasattr(response.content_delta, "model_dump")
+            else response.content_delta
+        )
+        hydrated = attach_signed_urls_to_delta(delta_dict, moment_media, user_id_str)
+        if hydrated is not None:
+            response.content_delta = response.content_delta.__class__(**hydrated)
+
+    return responses
+
+
+def _build_entry_responses(
+    session: Session,
+    entries: List,
+    user_id: uuid.UUID,
+) -> List[EntryResponse]:
+    return _hydrate_entry_deltas(session, entries, user_id)
 
 
 def _build_entry_response(
+    session: Session,
     entry,
+    user_id: uuid.UUID,
 ) -> EntryResponse:
-    return _build_entry_responses([entry])[0]
+    return _build_entry_responses(session, [entry], user_id)[0]
 
 @router.post(
     "/",
@@ -62,7 +113,7 @@ async def create_entry(
     try:
         entry = entry_service.create_entry(current_user.id, entry_data)
         log_user_action(current_user.email, f"created entry {entry.id}", request_id=None)
-        return _build_entry_response(entry)
+        return _build_entry_response(session, entry, current_user.id)
     except JournalNotFoundError:
         raise HTTPException(status_code=404, detail="Journal not found") from None
     except ValidationError as e:
@@ -96,7 +147,7 @@ async def create_draft_entry(
     try:
         entry = entry_service.create_entry(current_user.id, entry_data, is_draft=True)
         log_user_action(current_user.email, f"created draft entry {entry.id}", request_id=None)
-        return _build_entry_response(entry)
+        return _build_entry_response(session, entry, current_user.id)
     except JournalNotFoundError:
         raise HTTPException(status_code=404, detail="Journal not found") from None
     except ValidationError as e:
@@ -133,7 +184,7 @@ async def get_user_drafts(
             offset=offset,
             journal_id=journal_id,
         )
-        return _build_entry_responses(entries)
+        return _build_entry_responses(session, entries, current_user.id)
     except Exception as e:
         log_error(e, message="Unexpected error fetching draft entries", user_email=current_user.email)
         raise HTTPException(status_code=500, detail="An error occurred while fetching draft entries") from None
@@ -170,7 +221,7 @@ async def get_user_entries(
             offset=offset,
             include_drafts=include_drafts,
         )
-        return _build_entry_responses(entries)
+        return _build_entry_responses(session, entries, current_user.id)
     except Exception as e:
         log_error(e, message="Unexpected error fetching entries", user_email=current_user.email)
         raise HTTPException(status_code=500, detail="An error occurred while fetching entries") from None
@@ -206,7 +257,7 @@ async def get_journal_entries(
             include_drafts,
             include_pinned=include_pinned,
         )
-        return _build_entry_responses(entries)
+        return _build_entry_responses(session, entries, current_user.id)
     except JournalNotFoundError:
         raise HTTPException(status_code=404, detail="Journal not found") from None
     except Exception as e:
@@ -238,7 +289,7 @@ async def get_entry(
         entry = entry_service.get_entry_by_id(entry_id, current_user.id)
         if not entry:
             raise HTTPException(status_code=404, detail="Entry not found")
-        return _build_entry_response(entry)
+        return _build_entry_response(session, entry, current_user.id)
     except HTTPException:
         raise
     except Exception as e:
@@ -272,7 +323,7 @@ async def update_entry(
     try:
         entry = entry_service.update_entry(entry_id, current_user.id, entry_data)
         log_user_action(current_user.email, "Updated entry", request_id=None)
-        return _build_entry_response(entry)
+        return _build_entry_response(session, entry, current_user.id)
     except EntryNotFoundError:
         raise HTTPException(status_code=404, detail="Entry not found") from None
     except JournalNotFoundError:

--- a/tests/integration/test_entry_endpoints.py
+++ b/tests/integration/test_entry_endpoints.py
@@ -376,3 +376,84 @@ def test_entry_endpoints_require_auth(api_client: JournivApiClient):
             ),
         ],
     )
+
+
+def test_entry_includes_hydrated_content_delta_with_media(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+    journal_factory,
+):
+    """Entry content delta should be hydrated with signed media URLs."""
+    journal = journal_factory()
+    created = api_client.create_entry_with_moment(
+        api_user.access_token,
+        journal_id=journal["id"],
+        title="Entry with media hydration",
+        content="Initial content",
+    )
+    entry_id = created["id"]
+    moment_id = created["moment_id"]
+
+    # Upload media
+    from tests.integration.helpers import upload_sample_media
+    media = upload_sample_media(
+        api_client,
+        api_user.access_token,
+        moment_id,
+    )
+    media_id = media["id"]
+
+    # Wait for media to be ready
+    api_client.wait_for_media_ready(api_user.access_token, media_id)
+
+    # Update entry to reference the media in content_delta
+    delta = {
+        "ops": [
+            {"insert": "Look at this image: "},
+            {"insert": {"image": media_id}},
+            {"insert": "\n"}
+        ]
+    }
+
+    # Use the bare request to avoid _wrap_content_to_delta stripping content_delta from PUT params if it is smart, or use update_entry
+    api_client.request(
+        "PUT",
+        f"/entries/{entry_id}",
+        token=api_user.access_token,
+        json={"content_delta": delta},
+        expected=(200,)
+    )
+
+    # Fetch entry individually
+    fetched = api_client.get_entry(api_user.access_token, entry_id)
+    ops = fetched.get("content_delta", {}).get("ops", [])
+
+    image_op = None
+    for op in ops:
+        insert = op.get("insert")
+        if isinstance(insert, dict) and "image" in insert:
+            image_op = insert["image"]
+            break
+
+    assert image_op is not None, "Image operation missing from hydrated delta"
+    assert image_op != media_id, "Media ID was not hydrated"
+    assert "/api/v1/media/" in image_op, "Hydrated URL is invalid"
+    assert "sig=" in image_op, "Hydrated URL is missing signature"
+
+    # Also fetch via entries list
+    entries_list = api_client.list_entries(api_user.access_token, journal_id=journal["id"])
+    assert len(entries_list) == 1
+    list_ops = entries_list[0].get("content_delta", {}).get("ops", [])
+
+    list_image_op = None
+    for op in list_ops:
+        insert = op.get("insert")
+        if isinstance(insert, dict) and "image" in insert:
+            list_image_op = insert["image"]
+            break
+
+    assert list_image_op is not None, "Image operation missing from hydrated delta in list endpoint"
+    assert list_image_op != media_id, "Media ID was not hydrated in list endpoint"
+    assert "/api/v1/media/" in list_image_op, "Hydrated URL in list endpoint is invalid"
+    assert "sig=" in list_image_op, "Hydrated URL in list endpoint is missing signature"
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entry API responses now consistently include properly signed, authenticated media URLs for all embedded media content across all operations—including creation, retrieval, updates, and list views—providing secure and authenticated access to media resources.

* **Tests**
  * Added comprehensive integration test validating proper generation and inclusion of signed media URLs in entry responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->