### PR TITLE
fix: harden Day One datetime handling and make integration timestamps…

### DIFF
--- a/alembic/versions/f3b4c5d6e7f8_make_integration_timestamps_timezone_aware.py
+++ b/alembic/versions/f3b4c5d6e7f8_make_integration_timestamps_timezone_aware.py
@@ -1,0 +1,142 @@
+"""make integration timestamps timezone aware
+
+Revision ID: f3b4c5d6e7f8
+Revises: e5f6a7b8c9d0, 3a7b1c2d4e5f
+Create Date: 2026-02-26 10:15:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3b4c5d6e7f8"
+down_revision: Union[str, Sequence[str], None] = ("e5f6a7b8c9d0", "3a7b1c2d4e5f")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _to_timestamptz(column_name: str, nullable: bool) -> None:
+    op.alter_column(
+        "integration",
+        column_name,
+        existing_type=sa.DateTime(),
+        type_=sa.DateTime(timezone=True),
+        existing_nullable=nullable,
+        postgresql_using=f"{column_name} AT TIME ZONE 'UTC'",
+    )
+
+
+def _to_timestamp(column_name: str, nullable: bool) -> None:
+    op.alter_column(
+        "integration",
+        column_name,
+        existing_type=sa.DateTime(timezone=True),
+        type_=sa.DateTime(),
+        existing_nullable=nullable,
+        postgresql_using=f"{column_name} AT TIME ZONE 'UTC'",
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        _to_timestamptz("created_at", nullable=False)
+        _to_timestamptz("updated_at", nullable=False)
+        _to_timestamptz("token_expires_at", nullable=True)
+        _to_timestamptz("last_synced_at", nullable=True)
+        _to_timestamptz("last_error_at", nullable=True)
+        _to_timestamptz("connected_at", nullable=False)
+        return
+
+    with op.batch_alter_table("integration") as batch_op:
+        batch_op.alter_column(
+            "created_at",
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "updated_at",
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "token_expires_at",
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "last_synced_at",
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "last_error_at",
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "connected_at",
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        _to_timestamp("created_at", nullable=False)
+        _to_timestamp("updated_at", nullable=False)
+        _to_timestamp("token_expires_at", nullable=True)
+        _to_timestamp("last_synced_at", nullable=True)
+        _to_timestamp("last_error_at", nullable=True)
+        _to_timestamp("connected_at", nullable=False)
+        return
+
+    with op.batch_alter_table("integration") as batch_op:
+        batch_op.alter_column(
+            "created_at",
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "updated_at",
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "token_expires_at",
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "last_synced_at",
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "last_error_at",
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "connected_at",
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=False,
+        )

--- a/app/data_transfer/dayone/mappers.py
+++ b/app/data_transfer/dayone/mappers.py
@@ -304,7 +304,18 @@ class DayOneToJournivMapper:
             dayone_entry.modified_date or dayone_entry.creation_date
         )
         entry_timezone = normalize_timezone(dayone_entry.time_zone)
-        entry_date = local_date_for_user(creation_date_utc, entry_timezone)
+        try:
+            entry_date = local_date_for_user(creation_date_utc, entry_timezone)
+        except (OverflowError, ValueError) as exc:
+            log_warning(
+                "Failed to derive local date from Day One entry timestamp; falling back to UTC date",
+                entry_id=dayone_entry.uuid,
+                timezone=entry_timezone,
+                creation_date=str(creation_date_utc),
+                error=str(exc),
+            )
+            entry_timezone = "UTC"
+            entry_date = creation_date_utc.date()
 
         location_json = None
         latitude = None

--- a/app/data_transfer/dayone/models.py
+++ b/app/data_transfer/dayone/models.py
@@ -6,10 +6,69 @@ Day One export format documentation:
 https://dayoneapp.com/guides/tips-and-tutorials/exporting-entries/
 """
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
+
+_EPOCH_MS_THRESHOLD = 1_000_000_000_000  # ~2001 in milliseconds
+_EPOCH_US_THRESHOLD = 1_000_000_000_000_000  # ~2001 in microseconds
+_EPOCH_NS_THRESHOLD = 1_000_000_000_000_000_000  # ~2001 in nanoseconds
+_MIN_IMPORT_DATETIME_UTC = datetime(1900, 1, 1, tzinfo=timezone.utc)
+_MAX_IMPORT_DATETIME_UTC = datetime(9998, 12, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+
+def _parse_dayone_datetime(value: Any) -> Any:
+    """Normalize Day One datetime payloads before Pydantic coercion."""
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid datetime value type: {type(value).__name__}")
+
+    numeric_value: float | None = None
+    if isinstance(value, (int, float)):
+        numeric_value = float(value)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return value
+        try:
+            numeric_value = float(stripped)
+        except ValueError:
+            return value
+    else:
+        return value
+
+    if not math.isfinite(numeric_value):
+        raise ValueError(f"Invalid non-finite datetime value: {value}")
+
+    epoch_seconds = numeric_value
+    abs_value = abs(numeric_value)
+    if abs_value >= _EPOCH_NS_THRESHOLD:
+        epoch_seconds = numeric_value / 1_000_000_000
+    elif abs_value >= _EPOCH_US_THRESHOLD:
+        epoch_seconds = numeric_value / 1_000_000
+    elif abs_value >= _EPOCH_MS_THRESHOLD:
+        epoch_seconds = numeric_value / 1_000
+
+    try:
+        return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError) as exc:
+        raise ValueError(f"Invalid epoch datetime value: {value}") from exc
+
+
+def _validate_dayone_datetime_range(dt: datetime, field_name: str) -> datetime:
+    if dt.tzinfo is None:
+        dt_utc = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt_utc = dt.astimezone(timezone.utc)
+
+    if dt_utc < _MIN_IMPORT_DATETIME_UTC or dt_utc > _MAX_IMPORT_DATETIME_UTC:
+        raise ValueError(
+            f"{field_name} out of supported range: {dt_utc.isoformat()} "
+            f"(expected {_MIN_IMPORT_DATETIME_UTC.isoformat()}..{_MAX_IMPORT_DATETIME_UTC.isoformat()})"
+        )
+    return dt_utc
 
 
 class DayOneLocation(BaseModel):
