### PR TITLE
fix: repair broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Need help or want to report an issue?
 - **Email**: journiv@protonmail.com
 - **Discord**: Join our [community server](https://discord.gg/CuEJ8qft46)
 
-![Star History Chart](https://api.star-history.com/svg?repos=journiv/journiv-app&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=journiv/journiv-app&type=Date)
 
 ---
 


### PR DESCRIPTION
The star history chart shown in the README is currently broken because of GitHub stargazer API restrictions. This change updates the chart to use a working star history service so it displays correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Support section’s Star History Chart to use the new image source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->