### PR TITLE
fix: add media inline for daylio imports

### DIFF
--- a/app/data_transfer/daylio/mappers.py
+++ b/app/data_transfer/daylio/mappers.py
@@ -104,6 +104,7 @@ class DaylioToJournivMapper:
                     day_entry,
                     import_timestamp=import_timestamp,
                     journal_external_id=journal.external_id,
+                    media_items=moment.media,
                 )
                 timeline_moments.append(moment)
                 continue
@@ -377,12 +378,17 @@ class DaylioToJournivMapper:
         *,
         import_timestamp: datetime,
         journal_external_id: Optional[str],
+        media_items: Optional[List[MomentMediaDTO]] = None,
     ) -> EntryDTO:
         logged_at = _ms_to_utc(day_entry.datetime) or import_timestamp
 
         title = (day_entry.note_title or "").strip() or None
         note = (day_entry.note or "").strip()
         content_delta = html_to_delta(note) if note else wrap_plain_text(None)
+        content_delta = DaylioToJournivMapper._append_media_to_entry_delta(
+            content_delta=content_delta,
+            media_items=media_items or [],
+        )
 
         return EntryDTO(
             title=title,
@@ -400,6 +406,51 @@ class DaylioToJournivMapper:
             updated_at=logged_at,
             external_id=f"daylio-entry-{day_entry.datetime}",
         )
+
+    @staticmethod
+    def _append_media_to_entry_delta(
+        *,
+        content_delta: Dict[str, Any],
+        media_items: List[MomentMediaDTO],
+    ) -> Dict[str, Any]:
+        """
+        Append imported media embeds to the end of entry content.
+
+        Daylio media is attached at moment level. For entry-backed moments we append
+        media placeholders so later entry edits preserve media ownership unless user
+        explicitly removes embeds.
+        """
+        if not media_items:
+            return content_delta
+
+        delta = content_delta if isinstance(content_delta, dict) else wrap_plain_text(None)
+        ops = delta.get("ops")
+        if not isinstance(ops, list):
+            ops = [{"insert": "\n"}]
+            delta["ops"] = ops
+
+        # Ensure we end on a newline before appending embeds.
+        if not ops:
+            ops.append({"insert": "\n"})
+        else:
+            last_insert = ops[-1].get("insert") if isinstance(ops[-1], dict) else None
+            if isinstance(last_insert, dict):
+                ops.append({"insert": "\n"})
+            elif isinstance(last_insert, str) and not last_insert.endswith("\n"):
+                ops.append({"insert": "\n"})
+
+        for media in media_items:
+            if not media.external_id:
+                continue
+            key = "image"
+            if media.media_type == "video":
+                key = "video"
+            elif media.media_type == "audio":
+                key = "audio"
+            ops.append({"insert": {key: media.external_id}})
+            ops.append({"insert": "\n"})
+
+        return delta
 
     @staticmethod
     def _map_moment(

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -809,6 +809,13 @@ class ImportService:
             if media_dto.external_id and media_dto.external_asset_id in media_id_map:
                 media_id_map[media_dto.external_id] = media_id_map[media_dto.external_asset_id]
 
+        # Daylio and other imports may use media.external_id placeholders directly
+        # in entry delta embeds. Resolve those placeholders using recorded ID mappings.
+        media_mappings = summary.id_mappings.get("media", {})
+        for media_dto in moment_dto.media:
+            if media_dto.external_id and media_dto.external_id in media_mappings:
+                media_id_map[media_dto.external_id] = media_mappings[media_dto.external_id]
+
         placeholder_map = self._build_dayone_placeholder_map(
             entry_dto,
             moment_dto.media,
@@ -1002,7 +1009,7 @@ class ImportService:
                     media_dir=media_dir,
                     existing_checksums=existing_media_checksums,
                     summary=summary,
-                    record_mapping=None,
+                    record_mapping=record_mapping,
                 )
                 if media_result["imported"]:
                     summary.media_files_imported += 1

--- a/tests/unit/data_transfer/test_daylio_mapper_media_embeds.py
+++ b/tests/unit/data_transfer/test_daylio_mapper_media_embeds.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timezone
+
+from app.data_transfer.daylio.mappers import DaylioToJournivMapper
+from app.data_transfer.daylio.models import DaylioDayEntry
+from app.schemas.dto import MomentMediaDTO
+
+
+def _media_dto(external_id: str, media_type: str) -> MomentMediaDTO:
+    now = datetime.now(timezone.utc)
+    return MomentMediaDTO(
+        filename=f"{external_id}.{media_type}",
+        file_path=f"assets/{external_id}",
+        media_type=media_type,
+        file_size=123,
+        mime_type="application/octet-stream",
+        checksum=None,
+        width=None,
+        height=None,
+        duration=None,
+        alt_text=None,
+        file_metadata=None,
+        thumbnail_path=None,
+        upload_status="completed",
+        created_at=now,
+        updated_at=now,
+        external_id=external_id,
+    )
+
+
+def test_map_entry_appends_media_embeds_for_daylio_entry() -> None:
+    day_entry = DaylioDayEntry(
+        datetime=1738368000000,
+        year=2025,
+        month=1,
+        day=1,
+        hour=8,
+        minute=0,
+        note="Imported note",
+        note_title="Imported title",
+    )
+
+    entry = DaylioToJournivMapper._map_entry(
+        day_entry,
+        import_timestamp=datetime.now(timezone.utc),
+        journal_external_id="journal-1",
+        media_items=[
+            _media_dto("asset-image-1", "image"),
+            _media_dto("asset-audio-2", "audio"),
+        ],
+    )
+
+    ops = entry.content_delta["ops"]
+    assert {"insert": {"image": "asset-image-1"}} in ops
+    assert {"insert": {"audio": "asset-audio-2"}} in ops
+    assert ops[-1] == {"insert": "\n"}
+
+
+def test_map_entry_without_media_keeps_text_only_delta() -> None:
+    day_entry = DaylioDayEntry(
+        datetime=1738368000000,
+        year=2025,
+        month=1,
+        day=1,
+        hour=8,
+        minute=0,
+        note="Text only",
+    )
+
+    entry = DaylioToJournivMapper._map_entry(
+        day_entry,
+        import_timestamp=datetime.now(timezone.utc),
+        journal_external_id="journal-1",
+        media_items=[],
+    )
+
+    ops = entry.content_delta["ops"]
+    assert {"insert": {"image": "asset-image-1"}} not in ops
+    assert {"insert": {"audio": "asset-audio-2"}} not in ops


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Media from Daylio imports (images, videos, audio) are now automatically embedded into journal entries during the import process.

* **Tests**
  * Added test coverage for media embedding functionality in Daylio imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->