### PR TITLE
feat: Add support for 12 or 24 hour time format #545

### DIFF
--- a/alembic/versions/e8f9a0b1c2d3_add_user_time_format.py
+++ b/alembic/versions/e8f9a0b1c2d3_add_user_time_format.py
@@ -1,0 +1,33 @@
+"""add user time format preference
+
+Revision ID: e8f9a0b1c2d3
+Revises: f4a8b9c0d1e2
+Create Date: 2026-08-18
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision = "e8f9a0b1c2d3"
+down_revision = "f4a8b9c0d1e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("user_settings") as batch_op:
+        batch_op.add_column(
+            sa.Column("time_format", sa.String(length=20), nullable=False, server_default="system")
+        )
+        batch_op.create_check_constraint(
+            "check_time_format_valid",
+            "time_format IN ('system', 'twelve_hour', 'twenty_four_hour')",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_settings") as batch_op:
+        batch_op.drop_constraint("check_time_format_valid", type_="check")
+        batch_op.drop_column("time_format")

--- a/app/main.py
+++ b/app/main.py
@@ -292,7 +292,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         status_code=422,
         content={
             "error": "validation_error",
-            "message": errors,
+            "message": sanitized_errors,
             "request_id": request_id,
         },
     )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -202,6 +202,7 @@ class UserSettings(TimestampMixin, table=True):
     reminder_time: Optional[str] = Field(None, max_length=5)  # HH:MM format
     writing_goal_daily: int = Field(default=500, ge=1, le=10000)  # Words per day (default: 500)
     start_of_week_day: int = Field(default=0, ge=0, le=6)  # 0=Monday ... 6=Sunday
+    time_format: str = Field(default="system", max_length=20)  # system, twelve_hour, twenty_four_hour
     theme: str = Field(default="light", max_length=20)  # light, dark, auto
 
     # Relations
@@ -212,6 +213,7 @@ class UserSettings(TimestampMixin, table=True):
         # Constraints
         CheckConstraint('writing_goal_daily > 0', name='check_goal_positive'),
         CheckConstraint('start_of_week_day >= 0 AND start_of_week_day <= 6', name='check_start_of_week_day_valid'),
+        CheckConstraint("time_format IN ('system', 'twelve_hour', 'twenty_four_hour')", name='check_time_format_valid'),
         CheckConstraint("theme IN ('light', 'dark', 'auto')", name='check_theme_valid'),
     )
 
@@ -222,6 +224,14 @@ class UserSettings(TimestampMixin, table=True):
         allowed_themes = {theme.value for theme in Theme}
         if v not in allowed_themes:
             raise ValueError(f'Invalid theme: {v}. Must be one of {sorted(allowed_themes)}')
+        return v
+
+    @field_validator('time_format')
+    @classmethod
+    def validate_time_format(cls, v):
+        allowed_formats = {'system', 'twelve_hour', 'twenty_four_hour'}
+        if v not in allowed_formats:
+            raise ValueError(f'time_format must be one of {sorted(allowed_formats)}')
         return v
 
     @field_validator('time_zone')

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -110,7 +110,9 @@ class UserSettingsUpdate(BaseModel):
         if v is not None:
             from app.core.time_utils import validate_timezone
             if not validate_timezone(v):
-                raise ValueError(f'Invalid timezone: "{v}". Must be a valid IANA timezone name (e.g., "America/New_York", "Europe/London", "Asia/Tokyo")')
+                raise ValueError(
+                    "Invalid timezone. Provide a valid IANA timezone name."
+                )
         return v
 
     @validator('start_of_week_day')

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -84,6 +84,7 @@ class UserSettingsBase(BaseModel):
     reminder_time: Optional[str] = None
     writing_goal_daily: Optional[int] = None
     start_of_week_day: int = Field(0, ge=0, le=6)  # 0=Monday ... 6=Sunday
+    time_format: str = "system"
     theme: str = "light"
 
 
@@ -100,6 +101,7 @@ class UserSettingsUpdate(BaseModel):
     reminder_time: Optional[str] = None
     writing_goal_daily: Optional[int] = None
     start_of_week_day: Optional[int] = Field(None, ge=0, le=6)
+    time_format: Optional[str] = None
     theme: Optional[str] = None
 
     @validator('time_zone')
@@ -115,6 +117,12 @@ class UserSettingsUpdate(BaseModel):
     def validate_start_of_week_day(cls, v):
         if v is not None and (v < 0 or v > 6):
             raise ValueError("start_of_week_day must be between 0 and 6")
+        return v
+
+    @validator('time_format')
+    def validate_time_format(cls, v):
+        if v is not None and v not in {'system', 'twelve_hour', 'twenty_four_hour'}:
+            raise ValueError('time_format must be system, twelve_hour, or twenty_four_hour')
         return v
 
 

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -47,6 +47,21 @@ def test_settings_reject_invalid_time_format(api_client: JournivApiClient, api_u
     assert response.status_code == 422
 
 
+def test_settings_does_not_echo_invalid_timezone(
+    api_client: JournivApiClient, api_user: ApiUser
+):
+    invalid_timezone = "Invalid/Timezone-should-not-appear-in-response"
+    response = api_client.request(
+        "PUT",
+        "/users/me/settings",
+        token=api_user.access_token,
+        json={"time_zone": invalid_timezone},
+    )
+
+    assert response.status_code == 422
+    assert invalid_timezone not in response.text
+
+
 def test_account_deletion_revokes_access(api_client: JournivApiClient):
     """Deleting the account immediately revokes existing tokens."""
     user = make_api_user(api_client)

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -26,13 +26,25 @@ def test_settings_round_trip(api_client: JournivApiClient, api_user: ApiUser):
     desired = {
         "time_zone": "America/New_York",
         "daily_prompt_enabled": False,
+        "time_format": "twenty_four_hour",
         "theme": "dark",
     }
     updated = api_client.update_user_settings(api_user.access_token, desired)
 
     assert updated["time_zone"] == desired["time_zone"]
     assert updated["daily_prompt_enabled"] is False
+    assert updated["time_format"] == desired["time_format"]
     assert updated["theme"] == "dark"
+
+
+def test_settings_reject_invalid_time_format(api_client: JournivApiClient, api_user: ApiUser):
+    response = api_client.request(
+        "PUT",
+        "/users/me/settings",
+        token=api_user.access_token,
+        json={"time_format": "invalid"},
+    )
+    assert response.status_code == 422
 
 
 def test_account_deletion_revokes_access(api_client: JournivApiClient):


### PR DESCRIPTION
#545 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-configurable time format preferences: system default, 12-hour, or 24-hour.
  * Time format settings are saved and returned with user settings.

* **Bug Fixes**
  * Invalid time format values are now rejected with a validation error.
  * Validation responses now provide clearer, streamlined details and avoid echoing invalid time-zone values.

* **Tests**
  * Added coverage for saving, retrieving, and validating time format preferences and time-zone input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->