### PR TITLE
fix: add archive goal support and plumb with daylio imports

### DIFF
--- a/app/api/v1/endpoints/goals.py
+++ b/app/api/v1/endpoints/goals.py
@@ -4,7 +4,7 @@ Goal endpoints.
 import uuid
 from typing import Annotated, List
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import ValidationError as PydanticValidationError
 from sqlmodel import Session
 
@@ -149,8 +149,8 @@ async def update_goal(
         ) from exc
 
 
-@router.delete(
-    "/{goal_id}",
+@router.patch(
+    "/{goal_id}/archive",
     response_model=GoalResponse,
     responses={
         401: {"description": "Not authenticated"},
@@ -173,6 +173,61 @@ async def archive_goal(
         raise HTTPException(
             status_code=500,
             detail="An error occurred while archiving goal",
+        ) from exc
+
+
+@router.post(
+    "/{goal_id}/unarchive",
+    response_model=GoalResponse,
+    responses={
+        401: {"description": "Not authenticated"},
+        403: {"description": "Account inactive"},
+        404: {"description": "Goal not found"},
+    },
+)
+async def unarchive_goal(
+    goal_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_current_user)],
+    session: Annotated[Session, Depends(get_session)],
+):
+    goal_service = GoalService(session)
+    try:
+        return goal_service.unarchive_goal(goal_id, current_user.id)
+    except GoalNotFoundError:
+        raise HTTPException(status_code=404, detail="Goal not found") from None
+    except Exception as exc:
+        log_error(exc, request_id=None, user_id=current_user.id)
+        raise HTTPException(
+            status_code=500,
+            detail="An error occurred while unarchiving goal",
+        ) from exc
+
+
+@router.delete(
+    "/{goal_id}",
+    status_code=204,
+    responses={
+        401: {"description": "Not authenticated"},
+        403: {"description": "Account inactive"},
+        404: {"description": "Goal not found"},
+    },
+)
+async def delete_goal_permanently(
+    goal_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_current_user)],
+    session: Annotated[Session, Depends(get_session)],
+):
+    goal_service = GoalService(session)
+    try:
+        goal_service.delete_goal_permanently(goal_id, current_user.id)
+        return Response(status_code=204)
+    except GoalNotFoundError:
+        raise HTTPException(status_code=404, detail="Goal not found") from None
+    except Exception as exc:
+        log_error(exc, request_id=None, user_id=current_user.id)
+        raise HTTPException(
+            status_code=500,
+            detail="An error occurred while deleting goal",
         ) from exc
 
 

