### PR TITLE
fix: handle last_error for scheduled sync for transient failures

### DIFF
--- a/app/integrations/schemas.py
+++ b/app/integrations/schemas.py
@@ -118,7 +118,7 @@ class IntegrationStatusResponse(BaseModel):
 
     Fields:
         provider: Which service this is
-        status: "connected" | "disconnected" | "error"
+        status: "connected" | "disconnected"; provider issues are exposed via last_error
         external_user_id: User's ID in the external system (if connected)
         connected_at: When the integration was first connected (if connected)
         last_synced_at: When we last successfully synced data (if any)
@@ -139,7 +139,7 @@ class IntegrationStatusResponse(BaseModel):
     provider: IntegrationProvider
     status: str = Field(
         ...,
-        description="Connection status: 'connected', 'disconnected', or 'error'"
+        description="Connection status: 'connected' or 'disconnected'. Provider issues are exposed via last_error."
     )
     external_user_id: Optional[str] = Field(
         default=None,

--- a/app/integrations/service.py
+++ b/app/integrations/service.py
@@ -373,13 +373,11 @@ async def get_integration_status(
             album_error=None
         )
 
-    # Determine status
-    if integration.last_error:
-        status = "error"
-    elif integration.is_active:
-        status = "connected"
-    else:
-        status = "disconnected"
+    # Determine status from the persisted connection state, not from the last
+    # sync result. Transient sync/provider failures are exposed through
+    # last_error, but they should not make the frontend hide a still-active
+    # stored integration or force the user to reconnect.
+    status = "connected" if integration.is_active else "disconnected"
 
     # Extract album metadata
     metadata = integration.get_metadata()
@@ -481,6 +479,13 @@ async def list_integration_assets(
             limit=limit,
             force_refresh=force_refresh
         )
+
+        if integration.last_error:
+            integration.last_error = None
+            integration.last_error_at = None
+            integration.updated_at = utc_now()
+            session.add(integration)
+            await _commit(session)
 
         # Handle if provider returns just list (backward compatibility or sloppy impl)
         if isinstance(result, tuple):

--- a/tests/unit/integrations/test_integrations.py
+++ b/tests/unit/integrations/test_integrations.py
@@ -8,6 +8,7 @@ These tests verify the core integration functionality including:
 """
 import uuid
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -185,6 +186,79 @@ class TestIntegrationService:
         assert response.provider == IntegrationProvider.IMMICH
         assert response.is_active is False
         assert response.external_user_id is None
+
+    @pytest.mark.asyncio
+    async def test_get_integration_status_stays_connected_with_last_error(self):
+        """Active integrations remain connected even when last sync has an error."""
+        from unittest.mock import MagicMock
+
+        from app.integrations.service import get_integration_status
+
+        mock_session = MagicMock()
+        mock_user = MagicMock()
+        mock_user.id = "user-123"
+        integration = MagicMock()
+        integration.provider = IntegrationProvider.IMMICH
+        integration.external_user_id = "immich-user-123"
+        integration.connected_at = datetime.now(timezone.utc)
+        integration.last_synced_at = None
+        integration.last_error = "temporary provider timeout"
+        integration.is_active = True
+        integration.import_mode = "link_only"
+        integration.get_metadata.return_value = {}
+
+        mock_session.exec.return_value.first.return_value = integration
+
+        response = await get_integration_status(
+            session=mock_session,
+            user=mock_user,
+            provider=IntegrationProvider.IMMICH,
+        )
+
+        assert response.status == "connected"
+        assert response.is_active is True
+        assert response.last_error == "temporary provider timeout"
+
+    @pytest.mark.asyncio
+    async def test_list_integration_assets_clears_stale_last_error_on_success(self):
+        """A successful asset list clears stale sync/list errors."""
+        from contextlib import contextmanager
+        from unittest.mock import MagicMock
+
+        from app.integrations.service import list_integration_assets
+
+        mock_session = MagicMock()
+        temp_session = MagicMock()
+        mock_user = SimpleNamespace(id="user-123")
+        integration = SimpleNamespace(
+            user_id=mock_user.id,
+            provider=IntegrationProvider.IMMICH,
+            is_active=True,
+            last_error="temporary provider timeout",
+            last_error_at=datetime.now(timezone.utc),
+            updated_at=None,
+        )
+        temp_session.exec.return_value.first.return_value = integration
+        mock_provider = SimpleNamespace(list_assets=AsyncMock(return_value=[]))
+
+        @contextmanager
+        def fake_session_context():
+            yield temp_session
+
+        with patch("app.core.database.get_session_context", fake_session_context), \
+             patch("app.integrations.service.get_provider_module", return_value=mock_provider):
+            assets, total = await list_integration_assets(
+                session=mock_session,
+                user=mock_user,
+                provider=IntegrationProvider.IMMICH,
+            )
+
+        assert assets == []
+        assert total == -1
+        assert integration.last_error is None
+        assert integration.last_error_at is None
+        mock_session.add.assert_called_once_with(integration)
+        mock_session.commit.assert_called_once()
 
 
 # ================================================================================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integration status now displays only "connected" or "disconnected" states for clearer visibility
  * Provider errors are surfaced through detailed error information rather than as a separate status state
  * Successful asset synchronization automatically clears previous error records for improved recovery experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->