### PR TITLE
fix: CORS rejecting browser video Range requests

### DIFF
--- a/app/core/cors.py
+++ b/app/core/cors.py
@@ -1,0 +1,21 @@
+"""Shared CORS policy constants."""
+
+from typing import Final
+
+# Browser media elements use byte-range requests to load video metadata and
+# seek without downloading the entire file. Keep these headers explicit so
+# cross-origin Flutter web/PWA clients can use the signed media endpoints.
+CORS_ALLOW_HEADERS: Final[tuple[str, ...]] = (
+    "Authorization",
+    "Content-Type",
+    "Accept",
+    "Origin",
+    "X-Requested-With",
+    "Range",
+)
+
+CORS_EXPOSE_HEADERS: Final[tuple[str, ...]] = (
+    "Accept-Ranges",
+    "Content-Length",
+    "Content-Range",
+)

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.api.v1.api import api_router
 from app.api.v1.endpoints import public
 from app.core.cache import create_cache
 from app.core.config import settings
+from app.core.cors import CORS_ALLOW_HEADERS, CORS_EXPOSE_HEADERS
 from app.core.database import init_db
 from app.core.exceptions import (
     EntryNotFoundError,
@@ -148,13 +149,8 @@ if cors_enabled:
         allow_origins=cors_origins,
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-        allow_headers=[
-            "Authorization",
-            "Content-Type",
-            "Accept",
-            "Origin",
-            "X-Requested-With",
-        ],
+        allow_headers=CORS_ALLOW_HEADERS,
+        expose_headers=CORS_EXPOSE_HEADERS,
         max_age=3600,
     )
     log_info(f"CORS enabled for origins: {cors_origins}")

--- a/tests/unit/core/test_cors.py
+++ b/tests/unit/core/test_cors.py
@@ -1,0 +1,37 @@
+import os
+
+from fastapi.testclient import TestClient
+
+FRONTEND_ORIGIN = "http://localhost:7357"
+
+os.environ["ENABLE_CORS"] = "true"
+os.environ["CORS_ORIGINS"] = FRONTEND_ORIGIN
+
+from app.main import app  # noqa: E402
+
+
+def test_video_range_preflight_is_allowed() -> None:
+    client = TestClient(app)
+
+    response = client.options(
+        "/api/v1/memory",
+        headers={
+            "Origin": FRONTEND_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Range",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "range" in response.headers["access-control-allow-headers"].lower()
+
+
+def test_video_range_response_headers_are_exposed() -> None:
+    client = TestClient(app)
+
+    response = client.get("/api/v1/memory", headers={"Origin": FRONTEND_ORIGIN})
+
+    exposed_headers = response.headers["access-control-expose-headers"].lower()
+    assert "accept-ranges" in exposed_headers
+    assert "content-length" in exposed_headers
+    assert "content-range" in exposed_headers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-origin media requests by supporting byte-range requests.
  * Exposed relevant response headers, including content length, content range, and accepted ranges, for compatible clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->