### PR TITLE
fix: strip top level None values from mood and analytics

### DIFF
--- a/app/api/v1/endpoints/moods.py
+++ b/app/api/v1/endpoints/moods.py
@@ -36,6 +36,10 @@ from app.services.mood_service import MoodService
 router = APIRouter(prefix="/moods", tags=["moods"])
 
 
+def _strip_none_values(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove top-level null values for map-based API response compatibility."""
+    return {key: value for key, value in payload.items() if value is not None}
+
 
 @router.get(
     "/",
@@ -365,7 +369,9 @@ async def get_mood_statistics(
         )
     mood_service = MoodService(session)
     try:
-        return mood_service.get_mood_statistics(current_user.id, start_date, end_date)
+        return _strip_none_values(
+            mood_service.get_mood_statistics(current_user.id, start_date, end_date)
+        )
     except Exception as exc:
         log_error(exc, request_id=None, user_id=current_user.id)
         raise HTTPException(
@@ -389,7 +395,7 @@ async def get_mood_streak(
     """Get mood logging streak for the current user."""
     mood_service = MoodService(session)
     try:
-        return mood_service.get_mood_streak(current_user.id)
+        return _strip_none_values(mood_service.get_mood_streak(current_user.id))
     except Exception as exc:
         log_error(exc, request_id=None, user_id=current_user.id)
         raise HTTPException(

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -245,7 +245,7 @@ class AnalyticsService:
         """Get comprehensive writing analytics for a user."""
         streak = self.get_writing_streak(user_id)
         if not streak:
-            return {
+            return self._strip_none_values({
                 'current_streak': 0,
                 'longest_streak': 0,
                 'total_entries': 0,
@@ -253,9 +253,9 @@ class AnalyticsService:
                 'average_words_per_entry': 0.0,
                 'last_entry_date': None,
                 'streak_start_date': None
-            }
+            })
 
-        return {
+        return self._strip_none_values({
             'current_streak': streak.current_streak,
             'longest_streak': streak.longest_streak,
             'total_entries': streak.total_entries,
@@ -263,7 +263,12 @@ class AnalyticsService:
             'average_words_per_entry': round(streak.average_words_per_entry, 2),
             'last_entry_date': streak.last_entry_date,
             'streak_start_date': streak.streak_start_date
-        }
+        })
+
+    @staticmethod
+    def _strip_none_values(payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Remove top-level keys with None values to keep map-value contracts non-null."""
+        return {key: value for key, value in payload.items() if value is not None}
 
     def get_writing_patterns(self, user_id: uuid.UUID, days: int = 30) -> Dict[str, Any]:
         """Get writing patterns for the last N days."""

--- a/app/services/mood_service.py
+++ b/app/services/mood_service.py
@@ -102,6 +102,11 @@ class MoodService:
             log_error(exc)
             raise
 
+    @staticmethod
+    def _strip_none_values(payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Remove top-level keys with None values for map-value API compatibility."""
+        return {key: value for key, value in payload.items() if value is not None}
+
     def get_moods_for_user(
         self,
         user_id: uuid.UUID,
@@ -389,7 +394,7 @@ class MoodService:
                     (mood_distribution[category] / total_logs) * 100, 2
                 )
 
-        return {
+        return self._strip_none_values({
             "total_logs": total_logs,
             "date_range": {
                 "start_date": start_date.isoformat(),
@@ -419,7 +424,7 @@ class MoodService:
                 }
                 for trend in daily_moods
             ],
-        }
+        })
 
     def get_mood_streak(self, user_id: uuid.UUID) -> Dict[str, Any]:
         """Get current mood logging streak for a user based on moments."""
@@ -436,11 +441,11 @@ class MoodService:
         )
 
         if not mood_dates:
-            return {
+            return self._strip_none_values({
                 "current_streak": 0,
                 "total_days_logged": 0,
                 "last_logged_date": None,
-            }
+            })
 
         latest_date = mood_dates[0]
         today = utc_now().date()
@@ -460,8 +465,8 @@ class MoodService:
             else:
                 break
 
-        return {
+        return self._strip_none_values({
             "current_streak": current_streak,
             "total_days_logged": len(mood_dates),
             "last_logged_date": latest_date,
-        }
+        })

--- a/tests/integration/test_mood_endpoints.py
+++ b/tests/integration/test_mood_endpoints.py
@@ -93,6 +93,21 @@ def test_mood_lists_support_filters_and_analytics(
         assert isinstance(streak, dict)
 
 
+def test_mood_streak_omits_null_fields_for_empty_history(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+):
+    """Fresh users should not receive null map values in streak payload."""
+    streak_response = api_client.request(
+        "GET", "/moods/analytics/streak", token=api_user.access_token
+    )
+    assert streak_response.status_code == 200
+    streak = streak_response.json()
+    assert streak["current_streak"] == 0
+    assert streak["total_days_logged"] == 0
+    assert "last_logged_date" not in streak
+
+
 def test_mood_log_rejects_unknown_ids(api_client: JournivApiClient, api_user: ApiUser):
     """Logging a moment with unknown mood IDs should return 400."""
     unknown_mood = str(uuid.uuid4())

--- a/tests/integration/test_streak_recalculation.py
+++ b/tests/integration/test_streak_recalculation.py
@@ -217,8 +217,8 @@ def test_case_d_deleting_all_entries_resets_to_zero(
     ).json()
     assert analytics_after["current_streak"] == 0
     assert analytics_after["longest_streak"] == 0
-    assert analytics_after["last_entry_date"] is None
-    assert analytics_after["streak_start_date"] is None
+    assert "last_entry_date" not in analytics_after
+    assert "streak_start_date" not in analytics_after
 
 
 def test_case_e_longest_streak_persists_historically(

--- a/tests/unit/services/test_mood_analytics_contract.py
+++ b/tests/unit/services/test_mood_analytics_contract.py
@@ -1,0 +1,101 @@
+import uuid
+
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, create_engine
+
+from app import models as _models  # noqa: F401
+from app.models.base import BaseModel
+from app.models.mood import Mood
+from app.models.moment import Moment
+from app.models.user import User
+from app.services.mood_service import MoodService
+
+
+def _make_engine():
+    return create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+
+def _create_user(session: Session) -> User:
+    user = User(
+        email=f"mood-analytics-{uuid.uuid4().hex}@example.com",
+        password="password123",
+        name="Mood Analytics User",
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _create_mood(session: Session, user_id: uuid.UUID, name: str) -> Mood:
+    mood = Mood(
+        user_id=user_id,
+        name=name,
+        key=f"{name.lower()}-{uuid.uuid4().hex[:6]}",
+        icon=":)",
+        category="neutral",
+        score=3,
+        position=0,
+        is_active=True,
+    )
+    session.add(mood)
+    session.commit()
+    session.refresh(mood)
+    return mood
+
+
+def test_mood_streak_omits_last_logged_date_when_empty():
+    engine = _make_engine()
+    BaseModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        user = _create_user(session)
+        service = MoodService(session)
+
+        streak = service.get_mood_streak(user.id)
+
+        assert streak["current_streak"] == 0
+        assert streak["total_days_logged"] == 0
+        assert "last_logged_date" not in streak
+
+
+def test_mood_statistics_omits_most_frequent_mood_when_empty():
+    engine = _make_engine()
+    BaseModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        user = _create_user(session)
+        service = MoodService(session)
+
+        stats = service.get_mood_statistics(user.id)
+
+        assert stats["total_logs"] == 0
+        assert "most_frequent_mood" not in stats
+
+
+def test_mood_streak_includes_last_logged_date_when_data_exists():
+    engine = _make_engine()
+    BaseModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        user = _create_user(session)
+        mood = _create_mood(session, user.id, "Okay")
+        session.add(
+            Moment(
+                user_id=user.id,
+                primary_mood_id=mood.id,
+                logged_timezone="UTC",
+            )
+        )
+        session.commit()
+
+        service = MoodService(session)
+        streak = service.get_mood_streak(user.id)
+
+        assert streak["current_streak"] >= 1
+        assert streak["total_days_logged"] >= 1
+        assert streak.get("last_logged_date") is not None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mood analytics and writing analytics endpoints now omit top-level null fields, returning cleaner payloads (e.g., absent dates or stats when not applicable).

* **Tests**
  * Added integration and unit tests to verify analytics endpoints omit null fields and report zero/empty statistics correctly for users with no history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->