### PR TITLE
fix: media unavailable - Immich HEIC import (#367)

### DIFF
--- a/app/api/v1/endpoints/media.py
+++ b/app/api/v1/endpoints/media.py
@@ -472,7 +472,7 @@ async def get_media_signed(
 
             # For internal media, fetch file info while we have the session
             if has_local_file or external_provider != "immich":
-                file_info = await media_service.get_media_file_for_serving(
+                file_info = await media_service.get_media_file_for_display(
                     media_id, uid, session, range_header
                 )
         # Session is now closed - DB connection released
@@ -589,6 +589,24 @@ async def get_media_signed(
             exc_info=True
         )
         raise HTTPException(status_code=500, detail="Failed to serve file") from None
+    except Exception as exc:
+        error_logger.exception(
+            "Failed to queue media processing task",
+            extra={
+                "user_id": str(current_user.id),
+                "media_id": str(media_record.id),
+            },
+        )
+
+    with database_module.get_session_context() as session:
+        failed_media = session.get(MomentMedia, media_record.id)
+        if failed_media:
+            failed_media.upload_status = UploadStatus.FAILED
+            failed_media.processing_error = (
+                "Media processing could not be queued"
+            )
+            session.add(failed_media)
+            session.commit()
 
 
 @router.get(
@@ -677,7 +695,10 @@ async def get_media_thumbnail_signed(
         if not thumbnail_path:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Thumbnail not found")
 
-        return FileResponse(thumbnail_path)
+        return FileResponse(
+                thumbnail_path,
+                media_type="image/jpeg",
+                )
     except MediaNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/app/services/media_service.py
+++ b/app/services/media_service.py
@@ -1336,7 +1336,7 @@ class MediaService:
 
         if media_type_value == "image":
             thumbnail_dir = file_path_obj.parent / "thumbnails"
-            thumbnail_path = thumbnail_dir / f"thumb_{file_path_obj.name}"
+            thumbnail_path = thumbnail_dir / f"thumb_{file_path_obj.stem}.jpg"
             self._generate_image_thumbnail(file_path_obj, thumbnail_path)
         elif media_type_value == "video":
             thumbnail_dir = file_path_obj.parent / "thumbnails"
@@ -1915,6 +1915,22 @@ class MediaService:
             media,
             range_header=range_header,
             allow_display_version=False,
+        )
+
+    async def get_media_file_for_display(
+        self,
+        media_id: uuid.UUID,
+        user_id: uuid.UUID,
+        session: Session,
+        range_header: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get browser-compatible media, preferring a generated display version."""
+        media = self.get_media_by_id(media_id, user_id, session)
+
+        return await self._build_media_file_info(
+            media,
+            range_header=range_header,
+            allow_display_version=True,
         )
 
     async def process_moment_media(self, moment_id: uuid.UUID, user_id: uuid.UUID, session: Session) -> int:

--- a/app/tasks/media_processing_tasks.py
+++ b/app/tasks/media_processing_tasks.py
@@ -57,7 +57,19 @@ def process_media_upload(self, media_id: str, file_path: str, user_id: str):
                 log_info("Processed uploaded media", media_id=media_id, user_id=user_id)
         except Exception as exc:
             log_error(exc, media_id=media_id, user_id=user_id)
+            try:
+                service._mark_processing_failed(
+                    media_id,
+                    f"Background media processing failed: {exc}",
+                )
+            except Exception as status_exc:
+                log_error(
+                    status_exc,
+                    message="Failed to update media processing status",
+                    media_id=media_id,
+                )
             raise
+
 
 
 @celery_app.task(name="app.tasks.media.cleanup_moment_media_files", bind=True)

--- a/tests/unit/services/test_media_service_heic.py
+++ b/tests/unit/services/test_media_service_heic.py
@@ -6,7 +6,8 @@ Covers:
 - _build_display_path naming convention
 - _generate_heic_display_version transcoding (requires pillow-heif)
 - process_uploaded_file skips regeneration when display_path exists
-- get_media_file_for_serving serves original bytes for authenticated downloads
+- display serving prefers WebP while original serving preserves HEIC bytes
+- image thumbnails use an extension matching their JPEG encoding
 - delete_media_by_id cleans up display version file
 """
 import shutil
@@ -303,6 +304,15 @@ class TestServingHeicDisplayVersion:
         assert result["content_type"] == "image/heic"
         assert result["file_path"] == heic_file
 
+        display_result = await service.get_media_file_for_display(
+            media_id=media.id,
+            user_id=test_user.id,
+            session=test_db,
+        )
+
+        assert display_result["content_type"] == "image/webp"
+        assert display_result["file_path"] == display_file
+
     @pytest.mark.asyncio
     async def test_serves_original_when_no_display_path(
         self, tmp_path, test_db, test_user, test_entry
@@ -339,6 +349,20 @@ class TestServingHeicDisplayVersion:
         assert result["file_path"] == heic_file
         # content_type should NOT be image/webp
         assert result["content_type"] != "image/webp"
+
+
+class TestImageThumbnailFilename:
+    def test_heic_thumbnail_uses_jpeg_extension(self, tmp_path, test_db):
+        service = _build_service(tmp_path, test_db)
+        source = tmp_path / "media" / "photo.heic"
+
+        with patch.object(service, "_generate_image_thumbnail") as generate:
+            result = service._generate_thumbnail(str(source), MediaType.IMAGE)
+
+        assert result is not None
+        thumbnail_path = Path(result)
+        assert thumbnail_path.name == "thumb_photo.jpg"
+        generate.assert_called_once_with(source, thumbnail_path)
 
 
 # ─── delete: display version file cleanup ────────────────────────────

--- a/tests/unit/test_media_endpoints_heic.py
+++ b/tests/unit/test_media_endpoints_heic.py
@@ -1,0 +1,136 @@
+"""Regression tests for serving local HEIC display assets."""
+
+import uuid
+from contextlib import nullcontext
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.responses import FileResponse
+
+from app.api.v1.endpoints import media as media_endpoint
+
+
+@pytest.mark.asyncio
+async def test_signed_media_uses_browser_compatible_display_version(
+    tmp_path: Path,
+) -> None:
+    """The signed display route must not send raw HEIC bytes to the browser."""
+    media_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    display_path = tmp_path / "photo_display.webp"
+    display_path.write_bytes(b"webp display bytes")
+
+    media = MagicMock(
+        external_provider=None,
+        external_asset_id=None,
+        file_path="images/photo.heic",
+    )
+    service = MagicMock()
+    service.get_media_by_id.return_value = media
+    service.get_media_file_for_display = AsyncMock(
+        return_value={
+            "range_info": None,
+            "file_path": display_path,
+            "content_type": "image/webp",
+            "filename": "photo_display.webp",
+            "file_size": display_path.stat().st_size,
+        }
+    )
+    session = MagicMock()
+
+    with (
+        patch.object(
+            media_endpoint,
+            "is_signature_expired",
+            return_value=False,
+        ),
+        patch.object(
+            media_endpoint,
+            "verify_media_signature",
+            return_value=True,
+        ),
+        patch.object(
+            media_endpoint,
+            "_get_media_service",
+            return_value=service,
+        ),
+        patch.object(
+            media_endpoint.database_module,
+            "get_session_context",
+            return_value=nullcontext(session),
+        ),
+    ):
+        response = await media_endpoint.get_media_signed(
+            media_id=media_id,
+            uid=user_id,
+            exp=2_000_000_000,
+            sig="valid-signature",
+        )
+
+    assert isinstance(response, FileResponse)
+    assert Path(response.path) == display_path
+    assert response.media_type == "image/webp"
+
+    service.get_media_file_for_display.assert_awaited_once_with(
+        media_id,
+        user_id,
+        session,
+        None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_signed_legacy_heic_thumbnail_is_advertised_as_jpeg(
+    tmp_path: Path,
+) -> None:
+    """Old JPEG thumbnails with a .heic suffix still need a JPEG MIME type."""
+    media_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    legacy_thumbnail = tmp_path / "thumb_photo.heic"
+    legacy_thumbnail.write_bytes(b"jpeg thumbnail bytes")
+
+    media = MagicMock(
+        external_provider=None,
+        external_asset_id=None,
+        thumbnail_path="images/thumb_photo.heic",
+    )
+    service = MagicMock()
+    service.get_media_by_id.return_value = media
+    service.get_media_thumbnail_path.return_value = legacy_thumbnail
+    session = MagicMock()
+
+    with (
+        patch.object(
+            media_endpoint,
+            "is_signature_expired",
+            return_value=False,
+        ),
+        patch.object(
+            media_endpoint,
+            "verify_media_signature",
+            return_value=True,
+        ),
+        patch.object(
+            media_endpoint,
+            "_get_media_service",
+            return_value=service,
+        ),
+        patch.object(
+            media_endpoint.database_module,
+            "get_session_context",
+            return_value=nullcontext(session),
+        ),
+    ):
+        response = await media_endpoint.get_media_thumbnail_signed(
+            media_id=media_id,
+            uid=user_id,
+            exp=2_000_000_000,
+            sig="valid-signature",
+        )
+
+    assert isinstance(response, FileResponse)
+    assert Path(response.path) == legacy_thumbnail
+    assert response.media_type == "image/jpeg"
+
+    service.get_media_thumbnail_path.assert_called_once_with(media)


### PR DESCRIPTION
## Description
Signed display URLs now prefer the generated WebP rendition while preserving original HEIC files for downloads/exports.
Generated image thumbnails now use .jpg, matching their actual JPEG encoding.
Legacy thumbnails with .heic filenames are explicitly served as image/jpeg.
Added regression tests covering WebP display selection and JPEG thumbnail naming

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [X] Tests pass locally
- [X] New tests added for new functionality
- [X] Manual testing completed

## Checklist
- [X] Code follows project style guidelines
- [X] Self-review completed
- [ ] Documentation updated
- [X] No breaking changes (or clearly documented)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - HEIC media now uses browser-compatible display versions, such as WebP, when available.
  - Signed media displays preserve support for range-based viewing.
  - Thumbnails are served with the correct JPEG content type.

- **Bug Fixes**
  - HEIC thumbnail filenames now consistently use the `.jpg` extension.
  - Media processing failures are recorded with a clear failed status and error message, improving visibility when processing cannot be queued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->