### PR TITLE
fix: handle standard Quill block attributes on newline ops #362

### DIFF
--- a/app/utils/render_engine.py
+++ b/app/utils/render_engine.py
@@ -144,6 +144,23 @@ def render_delta_to_html(
         current_block_type = None
         return content
 
+    def take_current_line_content() -> str:
+        """Consume only the current line, flushing earlier paragraph lines first."""
+        nonlocal current_block, current_block_type
+        if not current_block:
+            return ""
+        content = ''.join(current_block)
+        if '<br>' not in content:
+            return take_current_block_content()
+
+        previous_content, _, current_line = content.rpartition('<br>')
+        if previous_content.strip():
+            tag = current_block_type or 'p'
+            html_parts.append(f'<{tag}>{previous_content}<br></{tag}>')
+        current_block = []
+        current_block_type = None
+        return current_line.strip()
+
     for op in ops:
         if not isinstance(op, dict):
             continue
@@ -158,7 +175,9 @@ def render_delta_to_html(
             lines = insert.split('\n')
 
             for i, line in enumerate(lines):
-                is_newline = (i < len(lines) - 1) or (i == 0 and not line)
+                is_newline = i < len(lines) - 1
+                if not is_newline and not line:
+                    continue
 
                 # Check for block-level formatting
                 header = attributes.get("header")
@@ -181,7 +200,7 @@ def render_delta_to_html(
 
                     carried_content = ""
                     if is_newline and not line and current_block and (current_block_type in (None, 'p')):
-                        carried_content = take_current_block_content()
+                        carried_content = take_current_line_content()
                     else:
                         flush_block()
 
@@ -205,7 +224,7 @@ def render_delta_to_html(
 
                     carried_content = ""
                     if is_newline and not line and current_block and (current_block_type in (None, 'p')):
-                        carried_content = take_current_block_content()
+                        carried_content = take_current_line_content()
 
                     if current_block_type != 'blockquote':
                         flush_block()
@@ -228,7 +247,7 @@ def render_delta_to_html(
 
                     carried_content = ""
                     if is_newline and not line and current_block and (current_block_type in (None, 'p')):
-                        carried_content = take_current_block_content()
+                        carried_content = take_current_line_content()
 
                     header_tag = f'h{_normalize_header_level(header)}'
 
@@ -245,9 +264,6 @@ def render_delta_to_html(
 
                 else:
                     # Regular paragraph
-                    flush_list()
-                    flush_code_block()
-
                     if current_block_type and current_block_type != 'p':
                         flush_block()
 
@@ -256,6 +272,8 @@ def render_delta_to_html(
                         current_block.append(formatted_line)
 
                     if is_newline:
+                        flush_list()
+                        flush_code_block()
                         if current_block:
                             current_block.append('<br>')
 
@@ -367,9 +385,9 @@ def render_delta_to_html(
                         html_parts.append(f'<audio controls src="{safe_url}"></audio>')
 
     # Flush any remaining blocks
-    flush_block()
     flush_list()
     flush_code_block()
+    flush_block()
 
     # Join all HTML parts
     result = ''.join(html_parts)

--- a/tests/unit/utils/test_render_engine.py
+++ b/tests/unit/utils/test_render_engine.py
@@ -120,6 +120,42 @@ def test_render_ordered_list():
     assert "</ol>" in result
 
 
+def test_render_ordered_list_with_quill_newline_attributes():
+    """Test rendering standard Quill ordered lists with block attributes on newlines."""
+    delta = {
+        "ops": [
+            {"insert": "First"},
+            {"insert": "\n", "attributes": {"list": "ordered"}},
+            {"insert": "Second"},
+            {"insert": "\n", "attributes": {"list": "ordered"}},
+            {"insert": "Third"},
+            {"insert": "\n", "attributes": {"list": "ordered"}},
+        ]
+    }
+    result = render_delta_to_html(delta)
+    assert result == "<ol><li>First</li><li>Second</li><li>Third</li></ol>"
+
+
+def test_render_quill_list_separated_by_plain_paragraph():
+    """Test standard Quill list items split by a plain paragraph."""
+    delta = {
+        "ops": [
+            {"insert": "First"},
+            {"insert": "\n", "attributes": {"list": "ordered"}},
+            {"insert": "Plain paragraph"},
+            {"insert": "\n"},
+            {"insert": "Second"},
+            {"insert": "\n", "attributes": {"list": "ordered"}},
+        ]
+    }
+    result = render_delta_to_html(delta)
+    assert result == (
+        "<ol><li>First</li></ol>"
+        "<p>Plain paragraph<br></p>"
+        "<ol><li>Second</li></ol>"
+    )
+
+
 def test_render_blockquote():
     """Test rendering blockquotes."""
     delta = {


### PR DESCRIPTION
Now consecutive list items render as one <ol>/<ul> and plain paragraphs still split lists correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering accuracy for content with line breaks in lists, blockquotes, and headings.
  * Enhanced handling of paragraph transitions and code block processing in the rendering pipeline.

* **Tests**
  * Added unit tests for ordered list rendering with various paragraph combinations to ensure proper HTML output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/journiv/journiv-app/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->