### PR TITLE
fix: handle daylio daily goal with bitmask 127

### DIFF
--- a/app/data_transfer/daylio/mappers.py
+++ b/app/data_transfer/daylio/mappers.py
@@ -307,9 +307,10 @@ class DaylioToJournivMapper:
                 reminder_time = f"{goal.reminder_hour:02d}:{goal.reminder_minute:02d}"
 
             frequency = GoalFrequency.DAILY
-            target = goal.repeat_value or 1
+            target = 1
             if goal.repeat_type == 2:
                 frequency = GoalFrequency.WEEKLY
+                target = goal.repeat_value or 1
             elif goal.repeat_type == 1:
                 frequency = GoalFrequency.DAILY
 

--- a/tests/integration/test_daylio_import_e2e.py
+++ b/tests/integration/test_daylio_import_e2e.py
@@ -5,6 +5,7 @@ End-to-end integration tests for Daylio import using real fixture exports.
 from __future__ import annotations
 
 import base64
+from collections import Counter
 import json
 import zipfile
 from datetime import datetime, timezone
@@ -123,12 +124,15 @@ def test_daylio_import_from_real_fixture_file(
     expected_asset_refs = sum(len(entry.get("assets") or []) for entry in day_entries)
     mapper_ctx = DaylioToJournivMapper._build_context(backup_model)
     mapper_import_timestamp = datetime.now(tz=timezone.utc)
-    expected_goals = len(
-        DaylioToJournivMapper._map_goals(
-            backup_model,
-            mapper_import_timestamp,
-            mapper_ctx,
-        )
+    expected_goal_dtos = DaylioToJournivMapper._map_goals(
+        backup_model,
+        mapper_import_timestamp,
+        mapper_ctx,
+    )
+    expected_goals = len(expected_goal_dtos)
+    expected_goal_frequency_target_pairs = Counter(
+        (goal.frequency_type.value, goal.target_count)
+        for goal in expected_goal_dtos
     )
     expected_goal_logs = len(
         DaylioToJournivMapper._merge_goal_logs(
@@ -151,6 +155,7 @@ def test_daylio_import_from_real_fixture_file(
         if log.moment_external_id
     )
     pre_import_goals = api_client.list_goals(api_user.access_token)
+    pre_import_goal_ids = {goal["id"] for goal in pre_import_goals}
     pre_import_total_goal_logs = _total_goal_logs(
         api_client,
         api_user.access_token,
@@ -208,6 +213,15 @@ def test_daylio_import_from_real_fixture_file(
     assert len(entries) == expected_entries
 
     post_import_goals = api_client.list_goals(api_user.access_token)
+    imported_goals = [goal for goal in post_import_goals if goal["id"] not in pre_import_goal_ids]
+    imported_goal_frequency_target_pairs = Counter(
+        (goal.get("frequency_type"), goal.get("target_count"))
+        for goal in imported_goals
+    )
+
+    assert len(imported_goals) == expected_goals
+    assert imported_goal_frequency_target_pairs == expected_goal_frequency_target_pairs
+
     post_import_total_goal_logs = _total_goal_logs(
         api_client,
         api_user.access_token,

--- a/tests/unit/data_transfer/test_daylio_goal_history_mapping.py
+++ b/tests/unit/data_transfer/test_daylio_goal_history_mapping.py
@@ -4,9 +4,11 @@ from app.data_transfer.daylio.mappers import DaylioToJournivMapper
 from app.data_transfer.daylio.models import (
     DaylioBackup,
     DaylioDayEntry,
+    DaylioGoal,
     DaylioGoalEntry,
     DaylioGoalSuccessWeek,
 )
+from app.models.enums import GoalFrequency
 
 
 def test_map_goal_success_weeks_to_weekly_goal_logs():
@@ -159,3 +161,55 @@ def test_map_goal_success_weeks_handles_month_one_day_thirty_without_fallback():
 
     assert len(logs) == 1
     assert logs[0].created_at == datetime(2022, 1, 30, tzinfo=timezone.utc)
+
+
+def test_map_goals_uses_unit_target_for_daily_repeat_bitmask():
+    backup = DaylioBackup(
+        version=19,
+        goals=[
+            DaylioGoal(
+                goal_id=1,
+                name="short exercise",
+                repeat_type=1,
+                repeat_value=127,  # Daylio daily schedule bitmask (all days of the week selected)
+            ),
+        ],
+    )
+    import_timestamp = datetime(2026, 2, 20, tzinfo=timezone.utc)
+    ctx = DaylioToJournivMapper._build_context(backup)
+
+    goals = DaylioToJournivMapper._map_goals(
+        backup,
+        import_timestamp=import_timestamp,
+        ctx=ctx,
+    )
+
+    assert len(goals) == 1
+    assert goals[0].frequency_type == GoalFrequency.DAILY
+    assert goals[0].target_count == 1
+
+
+def test_map_goals_uses_repeat_value_for_weekly_target():
+    backup = DaylioBackup(
+        version=19,
+        goals=[
+            DaylioGoal(
+                goal_id=2,
+                name="Journal 3 days this week",
+                repeat_type=2,
+                repeat_value=3,
+            ),
+        ],
+    )
+    import_timestamp = datetime(2026, 2, 20, tzinfo=timezone.utc)
+    ctx = DaylioToJournivMapper._build_context(backup)
+
+    goals = DaylioToJournivMapper._map_goals(
+        backup,
+        import_timestamp=import_timestamp,
+        ctx=ctx,
+    )
+
+    assert len(goals) == 1
+    assert goals[0].frequency_type == GoalFrequency.WEEKLY
+    assert goals[0].target_count == 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed goal target calculation during Daylio import: daily goals now correctly set target to 1, while weekly goals preserve their configured repeat values.

* **Tests**
  * Added unit and integration tests to validate goal import behavior and frequency target calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->