@@ -98,6 +157,18 @@ class DayOnePhoto(BaseModel):
             raise ValueError("MD5 must be a valid hex string")
         return v.lower() if v else v
 
+    @field_validator("date", mode="before")
+    @classmethod
+    def normalize_date(cls, v: Optional[Any]) -> Optional[Any]:
+        return _parse_dayone_datetime(v)
+
+    @field_validator("date")
+    @classmethod
+    def validate_date_range(cls, v: Optional[datetime]) -> Optional[datetime]:
+        if v is None:
+            return v
+        return _validate_dayone_datetime_range(v, "photo.date")
+
     class Config:
         populate_by_name = True
         extra = "allow"
@@ -124,6 +195,18 @@ class DayOneVideo(BaseModel):
         if v is not None and not all(c in '0123456789abcdefABCDEF' for c in v):
             raise ValueError("MD5 must be a valid hex string")
         return v.lower() if v else v
+
+    @field_validator("date", mode="before")
+    @classmethod
+    def normalize_date(cls, v: Optional[Any]) -> Optional[Any]:
+        return _parse_dayone_datetime(v)
+
+    @field_validator("date")
+    @classmethod
+    def validate_date_range(cls, v: Optional[datetime]) -> Optional[datetime]:
+        if v is None:
+            return v
+        return _validate_dayone_datetime_range(v, "video.date")
 
     class Config:
         populate_by_name = True
@@ -179,6 +262,18 @@ class DayOneEntry(BaseModel):
                 if cleaned:
                     validated.append(cleaned)
         return validated
+
+    @field_validator("creation_date", "modified_date", mode="before")
+    @classmethod
+    def normalize_entry_datetimes(cls, v: Optional[Any]) -> Optional[Any]:
+        return _parse_dayone_datetime(v)
+
+    @field_validator("creation_date", "modified_date")
+    @classmethod
+    def validate_entry_datetime_range(cls, v: Optional[datetime], info) -> Optional[datetime]:
+        if v is None:
+            return v
+        return _validate_dayone_datetime_range(v, info.field_name)
 
     class Config:
         populate_by_name = True

