### PR TITLE
fix: restore soft deleted mood on recreate and fix activity delete #501

### DIFF
--- a/alembic/versions/4c5d6e7f8a9b_add_activity_soft_delete_flag.py
+++ b/alembic/versions/4c5d6e7f8a9b_add_activity_soft_delete_flag.py
@@ -1,0 +1,36 @@
+"""add activity soft delete flag
+
+Revision ID: 4c5d6e7f8a9b
+Revises: a1a2b3c4d5e6
+Create Date: 2026-03-15 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4c5d6e7f8a9b"
+down_revision = "a1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "activity",
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.create_index(
+        "idx_activity_user_active",
+        "activity",
+        ["user_id", "is_active"],
+        unique=False,
+    )
+    if op.get_bind().dialect.name != "sqlite":
+        op.alter_column("activity", "is_active", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_activity_user_active", table_name="activity")
+    op.drop_column("activity", "is_active")

--- a/app/api/v1/endpoints/activity_groups.py
+++ b/app/api/v1/endpoints/activity_groups.py
@@ -96,7 +96,7 @@ async def get_activity_group(
 ):
     """Get a specific activity group."""
     service = ActivityGroupService(session)
-    group = service.get_group_by_id(group_id, current_user.id)
+    group = service.get_group_with_activities(group_id, current_user.id)
     if not group:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/app/models/activity.py
+++ b/app/models/activity.py
@@ -35,6 +35,7 @@ class Activity(BaseModel, table=True):
     icon: Optional[str] = Field(None, max_length=50)  # e.g., "🏃" or "mdi-run"
     color: Optional[str] = Field(None, max_length=50)  # hex color or theme token
     position: int = Field(default=0, nullable=False)
+    is_active: bool = Field(default=True, nullable=False)
     stable_key: Optional[str] = Field(default=None, max_length=100, index=True)
     group_id: Optional[uuid.UUID] = Field(
         default=None,
@@ -57,6 +58,7 @@ class Activity(BaseModel, table=True):
     # Table constraints and indexes
     __table_args__ = (
         Index('idx_activity_user_name', 'user_id', 'name'),
+        Index('idx_activity_user_active', 'user_id', 'is_active'),
         Index('idx_activity_user_group_position', 'user_id', 'group_id', 'position'),
         CheckConstraint('length(name) > 0', name='check_activity_name_not_empty'),
         UniqueConstraint('user_id', 'stable_key', name='uq_activity_user_stable_key'),

--- a/app/services/activity_group_service.py
+++ b/app/services/activity_group_service.py
@@ -5,10 +5,11 @@ import uuid
 from typing import List, Optional
 
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import selectinload, with_loader_criteria
 from sqlmodel import Session, col, func, select
 
 from app.core.logging_config import log_error, log_info
+from app.models.activity import Activity
 from app.models.activity_group import ActivityGroup
 from app.schemas.activity_group import ActivityGroupCreate, ActivityGroupUpdate
 from app.services.reorder_utils import apply_position_updates
@@ -67,6 +68,13 @@ class ActivityGroupService:
             select(ActivityGroup)
             .where(ActivityGroup.user_id == user_id)
             .options(selectinload(ActivityGroup.activities))  # type: ignore[arg-type]
+            .options(
+                with_loader_criteria(
+                    Activity,
+                    col(Activity.is_active).is_(True),
+                    include_aliases=True,
+                )
+            )
             .order_by(col(ActivityGroup.position), col(ActivityGroup.name))
         )
 
@@ -152,5 +160,12 @@ class ActivityGroupService:
                 ActivityGroup.user_id == user_id,
             )
             .options(selectinload(ActivityGroup.activities))  # type: ignore[arg-type]
+            .options(
+                with_loader_criteria(
+                    Activity,
+                    col(Activity.is_active).is_(True),
+                    include_aliases=True,
+                )
+            )
         )
         return self.session.exec(statement).first()

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlmodel import Session, col, func, select
 
 from app.core.logging_config import log_error, log_info
+from app.core.time_utils import utc_now
 from app.models.activity import Activity
 from app.models.activity_group import ActivityGroup
 from app.models.moment import Moment, MomentMoodActivity
@@ -25,8 +26,17 @@ class ActivityService:
     def __init__(self, session: Session):
         self.session = session
 
+    def _commit(self) -> None:
+        try:
+            self.session.commit()
+        except SQLAlchemyError as exc:
+            self.session.rollback()
+            log_error(exc)
+            raise
+
     def create_activity(self, user_id: uuid.UUID, activity_data: ActivityCreate) -> Activity:
         """Create a new activity for a user."""
+        normalized_name = activity_data.name.strip()
         if activity_data.group_id is not None:
             self._validate_group_id(user_id, activity_data.group_id)
         position = activity_data.position
@@ -39,13 +49,37 @@ class ActivityService:
             ).first()
             position = (max_position or 0) + 1
 
+        existing = self.session.exec(
+            select(Activity).where(
+                col(Activity.user_id) == user_id,
+                func.lower(Activity.name) == normalized_name.lower(),
+            )
+        ).first()
+        if existing:
+            if existing.is_active:
+                raise ValueError(f"Activity with name '{normalized_name}' already exists")
+
+            existing.name = normalized_name
+            existing.icon = activity_data.icon
+            existing.color = activity_data.color
+            existing.group_id = activity_data.group_id
+            existing.position = position
+            existing.is_active = True
+            existing.updated_at = utc_now()
+            self.session.add(existing)
+            self._commit()
+            self.session.refresh(existing)
+            log_info(f"Activity reactivated: {existing.id} for user {user_id}")
+            return existing
+
         activity = Activity(
             user_id=user_id,
-            name=activity_data.name,
+            name=normalized_name,
             icon=activity_data.icon,
             color=activity_data.color,
             group_id=activity_data.group_id,
             position=position,
+            is_active=True,
         )
         try:
             self.session.add(activity)
@@ -55,7 +89,7 @@ class ActivityService:
             self.session.rollback()
             log_error(exc)
             if "idx_activity_user_name" in str(exc.orig):
-                raise ValueError(f"Activity with name '{activity_data.name}' already exists") from exc
+                raise ValueError(f"Activity with name '{normalized_name}' already exists") from exc
             raise ValueError("Database constraint violated") from exc
         except SQLAlchemyError as exc:
             self.session.rollback()
@@ -73,7 +107,10 @@ class ActivityService:
         search: Optional[str] = None,
     ) -> List[Activity]:
         """Get all activities for a user with optional search."""
-        statement = select(Activity).where(Activity.user_id == user_id)
+        statement = select(Activity).where(
+            Activity.user_id == user_id,
+            col(Activity.is_active).is_(True),
+        )
 
         if search:
             normalized = search.strip().lower()
@@ -94,12 +131,20 @@ class ActivityService:
     def _escape_like_pattern(value: str) -> str:
         return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
-    def get_activity_by_id(self, activity_id: uuid.UUID, user_id: uuid.UUID) -> Optional[Activity]:
+    def get_activity_by_id(
+        self,
+        activity_id: uuid.UUID,
+        user_id: uuid.UUID,
+        *,
+        include_inactive: bool = False,
+    ) -> Optional[Activity]:
         """Get an activity by ID, ensuring it belongs to the user."""
         statement = select(Activity).where(
             Activity.id == activity_id,
             Activity.user_id == user_id,
         )
+        if not include_inactive:
+            statement = statement.where(col(Activity.is_active).is_(True))
         return self.session.exec(statement).first()
 
     def update_activity(
@@ -141,18 +186,27 @@ class ActivityService:
         if not activity:
             raise ActivityNotFoundError(f"Activity {activity_id} not found")
 
-        try:
-            self.session.delete(activity)
-            self.session.commit()
-        except SQLAlchemyError as exc:
-            self.session.rollback()
-            log_error(exc)
-            raise
-        else:
-            log_info(f"Activity deleted: {activity_id}")
+        activity.is_active = False
+        activity.updated_at = utc_now()
+        self.session.add(activity)
+        self._commit()
+        log_info(f"Activity soft-deleted: {activity_id}")
 
     def reorder_activities(self, user_id: uuid.UUID, updates: list[tuple[uuid.UUID, int]]) -> None:
         """Bulk update activity positions for a user."""
+        if updates:
+            requested_ids = [activity_id for activity_id, _ in updates]
+            active_ids = set(
+                self.session.exec(
+                    select(Activity.id).where(
+                        col(Activity.user_id) == user_id,
+                        col(Activity.is_active).is_(True),
+                        col(Activity.id).in_(requested_ids),
+                    )
+                ).all()
+            )
+            if len(active_ids) != len(set(requested_ids)):
+                raise ActivityNotFoundError("One or more activities not found")
         updated = apply_position_updates(self.session, Activity, user_id, updates)
         if updated != len({activity_id for activity_id, _ in updates}):
             raise ActivityNotFoundError("One or more activities not found")

--- a/app/services/goal_service.py
+++ b/app/services/goal_service.py
@@ -618,6 +618,7 @@ class GoalService:
             select(Activity.id).where(
                 col(Activity.id) == activity_id,
                 col(Activity.user_id) == user_id,
+                col(Activity.is_active).is_(True),
             )
         ).first()
         if not exists:

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -2033,6 +2033,17 @@ class ImportService:
                 existing = activities_by_name.get(normalized_activity_name.lower())
 
             if existing:
+                if not existing.is_active:
+                    existing.is_active = True
+                existing.icon = activity_dto.icon
+                existing.color = activity_dto.color
+                if activity_dto.group_external_id:
+                    existing.group_id = activity_group_id_map.get(activity_dto.group_external_id)
+                existing.position = (
+                    activity_dto.position if activity_dto.position is not None else existing.position
+                )
+                if activity_dto.updated_at:
+                    existing.updated_at = activity_dto.updated_at
                 if stable_key and not existing.stable_key:
                     backfill_sp = self.db.begin_nested()
                     try:

--- a/app/services/moment_service.py
+++ b/app/services/moment_service.py
@@ -126,6 +126,7 @@ class MomentService:
                 select(Activity.id).where(
                     col(Activity.id).in_(normalize_uuid_list(activity_ids)),
                     col(Activity.user_id) == user_id,
+                    col(Activity.is_active).is_(True),
                 )
             ).all()
             if len(existing_activities) != len(activity_ids):
@@ -147,6 +148,7 @@ class MomentService:
             select(Activity.id).where(
                 col(Activity.id).in_(normalize_uuid_list(set(activity_ids))),
                 col(Activity.user_id) == user_id,
+                col(Activity.is_active).is_(True),
             )
         ).all()
         if len(existing_activities) != len(set(activity_ids)):

--- a/app/services/mood_service.py
+++ b/app/services/mood_service.py
@@ -157,15 +157,6 @@ class MoodService:
         if not name:
             raise ValidationError("Mood name cannot be empty")
 
-        existing = self.session.exec(
-            select(Mood).where(
-                Mood.user_id == user_id,
-                func.lower(Mood.name) == name.lower(),
-            )
-        ).first()
-        if existing:
-            raise MoodAlreadyExistsError("Mood name already exists")
-
         score_raw = data.get("score", 3)
         try:
             score = int(score_raw) if score_raw is not None else 3
@@ -189,6 +180,29 @@ class MoodService:
                 raise ValidationError("position must be an integer") from exc
             if position < 0:
                 raise ValidationError("position must be a non-negative integer")
+
+        existing = self.session.exec(
+            select(Mood).where(
+                Mood.user_id == user_id,
+                func.lower(Mood.name) == name.lower(),
+            )
+        ).first()
+        if existing:
+            if existing.is_active:
+                raise MoodAlreadyExistsError("Mood name already exists")
+
+            existing.icon = data.get("icon")
+            existing.color_value = data.get("color_value")
+            existing.score = score
+            existing.category = category
+            existing.position = position
+            existing.is_active = True
+            existing.updated_at = utc_now()
+            self.session.flush()
+            self._ensure_default_group_link(user_id, existing)
+            self._commit()
+            self.session.refresh(existing)
+            return existing
 
         key = self._generate_unique_key(user_id, name)
         mood = Mood(

--- a/tests/integration/test_mood_endpoints.py
+++ b/tests/integration/test_mood_endpoints.py
@@ -211,3 +211,43 @@ def test_reorder_mood_group_moods_rejects_non_member_moods(
         expected=(400,),
     )
     assert "do not belong" in response.json()["detail"].lower()
+
+
+def test_recreating_deleted_mood_reactivates_existing_row(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+):
+    name = f"Recreate Mood {uuid.uuid4().hex[:6]}"
+    original = api_client.create_mood(
+        api_user.access_token,
+        name=name,
+        score=2,
+        icon="cloud",
+        color_value=0x111111,
+    )
+
+    delete_response = api_client.request(
+        "DELETE",
+        f"/moods/{original['id']}",
+        token=api_user.access_token,
+        expected=(204,),
+    )
+    assert delete_response.status_code == 204
+
+    recreated = api_client.create_mood(
+        api_user.access_token,
+        name=name,
+        score=5,
+        icon="sun",
+        color_value=0x222222,
+    )
+
+    assert recreated["id"] == original["id"]
+    assert recreated["name"] == name
+    assert recreated["score"] == 5
+    assert recreated["icon"] == "sun"
+    assert recreated["color_value"] == 0x222222
+
+    moods = api_client.get_moods_by_name(api_user.access_token, name=name)
+    assert len(moods) == 1
+    assert moods[0]["id"] == original["id"]

--- a/tests/unit/services/test_activity_service.py
+++ b/tests/unit/services/test_activity_service.py
@@ -1,0 +1,105 @@
+import uuid
+from datetime import date
+
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, create_engine, select
+
+from app import models as _models  # noqa: F401
+from app.models.activity import Activity
+from app.models.base import BaseModel
+from app.models.moment import Moment, MomentMoodActivity
+from app.models.user import User
+from app.schemas.activity import ActivityCreate
+from app.services.activity_service import ActivityService
+
+
+def _make_engine():
+    return create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+
+def _create_user(session: Session) -> User:
+    user = User(
+        email=f"activity-{uuid.uuid4().hex}@example.com",
+        password="password123",
+        name="Activity User",
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def test_delete_activity_soft_deletes_and_preserves_historical_links():
+    engine = _make_engine()
+    BaseModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        user = _create_user(session)
+        service = ActivityService(session)
+        activity = service.create_activity(
+            user.id,
+            ActivityCreate(name="Run", icon="run", color="#111111"),
+        )
+
+        moment = Moment(
+            user_id=user.id,
+            logged_date_tz=date.today(),
+            logged_timezone="UTC",
+        )
+        session.add(moment)
+        session.commit()
+        session.refresh(moment)
+
+        link = MomentMoodActivity(moment_id=moment.id, activity_id=activity.id)
+        session.add(link)
+        session.commit()
+
+        service.delete_activity(activity.id, user.id)
+
+        persisted_activity = session.exec(
+            select(Activity).where(Activity.id == activity.id)
+        ).first()
+        persisted_link = session.exec(
+            select(MomentMoodActivity).where(MomentMoodActivity.activity_id == activity.id)
+        ).first()
+
+        assert persisted_activity is not None
+        assert persisted_activity.is_active is False
+        assert persisted_link is not None
+        assert service.get_user_activities(user.id) == []
+
+
+def test_create_activity_reactivates_matching_inactive_row():
+    engine = _make_engine()
+    BaseModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        user = _create_user(session)
+        service = ActivityService(session)
+
+        original = service.create_activity(
+            user.id,
+            ActivityCreate(name="Read", icon="book", color="#123456"),
+        )
+        service.delete_activity(original.id, user.id)
+
+        recreated = service.create_activity(
+            user.id,
+            ActivityCreate(name="Read", icon="book-open", color="#654321"),
+        )
+
+        persisted = session.exec(
+            select(Activity).where(Activity.user_id == user.id, Activity.name == "Read")
+        ).all()
+
+        assert recreated.id == original.id
+        assert recreated.is_active is True
+        assert recreated.icon == "book-open"
+        assert recreated.color == "#654321"
+        assert len(persisted) == 1
+        assert persisted[0].id == original.id
+        assert persisted[0].is_active is True

--- a/tests/unit/services/test_mood_ordering_services.py
+++ b/tests/unit/services/test_mood_ordering_services.py
@@ -77,6 +77,49 @@ def test_reorder_moods_rejects_duplicate_ids():
             service.reorder_moods(user.id, [mood.id, mood.id])
 
 
+def test_create_user_mood_reactivates_matching_inactive_mood():
+    engine = _make_engine()
+    BaseModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        user = _create_user(session)
+        service = MoodService(session)
+
+        original = service.create_user_mood(
+            user.id,
+            {
+                "name": "Test",
+                "score": 2,
+                "icon": "cloud",
+                "color_value": 0x111111,
+            },
+        )
+        service.delete_user_mood(user.id, original)
+
+        recreated = service.create_user_mood(
+            user.id,
+            {
+                "name": "Test",
+                "score": 5,
+                "icon": "sun",
+                "color_value": 0x222222,
+            },
+        )
+
+        assert recreated.id == original.id
+        assert recreated.is_active is True
+        assert recreated.score == 5
+        assert recreated.icon == "sun"
+        assert recreated.color_value == 0x222222
+
+        persisted = session.exec(
+            select(Mood).where(Mood.user_id == user.id, Mood.name == "Test")
+        ).all()
+        assert len(persisted) == 1
+        assert persisted[0].id == original.id
+        assert persisted[0].is_active is True
+
+
 def test_reorder_groups_rejects_unknown_group_ids():
     engine = _make_engine()
     BaseModel.metadata.create_all(engine)


### PR DESCRIPTION
fixes #501 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activities and moods now support soft-delete; recreating an item with the same name will reactivate and update it
  * Group endpoints now return groups with their associated (active) activities

* **Bug Fixes**
  * Queries and validations exclude soft-deleted (inactive) activities and moods
  * Reordering and deletion operations validate active status

* **Tests**
  * New unit and integration tests covering soft-delete, reactivation, and related behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->