### PR TITLE
fix: mood uuid mismatch on sqlite due to hypens

### DIFF
--- a/alembic/versions/e5f6a7b8c9d0_normalize_sqlite_mood_uuids.py
+++ b/alembic/versions/e5f6a7b8c9d0_normalize_sqlite_mood_uuids.py
@@ -1,0 +1,132 @@
+"""normalize sqlite mood uuid formats after system-mood removal
+
+Revision ID: e5f6a7b8c9d0
+Revises: d2e4f6a8b0c1
+Create Date: 2026-02-24 07:20:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e5f6a7b8c9d0"
+down_revision = "d2e4f6a8b0c1"
+branch_labels = None
+depends_on = None
+
+_STARTER_MOOD_STABLE_KEYS = [
+    "mood_awesome",
+    "mood_good",
+    "mood_meh",
+    "mood_bad",
+    "mood_awful",
+]
+
+
+def _is_sqlite(conn) -> bool:
+    return conn.dialect.name == "sqlite"
+
+
+def _column_exists(conn, table_name: str, column_name: str) -> bool:
+    rows = conn.execute(
+        sa.text(
+            """
+            SELECT 1
+            FROM pragma_table_info(:table_name)
+            WHERE name = :column_name
+            LIMIT 1
+            """
+        ),
+        {"table_name": table_name, "column_name": column_name},
+    ).fetchone()
+    return rows is not None
+
+
+def _normalize_uuid_column(conn, table_name: str, column_name: str) -> None:
+    if not _column_exists(conn, table_name, column_name):
+        return
+    conn.execute(
+        sa.text(
+            f"""
+            UPDATE {table_name}
+            SET {column_name} = lower(replace({column_name}, '-', ''))
+            WHERE {column_name} IS NOT NULL
+              AND {column_name} != lower(replace({column_name}, '-', ''))
+            """
+        )
+    )
+
+
+def _ensure_core_group_links(conn) -> None:
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO mood_group_link (
+                id,
+                created_at,
+                updated_at,
+                mood_group_id,
+                mood_id,
+                position
+            )
+            SELECT
+                lower(hex(randomblob(16))),
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP,
+                mg.id,
+                m.id,
+                m.position
+            FROM mood_group AS mg
+            JOIN mood AS m
+              ON m.user_id = mg.user_id
+            WHERE mg.stable_key = :core_group_stable_key
+              AND m.stable_key IN :starter_mood_stable_keys
+              AND COALESCE(m.is_active, 1) = 1
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM mood_group_link AS l
+                  WHERE l.mood_group_id = mg.id
+                    AND l.mood_id = m.id
+              )
+            """
+        ).bindparams(
+            sa.bindparam("starter_mood_stable_keys", expanding=True),
+        ),
+        {
+            "core_group_stable_key": "moodgroup_core_moods",
+            "starter_mood_stable_keys": _STARTER_MOOD_STABLE_KEYS,
+        },
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if not _is_sqlite(conn):
+        return
+
+    with op.get_context().autocommit_block():
+        conn.execute(sa.text("PRAGMA foreign_keys=OFF"))
+    try:
+        _normalize_uuid_column(conn, "mood", "id")
+        _normalize_uuid_column(conn, "mood", "user_id")
+        _normalize_uuid_column(conn, "mood_group", "id")
+        _normalize_uuid_column(conn, "mood_group", "user_id")
+        _normalize_uuid_column(conn, "mood_group_link", "id")
+        _normalize_uuid_column(conn, "mood_group_link", "mood_group_id")
+        _normalize_uuid_column(conn, "mood_group_link", "mood_id")
+        _normalize_uuid_column(conn, "user_mood_preference", "mood_id")
+        _normalize_uuid_column(conn, "user_mood_group_preference", "mood_group_id")
+        _normalize_uuid_column(conn, "moment", "primary_mood_id")
+        _normalize_uuid_column(conn, "moment_mood_activity", "mood_id")
+        _ensure_core_group_links(conn)
+    finally:
+        with op.get_context().autocommit_block():
+            conn.execute(sa.text("PRAGMA foreign_keys=ON"))
+
+
+def downgrade() -> None:
+    # Irreversible data normalization for SQLite UUID text representation.
+    pass

--- a/tests/upgrade/verify_after_upgrade.py
+++ b/tests/upgrade/verify_after_upgrade.py
@@ -137,6 +137,44 @@ def test_verify_moments_exist():
         print(f"Moments not available (skipping verification): {e}")
 
 
+def test_verify_mood_group_links_and_moment_moods():
+    """Verify mood-group links and moment mood references survived upgrade."""
+    print("\n=== Verifying mood group links and moment mood references ===")
+
+    token = login(TEST_EMAIL, TEST_PASSWORD)
+
+    moods_response = http_get("/moods/", token)
+    assert moods_response.status_code == 200, f"/moods failed: {moods_response.status_code}"
+    moods = moods_response.json()
+    mood_ids = {m["id"] for m in moods if m.get("id")}
+    assert mood_ids, "Expected at least one mood after upgrade"
+
+    groups_response = http_get("/moods/groups", token)
+    assert groups_response.status_code == 200, f"/moods/groups failed: {groups_response.status_code}"
+    groups = groups_response.json()
+    core_group = next(
+        (g for g in groups if str(g.get("name", "")).strip().lower() == "daily moods"),
+        None,
+    )
+    if core_group is None and len(groups) == 1:
+        core_group = groups[0]
+    assert core_group is not None, "Core mood group missing after upgrade"
+    core_group_moods = core_group.get("moods") or []
+    assert core_group_moods, "Core mood group has no linked moods after upgrade"
+    for mood in core_group_moods:
+        assert mood.get("id") in mood_ids, f"Core group linked unknown mood ID: {mood.get('id')}"
+
+    moments = get_moments(token)
+    moments_with_primary_mood = [m for m in moments if m.get("primary_mood_id")]
+    if moments_with_primary_mood:
+        missing = [
+            m["id"]
+            for m in moments_with_primary_mood
+            if m.get("primary_mood_id") not in mood_ids
+        ]
+        assert not missing, f"Moment primary_mood_id points to missing mood IDs: {missing}"
+
+
 def test_verify_user_settings_readable():
     """Verify user settings are still readable."""
     print("\n=== Verifying user settings ===")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a SQLite-only database migration to normalize UUID-like text across mood-related records and ensure core mood-group links are created after upgrade (downgrade is non‑reversible).
* **Tests**
  * Added a post-upgrade verification test to confirm mood groups, links, and moment primary-mood references are present and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->