--- a/app/integrations/service.py
+++ b/app/integrations/service.py
@@ -521,6 +521,8 @@ async def sync_integration(
         log_info(f"Skipping sync for inactive {provider} integration (user {user.id})")
         return
 
+    integration_id = integration.id
+
     # Delegate to provider module
     provider_module = get_provider_module(provider)
     try:
@@ -537,14 +539,31 @@ async def sync_integration(
         session.add(integration)
         await _commit(session)
 
-        log_info(f"Synced {provider} for user {user.id} (integration {integration.id})")
+        log_info(f"Synced {provider} for user {user.id} (integration {integration_id})")
     except Exception as e:
-        log_error(e, user_id=user.id)
-        # Update error tracking
-        integration.last_error = str(e)
-        integration.last_error_at = utc_now()
-        session.add(integration)
-        await _commit(session)
+        log_error(e, user_id=user.id, integration_id=integration_id, provider=provider)
+        await _rollback(session)
+
+        # Update error tracking using a fresh instance after rollback.
+        try:
+            integration_to_update = (await _exec(
+                session,
+                select(Integration).where(Integration.id == integration_id)
+            )).first()
+            if integration_to_update:
+                integration_to_update.last_error = str(e)
+                integration_to_update.last_error_at = utc_now()
+                session.add(integration_to_update)
+                await _commit(session)
+        except Exception as persist_error:
+            await _rollback(session)
+            log_error(
+                persist_error,
+                user_id=user.id,
+                provider=provider,
+                integration_id=integration_id,
+                message="Failed to persist integration sync error state",
+            )
         raise
 
 
@@ -555,38 +574,39 @@ async def sync_all_integrations(session: Session | AsyncSession) -> None:
     This function is called by scheduled background tasks (e.g., every 6 hours).
     It iterates through all active integrations and syncs them.
     """
-    integrations = (await _exec(
+    integration_rows = (await _exec(
         session,
-        select(Integration)
+        select(Integration.id, Integration.user_id, Integration.provider)
         .where(Integration.is_active)
     )).all()
 
-    log_info(f"Starting batch sync for {len(integrations)} active integrations")
+    log_info(f"Starting batch sync for {len(integration_rows)} active integrations")
 
-    for integration in integrations:
+    for integration_id, integration_user_id, integration_provider in integration_rows:
         try:
             # Get user (needed by provider modules)
             user = (await _exec(
                 session,
-                select(User).where(User.id == integration.user_id)
+                select(User).where(User.id == integration_user_id)
             )).first()
 
             if not user:
-                log_warning(f"User {integration.user_id} not found for integration {integration.id}")
+                log_warning(f"User {integration_user_id} not found for integration {integration_id}")
                 continue
 
-            await sync_integration(session, user, integration.provider)
+            await sync_integration(session, user, integration_provider)
         except Exception as e:
+            await _rollback(session)
             log_error(
                 e,
-                integration_id=integration.id,
-                provider=integration.provider,
-                user_id=integration.user_id
+                integration_id=integration_id,
+                provider=integration_provider,
+                user_id=integration_user_id
             )
             # Continue with next integration (don't stop the batch)
             continue
 
-    log_info(f"Completed batch sync for {len(integrations)} integrations")
+    log_info(f"Completed batch sync for {len(integration_rows)} integrations")
 
 
 async def update_integration_settings(

--- a/app/models/activity.py
+++ b/app/models/activity.py
@@ -48,7 +48,8 @@ class Activity(BaseModel, table=True):
     # Relations
     user: "User" = Relationship(back_populates="activities")
     moment_activity_links: List["MomentMoodActivity"] = Relationship(
-        back_populates="activity"
+        back_populates="activity",
+        sa_relationship_kwargs={"passive_deletes": True},
     )
     group: Optional["ActivityGroup"] = Relationship(back_populates="activities")
     goals: List["Goal"] = Relationship(back_populates="activity")

--- a/app/models/integration.py
+++ b/app/models/integration.py
@@ -19,7 +19,15 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from sqlalchemy import Column, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlmodel import Field, Index, Relationship
 
 from app.models.base import BaseModel
@@ -91,6 +99,17 @@ class Integration(BaseModel, table=True):
     """
     __tablename__ = "integration"
 
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+        description="UTC timestamp when this record was created",
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False, onupdate=func.now()),
+        description="UTC timestamp when this record was last updated",
+    )
+
     user_id: uuid.UUID = Field(
         sa_column=Column(
             ForeignKey("user.id", ondelete="CASCADE"),
@@ -123,6 +142,7 @@ class Integration(BaseModel, table=True):
 
     token_expires_at: Optional[datetime] = Field(
         default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
         description="Token expiration time (future use for OAuth)"
     )
 
@@ -135,6 +155,7 @@ class Integration(BaseModel, table=True):
     # Sync tracking
     last_synced_at: Optional[datetime] = Field(
         default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
         description="Last successful sync timestamp"
     )
 
@@ -146,6 +167,7 @@ class Integration(BaseModel, table=True):
 
     last_error_at: Optional[datetime] = Field(
         default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
         description="When the last error occurred"
     )
 
@@ -157,6 +179,7 @@ class Integration(BaseModel, table=True):
 
     connected_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
         description="When the user first connected this integration"
     )
 
@@ -213,4 +236,3 @@ class Integration(BaseModel, table=True):
         current = self.get_metadata()
         current.update(kwargs)
         self.set_metadata(current)
-

--- a/app/models/mood.py
+++ b/app/models/mood.py
@@ -45,7 +45,8 @@ class Mood(BaseModel, table=True):
 
     # Relations
     moment_activity_links: List["MomentMoodActivity"] = Relationship(
-        back_populates="mood"
+        back_populates="mood",
+        sa_relationship_kwargs={"passive_deletes": True},
     )
     user: Optional["User"] = Relationship(back_populates="moods")
     group_links: List["MoodGroupLink"] = Relationship(

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -948,7 +948,18 @@ class ImportService:
 
         logged_at_utc = moment_dto.logged_at_utc or utc_now()
         logged_timezone = normalize_timezone(moment_dto.logged_timezone)
-        logged_date_tz = local_date_for_user(logged_at_utc, logged_timezone)
+        try:
+            logged_date_tz = local_date_for_user(logged_at_utc, logged_timezone)
+        except (OverflowError, ValueError) as exc:
+            log_warning(
+                "Failed to derive moment local date; falling back to UTC date",
+                moment_external_id=moment_dto.external_id,
+                timezone=logged_timezone,
+                logged_at_utc=str(logged_at_utc),
+                error=str(exc),
+            )
+            logged_timezone = "UTC"
+            logged_date_tz = logged_at_utc.date()
 
         moment = Moment(
             user_id=user_id,

--- a/tests/unit/data_transfer/test_dayone_datetime_validation.py
+++ b/tests/unit/data_transfer/test_dayone_datetime_validation.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app.data_transfer.dayone.mappers import DayOneToJournivMapper
+from app.data_transfer.dayone.models import DayOneEntry
+
+
+def test_dayone_entry_accepts_epoch_milliseconds():
+    entry = DayOneEntry(
+        uuid="entry-epoch-ms",
+        creationDate=1_700_000_000_000,
+    )
+
+    assert entry.creation_date.tzinfo is not None
+    assert entry.creation_date.year == 2023
+
+
+def test_dayone_entry_rejects_out_of_range_datetime():
+    with pytest.raises(ValueError, match="out of supported range"):
+        DayOneEntry(
+            uuid="entry-out-of-range",
+            creationDate="0001-01-01T00:00:00Z",
+        )
+
+
+def test_dayone_entry_rejects_boolean_datetime():
+    with pytest.raises(ValueError, match="Invalid datetime value type"):
+        DayOneEntry(
+            uuid="entry-bool-date",
+            creationDate=True,
+        )
+
+
+def test_dayone_entry_rejects_non_finite_epoch_datetime():
+    with pytest.raises(ValueError, match="Invalid non-finite datetime value"):
+        DayOneEntry(
+            uuid="entry-nan-date",
+            creationDate=float("nan"),
+        )
+
+
+def test_map_moment_falls_back_to_utc_date_on_local_date_error(monkeypatch):
+    entry = DayOneEntry(
+        uuid="entry-overflow-fallback",
+        creationDate=datetime(2026, 2, 25, 20, 44, 52, tzinfo=timezone.utc),
+        timeZone="America/New_York",
+    )
+
+    def _raise_overflow(*args, **kwargs):
+        raise OverflowError("date value out of range")
+
+    monkeypatch.setattr(
+        "app.data_transfer.dayone.mappers.local_date_for_user",
+        _raise_overflow,
+    )
+
+    moment = DayOneToJournivMapper.map_moment(entry)
+    assert moment.logged_timezone == "UTC"
+    assert moment.logged_date_tz == datetime(2026, 2, 25, tzinfo=timezone.utc).date()

--- a/tests/unit/integrations/test_integrations.py
+++ b/tests/unit/integrations/test_integrations.py
@@ -18,7 +18,9 @@ from app.integrations.schemas import (
     IntegrationConnectRequest,
     IntegrationStatusResponse,
 )
+from app.models.activity import Activity
 from app.models.integration import AssetType, Integration, IntegrationProvider
+from app.models.mood import Mood
 
 # ================================================================================
 # MODEL TESTS
@@ -51,6 +53,23 @@ class TestIntegrationModel:
         all_providers = list(IntegrationProvider)
         assert len(all_providers) >= 1
         assert IntegrationProvider.IMMICH in all_providers
+
+    def test_integration_datetime_columns_are_timezone_aware(self):
+        table = Integration.__table__
+        for column_name in (
+            "created_at",
+            "updated_at",
+            "token_expires_at",
+            "last_synced_at",
+            "last_error_at",
+            "connected_at",
+        ):
+            assert table.c[column_name].type.timezone is True
+        assert table.c["updated_at"].onupdate is not None
+
+    def test_mood_and_activity_links_use_passive_deletes(self):
+        assert Activity.__mapper__.relationships["moment_activity_links"].passive_deletes is True
+        assert Mood.__mapper__.relationships["moment_activity_links"].passive_deletes is True
 
 
 # ================================================================================

--- a/tests/unit/integrations/test_sync_error_handling.py
+++ b/tests/unit/integrations/test_sync_error_handling.py
@@ -1,0 +1,68 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.integrations.service import sync_integration
+from app.models.integration import IntegrationProvider
+
+
+class _Result:
+    def __init__(self, value):
+        self._value = value
+
+    def first(self):
+        return self._value
+
+    def all(self):
+        return self._value
+
+
+@pytest.mark.asyncio
+async def test_sync_integration_rolls_back_and_persists_error_state():
+    user = SimpleNamespace(id=uuid.uuid4())
+    integration = SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        provider=IntegrationProvider.IMMICH,
+        is_active=True,
+        last_error=None,
+        last_error_at=None,
+    )
+    refreshed_integration = SimpleNamespace(
+        id=integration.id,
+        user_id=user.id,
+        provider=IntegrationProvider.IMMICH,
+        is_active=True,
+        last_error=None,
+        last_error_at=None,
+    )
+
+    mock_session = MagicMock()
+    mock_provider = SimpleNamespace(sync=AsyncMock(side_effect=RuntimeError("provider failed")))
+
+    exec_mock = AsyncMock(
+        side_effect=[
+            _Result(integration),           # initial integration lookup
+            _Result(refreshed_integration),  # re-fetch after rollback
+        ]
+    )
+    rollback_mock = AsyncMock()
+    commit_mock = AsyncMock()
+
+    with patch("app.integrations.service._exec", exec_mock), \
+         patch("app.integrations.service._rollback", rollback_mock), \
+         patch("app.integrations.service._commit", commit_mock), \
+         patch("app.integrations.service.get_provider_module", return_value=mock_provider):
+        with pytest.raises(RuntimeError, match="provider failed"):
+            await sync_integration(
+                session=mock_session,
+                user=user,
+                provider=IntegrationProvider.IMMICH,
+            )
+
+    assert rollback_mock.await_count == 1
+    commit_mock.assert_awaited_once()
+    assert refreshed_integration.last_error == "provider failed"
+    assert refreshed_integration.last_error_at is not None


### PR DESCRIPTION
… timezone-aware #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integration timestamps are now timezone-aware system-wide.

* **Bug Fixes**
  * Imports now gracefully fall back to UTC when local date localization fails.
  * Sync error handling improved to persist last-error info and report failures reliably.

* **Improvements**
  * Enhanced Day One date parsing, normalization, and range validation for multiple formats.
  * Relationship delete behavior updated to use passive deletes for better integrity.

* **Tests**
  * Added tests for datetime validation and sync error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->