### PR TITLE
fix: improve backend logic fallback for memories

### DIFF
--- a/app/schemas/moment.py
+++ b/app/schemas/moment.py
@@ -129,12 +129,14 @@ class MomentPageResponse(BaseModel):
 class MemoriesFilter(str, Enum):
     auto = "auto"
     last_years = "last_years"
+    last_year = "last_year"
     last_month = "last_month"
     last_week = "last_week"
 
 
 class MemoriesAppliedFilter(str, Enum):
     last_years = "last_years"
+    last_year = "last_year"
     last_month = "last_month"
     last_week = "last_week"
 

--- a/app/services/moment_service.py
+++ b/app/services/moment_service.py
@@ -715,6 +715,8 @@ class MomentService:
     def _to_applied_filter(memories_filter: MemoriesFilter) -> MemoriesAppliedFilter:
         if memories_filter == MemoriesFilter.last_years:
             return MemoriesAppliedFilter.last_years
+        if memories_filter == MemoriesFilter.last_year:
+            return MemoriesAppliedFilter.last_year
         if memories_filter == MemoriesFilter.last_month:
             return MemoriesAppliedFilter.last_month
         return MemoriesAppliedFilter.last_week
@@ -725,6 +727,11 @@ class MomentService:
         previous_month_end = current_month_start - timedelta(days=1)
         previous_month_start = previous_month_end.replace(day=1)
         return previous_month_start, previous_month_end
+
+    @staticmethod
+    def _last_year_window(today_local: date) -> tuple[date, date]:
+        previous_year = today_local.year - 1
+        return date(previous_year, 1, 1), date(previous_year, 12, 31)
 
     @staticmethod
     def _last_week_window(today_local: date) -> tuple[date, date]:
@@ -745,6 +752,13 @@ class MomentService:
                 .where(extract("month", col(Moment.logged_date_tz)) == today_local.month)
                 .where(extract("day", col(Moment.logged_date_tz)) == today_local.day)
                 .where(extract("year", col(Moment.logged_date_tz)) < today_local.year)
+            )
+        if memories_filter == MemoriesFilter.last_year:
+            previous_year_start, previous_year_end = self._last_year_window(today_local)
+            return (
+                statement
+                .where(col(Moment.logged_date_tz) >= previous_year_start)
+                .where(col(Moment.logged_date_tz) <= previous_year_end)
             )
         if memories_filter == MemoriesFilter.last_month:
             previous_month_start, previous_month_end = self._last_month_window(today_local)
@@ -826,12 +840,14 @@ class MomentService:
                 self._to_applied_filter(memories_filter),
             )
 
-        # Auto fallback: last years -> last month -> last week.
-        for candidate in (
-            MemoriesFilter.last_years,
-            MemoriesFilter.last_month,
-            MemoriesFilter.last_week,
-        ):
+        # Auto fallback: same date in previous years -> up to 3 from last year -> last month -> last week.
+        auto_candidates: List[Tuple[MemoriesFilter, int]] = [
+            (MemoriesFilter.last_years, limit),
+            (MemoriesFilter.last_year, min(limit, 3)),
+            (MemoriesFilter.last_month, limit),
+            (MemoriesFilter.last_week, limit),
+        ]
+        for candidate, candidate_limit in auto_candidates:
             if self._has_memories(
                 user_id,
                 today_local=today_local,
@@ -842,7 +858,7 @@ class MomentService:
                         user_id,
                         today_local=today_local,
                         memories_filter=candidate,
-                        limit=limit,
+                        limit=candidate_limit,
                     ),
                     self._to_applied_filter(candidate),
                 )