--- a/app/data_transfer/daylio/mappers.py
+++ b/app/data_transfer/daylio/mappers.py
@@ -35,6 +35,7 @@ from .html_to_delta import html_to_delta
 from .models import (
     DaylioBackup,
     DaylioDayEntry,
+    DaylioGoal,
 )
 
 _PREDEFINED_MOOD_NAMES = {
@@ -313,6 +314,11 @@ class DaylioToJournivMapper:
                 target = goal.repeat_value or 1
             elif goal.repeat_type == 1:
                 frequency = GoalFrequency.DAILY
+            archived_at = DaylioToJournivMapper._resolve_goal_archived_at(
+                goal=goal,
+                import_timestamp=import_timestamp,
+            )
+            is_archived = archived_at is not None
 
             goals.append(
                 GoalDTO(
@@ -321,11 +327,11 @@ class DaylioToJournivMapper:
                     frequency_type=frequency,
                     target_count=target,
                     reminder_time=reminder_time,
-                    is_paused=(goal.state or 0) != 0,
+                    is_paused=(goal.state or 0) != 0 and not is_archived,
                     icon=str(goal.id_icon) if goal.id_icon is not None else None,
                     color_value=None,
                     position=goal.order_number or goal.order or 0,
-                    archived_at=None,
+                    archived_at=archived_at,
                     activity_external_id=str(goal.id_tag) if goal.id_tag else None,
                     category_external_id=None,
                     created_at=_ms_to_utc(goal.created_at) or import_timestamp,
@@ -334,6 +340,19 @@ class DaylioToJournivMapper:
                 )
             )
         return goals
+
+    @staticmethod
+    def _resolve_goal_archived_at(
+        *,
+        goal: DaylioGoal,
+        import_timestamp: datetime,
+    ) -> Optional[datetime]:
+        end_date_utc = _ms_to_utc(goal.end_date) if goal.end_date and goal.end_date > 0 else None
+        if end_date_utc is not None:
+            return end_date_utc
+        if (goal.state or 0) == 1:
+            return import_timestamp
+        return None
 
     @staticmethod
     def _map_goal_logs(backup: DaylioBackup, import_timestamp: datetime) -> List[GoalLogDTO]:

--- a/app/data_transfer/daylio/models.py
+++ b/app/data_transfer/daylio/models.py
@@ -79,6 +79,7 @@ class DaylioGoal(DaylioBaseModel):
     repeat_type: Optional[int] = None
     repeat_value: Optional[int] = None
     state: Optional[int] = None
+    end_date: Optional[int] = None
     created_at: Optional[int] = None
     is_displayed_in_reports: Optional[bool] = None
 

--- a/app/services/goal_service.py
+++ b/app/services/goal_service.py
@@ -517,12 +517,40 @@ class GoalService:
     def archive_goal(self, goal_id: uuid.UUID, user_id: uuid.UUID) -> Goal:
         goal = self.get_goal(goal_id, user_id)
         if goal.archived_at is None:
-            goal.archived_at = utc_now()
-            goal.updated_at = utc_now()
+            now = utc_now()
+            goal.archived_at = now
+            goal.updated_at = now
             self.session.add(goal)
             self._commit()
             self.session.refresh(goal)
+            log_info(f"Goal archived for user {user_id}: {goal.id}")
         return goal
+
+    def unarchive_goal(self, goal_id: uuid.UUID, user_id: uuid.UUID) -> Goal:
+        goal = self.get_goal(goal_id, user_id)
+        if goal.archived_at is not None:
+            now = utc_now()
+            goal.archived_at = None
+            goal.updated_at = now
+            self.session.add(goal)
+            self._commit()
+            self.session.refresh(goal)
+            log_info(f"Goal unarchived for user {user_id}: {goal.id}")
+        return goal
+
+    def delete_goal_permanently(self, goal_id: uuid.UUID, user_id: uuid.UUID) -> None:
+        goal = self.get_goal(goal_id, user_id)
+        # Keep deletion behavior deterministic across engines by explicitly
+        # removing dependent logs before deleting the goal row.
+        self.session.exec(
+            delete(GoalLog).where(col(GoalLog.goal_id) == goal.id)
+        )
+        self.session.exec(
+            delete(GoalManualLog).where(col(GoalManualLog.goal_id) == goal.id)
+        )
+        self.session.delete(goal)
+        self._commit()
+        log_info(f"Goal permanently deleted for user {user_id}: {goal_id}")
 
     def toggle_goal_completion(
         self,

--- a/tests/integration/test_daylio_import_e2e.py
+++ b/tests/integration/test_daylio_import_e2e.py
@@ -5,9 +5,9 @@ End-to-end integration tests for Daylio import using real fixture exports.
 from __future__ import annotations
 
 import base64
-from collections import Counter
 import json
 import zipfile
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -130,6 +130,8 @@ def test_daylio_import_from_real_fixture_file(
         mapper_ctx,
     )
     expected_goals = len(expected_goal_dtos)
+    expected_archived_goals = sum(1 for goal in expected_goal_dtos if goal.archived_at is not None)
+    expected_active_goals = expected_goals - expected_archived_goals
     expected_goal_frequency_target_pairs = Counter(
         (goal.frequency_type.value, goal.target_count)
         for goal in expected_goal_dtos
@@ -154,7 +156,7 @@ def test_daylio_import_from_real_fixture_file(
         )
         if log.moment_external_id
     )
-    pre_import_goals = api_client.list_goals(api_user.access_token)
+    pre_import_goals = api_client.list_goals(api_user.access_token, include_archived=True)
     pre_import_goal_ids = {goal["id"] for goal in pre_import_goals}
     pre_import_total_goal_logs = _total_goal_logs(
         api_client,
@@ -212,15 +214,20 @@ def test_daylio_import_from_real_fixture_file(
     entries = api_client.list_entries(api_user.access_token)
     assert len(entries) == expected_entries
 
-    post_import_goals = api_client.list_goals(api_user.access_token)
+    post_import_active_goals = api_client.list_goals(api_user.access_token)
+    post_import_goals = api_client.list_goals(api_user.access_token, include_archived=True)
     imported_goals = [goal for goal in post_import_goals if goal["id"] not in pre_import_goal_ids]
+    imported_active_goals = [goal for goal in imported_goals if goal.get("archived_at") is None]
     imported_goal_frequency_target_pairs = Counter(
         (goal.get("frequency_type"), goal.get("target_count"))
         for goal in imported_goals
     )
 
     assert len(imported_goals) == expected_goals
+    assert len(imported_active_goals) == expected_active_goals
+    assert sum(1 for goal in imported_goals if goal.get("archived_at") is not None) == expected_archived_goals
     assert imported_goal_frequency_target_pairs == expected_goal_frequency_target_pairs
+    imported_archived_goal_ids = {goal["id"] for goal in imported_goals if goal.get("archived_at") is not None}
 
     post_import_total_goal_logs = _total_goal_logs(
         api_client,
@@ -234,6 +241,7 @@ def test_daylio_import_from_real_fixture_file(
         imported_goal_logs.extend(api_client.list_goal_logs(api_user.access_token, goal["id"], limit=365))
     linked_goal_logs = [log for log in imported_goal_logs if log.get("moment_id") is not None]
     assert len(linked_goal_logs) >= expected_linked_goal_logs
+    assert all(goal["id"] not in imported_archived_goal_ids for goal in post_import_active_goals)
 
     moments = api_client.list_moments(api_user.access_token, limit=200)
     assert len(moments) == expected_moments

--- a/tests/integration/test_goal_endpoints.py
+++ b/tests/integration/test_goal_endpoints.py
@@ -1,0 +1,84 @@
+"""
+Goal API integration coverage.
+"""
+
+from tests.integration.helpers import UNKNOWN_UUID, EndpointCase, assert_not_found
+from tests.lib import ApiUser, JournivApiClient
+
+
+def test_archiving_controls_visibility_and_unarchive(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+) -> None:
+    active_goal = api_client.create_goal(
+        api_user.access_token,
+        title="Active goal",
+        goal_type="achieve",
+        frequency_type="daily",
+        target_count=1,
+    )
+    archived_goal = api_client.create_goal(
+        api_user.access_token,
+        title="Archived goal",
+        goal_type="achieve",
+        frequency_type="daily",
+        target_count=1,
+    )
+
+    archive_response = api_client.archive_goal(
+        api_user.access_token,
+        archived_goal["id"],
+    )
+    assert archive_response.get("archived_at") is not None
+
+    active_only = api_client.list_goals(api_user.access_token)
+    assert any(goal["id"] == active_goal["id"] for goal in active_only)
+    assert all(goal["id"] != archived_goal["id"] for goal in active_only)
+
+    with_archived = api_client.list_goals(api_user.access_token, include_archived=True)
+    matching_archived = [goal for goal in with_archived if goal["id"] == archived_goal["id"]]
+    assert len(matching_archived) == 1
+    assert matching_archived[0].get("archived_at") is not None
+
+    unarchived = api_client.unarchive_goal(api_user.access_token, archived_goal["id"])
+    assert unarchived.get("archived_at") is None
+
+    refreshed = api_client.list_goals(api_user.access_token)
+    assert any(goal["id"] == archived_goal["id"] for goal in refreshed)
+
+
+def test_goal_unarchive_not_found(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+) -> None:
+    assert_not_found(
+        api_client,
+        api_user.access_token,
+        [
+            EndpointCase("POST", f"/goals/{UNKNOWN_UUID}/unarchive"),
+            EndpointCase("DELETE", f"/goals/{UNKNOWN_UUID}"),
+            EndpointCase("PATCH", f"/goals/{UNKNOWN_UUID}/archive"),
+        ],
+    )
+
+
+def test_goal_permanent_delete_removes_archived_goal(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+) -> None:
+    goal = api_client.create_goal(
+        api_user.access_token,
+        title="Delete me",
+        goal_type="achieve",
+        frequency_type="daily",
+        target_count=1,
+    )
+    api_client.archive_goal(api_user.access_token, goal["id"])
+
+    api_client.delete_goal_permanently(api_user.access_token, goal["id"])
+
+    goals_with_archived = api_client.list_goals(
+        api_user.access_token,
+        include_archived=True,
+    )
+    assert all(item["id"] != goal["id"] for item in goals_with_archived)

--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -917,6 +917,30 @@ class JournivApiClient:
             expected=(200,),
         ).json()
 
+    def archive_goal(self, token: str, goal_id: str) -> Dict[str, Any]:
+        return self.request(
+            "PATCH",
+            f"/goals/{goal_id}/archive",
+            token=token,
+            expected=(200,),
+        ).json()
+
+    def unarchive_goal(self, token: str, goal_id: str) -> Dict[str, Any]:
+        return self.request(
+            "POST",
+            f"/goals/{goal_id}/unarchive",
+            token=token,
+            expected=(200,),
+        ).json()
+
+    def delete_goal_permanently(self, token: str, goal_id: str) -> None:
+        self.request(
+            "DELETE",
+            f"/goals/{goal_id}",
+            token=token,
+            expected=(204,),
+        )
+
     def list_goal_logs(
         self,
         token: str,

--- a/tests/unit/data_transfer/test_daylio_goal_history_mapping.py
+++ b/tests/unit/data_transfer/test_daylio_goal_history_mapping.py
@@ -213,3 +213,89 @@ def test_map_goals_uses_repeat_value_for_weekly_target():
     assert len(goals) == 1
     assert goals[0].frequency_type == GoalFrequency.WEEKLY
     assert goals[0].target_count == 3
+
+
+def test_map_goals_marks_daylio_archived_goal_with_archived_at():
+    end_date_ms = 1772036346918
+    backup = DaylioBackup(
+        version=19,
+        goals=[
+            DaylioGoal(
+                goal_id=3,
+                name="Archived goal",
+                repeat_type=1,
+                repeat_value=127,
+                state=1,
+                end_date=end_date_ms,
+            ),
+        ],
+    )
+    import_timestamp = datetime(2026, 2, 20, tzinfo=timezone.utc)
+    ctx = DaylioToJournivMapper._build_context(backup)
+
+    goals = DaylioToJournivMapper._map_goals(
+        backup,
+        import_timestamp=import_timestamp,
+        ctx=ctx,
+    )
+
+    assert len(goals) == 1
+    assert goals[0].archived_at == datetime.fromtimestamp(end_date_ms / 1000, tz=timezone.utc)
+    assert goals[0].is_paused is False
+
+
+def test_map_goals_archives_from_state_when_end_date_missing():
+    backup = DaylioBackup(
+        version=19,
+        goals=[
+            DaylioGoal(
+                goal_id=4,
+                name="Archived from state",
+                repeat_type=1,
+                repeat_value=127,
+                state=1,
+                end_date=-1,
+            ),
+        ],
+    )
+    import_timestamp = datetime(2026, 2, 20, tzinfo=timezone.utc)
+    ctx = DaylioToJournivMapper._build_context(backup)
+
+    goals = DaylioToJournivMapper._map_goals(
+        backup,
+        import_timestamp=import_timestamp,
+        ctx=ctx,
+    )
+
+    assert len(goals) == 1
+    assert goals[0].archived_at == import_timestamp
+    assert goals[0].is_paused is False
+
+
+def test_map_goals_archives_from_end_date_even_when_state_active():
+    end_date_ms = 1772036346918
+    backup = DaylioBackup(
+        version=19,
+        goals=[
+            DaylioGoal(
+                goal_id=5,
+                name="Archived from end date",
+                repeat_type=1,
+                repeat_value=127,
+                state=0,
+                end_date=end_date_ms,
+            ),
+        ],
+    )
+    import_timestamp = datetime(2026, 2, 20, tzinfo=timezone.utc)
+    ctx = DaylioToJournivMapper._build_context(backup)
+
+    goals = DaylioToJournivMapper._map_goals(
+        backup,
+        import_timestamp=import_timestamp,
+        ctx=ctx,
+    )
+
+    assert len(goals) == 1
+    assert goals[0].archived_at == datetime.fromtimestamp(end_date_ms / 1000, tz=timezone.utc)
+    assert goals[0].is_paused is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Goals can now be archived and unarchived separately, preserving associated data without permanent deletion.
  * Permanently delete goals when needed with a dedicated delete action.
  * Filter goal lists by archived status with a new option.
  * Daylio imports now properly recognize and preserve goal archival information from import sources.

* **Tests**
  * Added tests validating goal archival, unarchival, and permanent deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->