--- a/tests/integration/test_moment_endpoints.py
+++ b/tests/integration/test_moment_endpoints.py
@@ -335,3 +335,36 @@ def test_moment_memories_endpoint_supports_explicit_last_month_filter(
     returned_ids = {item["id"] for item in response["items"]}
     assert month_memory["id"] in returned_ids
     assert noise_moment["id"] not in returned_ids
+
+
+def test_moment_memories_endpoint_supports_explicit_last_year_filter(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+    moment_factory,
+):
+    today = datetime.now(timezone.utc).date()
+    previous_year_date = today.replace(year=today.year - 1, day=1)
+    previous_year_memory = moment_factory(
+        logged_date=previous_year_date.isoformat(),
+        logged_timezone="UTC",
+        note="Previous year memory",
+    )
+    noise_memory = moment_factory(
+        logged_date=today.isoformat(),
+        logged_timezone="UTC",
+        note="Current year noise",
+    )
+
+    response = api_client.request(
+        "GET",
+        "/moments/memories",
+        token=api_user.access_token,
+        params={"filter": "last_year", "limit": 20},
+        expected=(200,),
+    ).json()
+
+    assert response["requested_filter"] == "last_year"
+    assert response["applied_filter"] == "last_year"
+    returned_ids = {item["id"] for item in response["items"]}
+    assert previous_year_memory["id"] in returned_ids
+    assert noise_memory["id"] not in returned_ids

--- a/tests/unit/services/test_moment_service.py
+++ b/tests/unit/services/test_moment_service.py
@@ -509,6 +509,109 @@ def test_get_memories_auto_falls_back_to_last_month(
     assert [item.id for item in items] == [memory.id]
 
 
+def test_get_memories_auto_falls_back_to_last_year_and_caps_to_three(
+    test_db: Session,
+    test_user: User,
+    test_moment_service: MomentService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_now = datetime(2026, 3, 10, 10, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("app.services.moment_service.utc_now", lambda: fake_now)
+
+    moments = [
+        Moment(
+            user_id=test_user.id,
+            logged_at_utc=datetime(2025, 12, 31, 10, 0, 0, tzinfo=timezone.utc),
+            logged_date_tz=date(2025, 12, 31),
+            note="Last year A",
+        ),
+        Moment(
+            user_id=test_user.id,
+            logged_at_utc=datetime(2025, 9, 12, 10, 0, 0, tzinfo=timezone.utc),
+            logged_date_tz=date(2025, 9, 12),
+            note="Last year B",
+        ),
+        Moment(
+            user_id=test_user.id,
+            logged_at_utc=datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc),
+            logged_date_tz=date(2025, 6, 1),
+            note="Last year C",
+        ),
+        Moment(
+            user_id=test_user.id,
+            logged_at_utc=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            logged_date_tz=date(2025, 1, 1),
+            note="Last year D",
+        ),
+    ]
+    for memory in moments:
+        test_db.add(memory)
+    test_db.commit()
+
+    items, applied_filter = test_moment_service.get_memories(
+        test_user.id,
+        memories_filter=MemoriesFilter.auto,
+        limit=20,
+    )
+    assert applied_filter == MemoriesAppliedFilter.last_year
+    assert len(items) == 3
+    assert [item.logged_date_tz for item in items] == [date(2025, 12, 31), date(2025, 9, 12), date(2025, 6, 1)]
+
+
+def test_get_memories_explicit_last_year_uses_requested_limit(
+    test_db: Session,
+    test_user: User,
+    test_moment_service: MomentService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_now = datetime(2026, 3, 10, 10, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("app.services.moment_service.utc_now", lambda: fake_now)
+
+    moments = [
+        Moment(
+            user_id=test_user.id,
+            logged_at_utc=datetime(2025, 12, 31, 10, 0, 0, tzinfo=timezone.utc),
+            logged_date_tz=date(2025, 12, 31),
+            note="Last year A",
+        ),
+        Moment(
+            user_id=test_user.id,
+            logged_at_utc=datetime(2025, 9, 12, 10, 0, 0, tzinfo=timezone.utc),
+            logged_date_tz=date(2025, 9, 12),
+            note="Last year B",
+        ),
+        Moment(
+            user_id=test_user.id,
+            logged_at_utc=datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc),
+            logged_date_tz=date(2025, 6, 1),
+            note="Last year C",
+        ),
+        Moment(
+            user_id=test_user.id,
+            logged_at_utc=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            logged_date_tz=date(2025, 1, 1),
+            note="Last year D",
+        ),
+    ]
+    for memory in moments:
+        test_db.add(memory)
+    test_db.commit()
+
+    items, applied_filter = test_moment_service.get_memories(
+        test_user.id,
+        memories_filter=MemoriesFilter.last_year,
+        limit=4,
+    )
+    assert applied_filter == MemoriesAppliedFilter.last_year
+    assert len(items) == 4
+    assert [item.logged_date_tz for item in items] == [
+        date(2025, 12, 31),
+        date(2025, 9, 12),
+        date(2025, 6, 1),
+        date(2025, 1, 1),
+    ]
+
+
 def test_get_memories_auto_falls_back_to_last_week(
     test_db: Session,
     test_user: User,


### PR DESCRIPTION
fixes #472 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "last_year" filter option for memories, enabling users to view and filter memories from the previous calendar year
  * Enhanced auto-fallback logic to intelligently suggest "last_year" memories when other filter options yield limited results, improving content discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->