### PR TITLE
feat(backend): reject stale entry updates

### DIFF
--- a/app/api/v1/endpoints/entries.py
+++ b/app/api/v1/endpoints/entries.py
@@ -13,6 +13,7 @@ from sqlmodel import Session, select
 from app.api.dependencies import get_current_user
 from app.core.database import get_session
 from app.core.exceptions import (
+    ConcurrentModificationError,
     EntryNotFoundError,
     JournalNotFoundError,
     ValidationError,
@@ -351,6 +352,12 @@ async def get_entry(
         401: {"description": "Not authenticated"},
         403: {"description": "Account inactive"},
         404: {"description": "Entry not found"},
+        409: {
+            "description": (
+                "The entry changed since `expected_updated_at`; saving would "
+                "discard that other edit"
+            )
+        },
         422: {
             "description": "Validation error (e.g., cannot move to archived journal)"
         },
@@ -375,6 +382,8 @@ async def update_entry(
         raise HTTPException(
             status_code=404, detail="Target journal not found"
         ) from None
+    except ConcurrentModificationError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from None
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=str(e)) from None
     except ValueError as e:

--- a/app/api/v1/endpoints/moments.py
+++ b/app/api/v1/endpoints/moments.py
@@ -10,7 +10,11 @@ from sqlmodel import Session, col, select
 
 from app.api.dependencies import get_current_user, get_session
 from app.core.db_utils import normalize_uuid_list
-from app.core.exceptions import TagNotFoundError, ValidationError
+from app.core.exceptions import (
+    ConcurrentModificationError,
+    TagNotFoundError,
+    ValidationError,
+)
 from app.core.logging_config import log_error, log_warning
 from app.integrations.schemas import MomentImmichPeopleSuggestionsResponse
 from app.models.enums import GoalLogStatus
@@ -655,6 +659,12 @@ async def get_moment(
         401: {"description": "Not authenticated"},
         403: {"description": "Account inactive"},
         404: {"description": "Moment not found"},
+        409: {
+            "description": (
+                "The entry changed since `entry_update.expected_updated_at`; "
+                "saving would discard that other edit"
+            )
+        },
         500: {"description": "Internal server error"},
     },
 )
@@ -675,6 +685,8 @@ async def update_moment(
         )
     except MomentNotFoundError:
         raise HTTPException(status_code=404, detail="Moment not found") from None
+    except ConcurrentModificationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from None
     except (ValueError, ValidationError) as exc:
         log_error(exc)
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -107,6 +107,23 @@ class ValidationError(JournivAppException):
     pass
 
 
+class ConcurrentModificationError(JournivAppException):
+    """Raised when an update is based on a version that is no longer current.
+
+    A client that sends ``expected_updated_at`` is saying "I edited the version
+    that looked like this". If the row has moved on since — another device, a
+    second tab — writing anyway would silently discard whatever that other write
+    said. The update is refused instead, and the caller is told, so the person
+    doing the writing gets to decide.
+
+    Clients that send nothing keep the previous last-write-wins behaviour.
+    """
+
+    def __init__(self, message: str, current_updated_at=None):
+        super().__init__(message)
+        self.current_updated_at = current_updated_at
+
+
 class LicenseResetInstallIdMismatchError(JournivAppException):
     """Raised when license reset install_id does not match this instance."""
     pass

--- a/app/schemas/entry.py
+++ b/app/schemas/entry.py
@@ -108,6 +108,15 @@ class EntryUpdate(BaseModel):
     content_delta: Optional[QuillDelta] = None
     journal_id: Optional[uuid.UUID] = None
     is_draft: Optional[bool] = None
+    expected_updated_at: Optional[datetime] = Field(
+        default=None,
+        description=(
+            "The entry's `updated_at` as the client last saw it. When given, the "
+            "update is refused with 409 if the entry has changed since, so a save "
+            "cannot silently discard an edit made on another device. Omit it for "
+            "last-write-wins."
+        ),
+    )
 
 
 class EntryResponse(EntryBase, TimestampMixin):

--- a/app/services/entry_service.py
+++ b/app/services/entry_service.py
@@ -12,13 +12,14 @@ from sqlalchemy.orm.attributes import QueryableAttribute
 from sqlmodel import Session, col, select
 
 from app.core.exceptions import (
+    ConcurrentModificationError,
     EntryNotFoundError,
     JournalNotFoundError,
     MediaNotFoundError,
     ValidationError,
 )
 from app.core.logging_config import log_debug, log_error, log_info, log_warning
-from app.core.time_utils import utc_now
+from app.core.time_utils import ensure_utc, utc_now
 from app.models.entry import Entry
 from app.models.journal import Journal
 from app.models.moment import MomentMedia
@@ -414,9 +415,32 @@ class EntryService:
 
         return list(self.session.exec(statement))
 
+    @staticmethod
+    def _check_expected_version(entry: Entry, expected_updated_at) -> None:
+        """Refuse an update built on a version the entry has moved past.
+
+        Compared as instants rather than as strings: the client sends back what
+        it was given, but a timezone-naive column and an offset-bearing payload
+        are the same moment and must compare equal.
+        """
+        if expected_updated_at is None:
+            return
+        current = ensure_utc(entry.updated_at)
+        if ensure_utc(expected_updated_at) == current:
+            return
+        log_info(
+            f"Refused concurrent update of entry {entry.id}: "
+            f"expected {expected_updated_at}, current {current}"
+        )
+        raise ConcurrentModificationError(
+            "This entry changed somewhere else since it was opened",
+            current_updated_at=current,
+        )
+
     def update_entry(self, entry_id: uuid.UUID, user_id: uuid.UUID, entry_data: EntryUpdate) -> Entry:
         """Update an entry — content fields only. Metadata lives on Moment."""
         entry = self._get_owned_entry(entry_id, user_id)
+        self._check_expected_version(entry, entry_data.expected_updated_at)
         was_draft = entry.is_draft
         media_service = MediaService(self.session)
 

--- a/tests/integration/test_entry_concurrency_endpoints.py
+++ b/tests/integration/test_entry_concurrency_endpoints.py
@@ -1,0 +1,111 @@
+"""
+The 409 must reach the wire, through both routes that update an entry.
+
+The editor saves either through `PUT /entries/{id}` or, when it is finalising a
+draft Moment, through `PUT /moments/{id}` with `entry_update`. Both must refuse
+a stale save, or a save takes whichever path happens to apply that day and the
+protection is only sometimes there.
+"""
+from datetime import date
+
+from tests.lib import ApiUser, JournivApiClient
+
+
+def _entry(api_client: JournivApiClient, api_user: ApiUser, journal_id: str):
+    return api_client.create_entry_with_moment(
+        api_user.access_token,
+        journal_id=journal_id,
+        title="Opened on two devices",
+        content="First device wrote this.",
+        logged_date=date.today().isoformat(),
+    )
+
+
+def test_stale_save_is_refused_on_the_entry_route(
+    api_client: JournivApiClient, api_user: ApiUser, journal_factory
+):
+    created = _entry(api_client, api_user, journal_factory()["id"])
+    opened_at = api_client.get_entry(api_user.access_token, created["id"])["updated_at"]
+
+    # The other device saves first.
+    api_client.update_entry(
+        api_user.access_token, created["id"], {"content": "Second device wrote this."}
+    )
+
+    refused = api_client.request(
+        "PUT",
+        f"/entries/{created['id']}",
+        token=api_user.access_token,
+        json={
+            "content_delta": {"ops": [{"insert": "First device, saving late.\n"}]},
+            "expected_updated_at": opened_at,
+        },
+        expected=(409,),
+    )
+    assert "changed somewhere else" in refused.json()["detail"]
+
+    # And the other device's writing is still there.
+    kept = api_client.get_entry(api_user.access_token, created["id"])
+    assert "Second device wrote this." in kept["content_plain_text"]
+
+
+def test_current_version_round_trips_through_the_entry_route(
+    api_client: JournivApiClient, api_user: ApiUser, journal_factory
+):
+    """The value the API hands out must be the value it accepts back.
+
+    This is the whole contract: serialise, send, parse, compare. A format or
+    precision mismatch anywhere in that loop would refuse every honest save.
+    """
+    created = _entry(api_client, api_user, journal_factory()["id"])
+    opened_at = api_client.get_entry(api_user.access_token, created["id"])["updated_at"]
+
+    api_client.request(
+        "PUT",
+        f"/entries/{created['id']}",
+        token=api_user.access_token,
+        json={
+            "content_delta": {"ops": [{"insert": "Saved from the version I read.\n"}]},
+            "expected_updated_at": opened_at,
+        },
+        expected=(200,),
+    )
+
+
+def test_stale_save_is_refused_on_the_moment_route(
+    api_client: JournivApiClient, api_user: ApiUser, journal_factory
+):
+    created = _entry(api_client, api_user, journal_factory()["id"])
+    opened_at = api_client.get_entry(api_user.access_token, created["id"])["updated_at"]
+
+    api_client.update_entry(
+        api_user.access_token, created["id"], {"content": "Second device wrote this."}
+    )
+
+    api_client.request(
+        "PUT",
+        f"/moments/{created['moment_id']}",
+        token=api_user.access_token,
+        json={
+            "entry_update": {
+                "content_delta": {"ops": [{"insert": "Late save.\n"}]},
+                "expected_updated_at": opened_at,
+            }
+        },
+        expected=(409,),
+    )
+
+
+def test_omitting_the_version_still_saves(
+    api_client: JournivApiClient, api_user: ApiUser, journal_factory
+):
+    """Existing clients — the Flutter app included — send nothing and must work."""
+    created = _entry(api_client, api_user, journal_factory()["id"])
+    api_client.update_entry(
+        api_user.access_token, created["id"], {"content": "Anywhere."}
+    )
+    api_client.update_entry(
+        api_user.access_token, created["id"], {"content": "Overwritten, as before."}
+    )
+    kept = api_client.get_entry(api_user.access_token, created["id"])
+    assert "Overwritten, as before." in kept["content_plain_text"]

--- a/tests/unit/services/test_entry_service_concurrency.py
+++ b/tests/unit/services/test_entry_service_concurrency.py
@@ -1,0 +1,156 @@
+"""
+An update built on a stale version must be refused, not silently applied.
+
+Journiv has no autosave: an editor holds a whole entry in memory and writes it
+back on Done. Two devices open on the same entry therefore mean the second Done
+replaces everything the first one wrote, with nothing to show that it happened.
+
+`EntryUpdate.expected_updated_at` closes that: a client that sends the version
+it edited gets a `ConcurrentModificationError` instead of a silent overwrite.
+Sending nothing keeps the old last-write-wins behaviour, so existing clients —
+the Flutter app among them — are unaffected.
+"""
+import uuid
+from datetime import timedelta
+
+import pytest
+from sqlmodel import Session, create_engine
+
+from app.core.exceptions import ConcurrentModificationError
+from app.core.time_utils import ensure_utc
+from app.models.base import BaseModel
+from app.models.entry import Entry
+from app.models.journal import Journal
+from app.models.moment import Moment
+from app.models.user import User
+from app.schemas.entry import EntryUpdate, QuillDelta
+from app.services.entry_service import EntryService
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    BaseModel.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _fixtures(session: Session):
+    user = User(email=f"c_{uuid.uuid4().hex[:8]}@example.com", password="x", name="C")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    journal = Journal(user_id=user.id, title="J")
+    moment = Moment(user_id=user.id)
+    session.add(journal)
+    session.add(moment)
+    session.commit()
+    session.refresh(journal)
+    session.refresh(moment)
+
+    entry = Entry(
+        user_id=user.id,
+        journal_id=journal.id,
+        moment_id=moment.id,
+        title="First",
+        content_delta={"ops": [{"insert": "one\n"}]},
+    )
+    session.add(entry)
+    session.commit()
+    session.refresh(entry)
+    return user, entry
+
+
+def _delta(text: str) -> QuillDelta:
+    return QuillDelta(ops=[{"insert": text}])
+
+
+def test_matching_version_is_accepted():
+    session = _session()
+    user, entry = _fixtures(session)
+    service = EntryService(session)
+
+    # Captured before the update: `entry` is the live ORM object and moves with it.
+    opened_at = ensure_utc(entry.updated_at)
+
+    updated = service.update_entry(
+        entry.id,
+        user.id,
+        EntryUpdate(
+            title="Second",
+            content_delta=_delta("two\n"),
+            expected_updated_at=opened_at,
+        ),
+    )
+
+    assert updated.title == "Second"
+    # And the version moves on, so the same save cannot be replayed — which is
+    # what makes the check worth anything at all.
+    assert ensure_utc(updated.updated_at) > opened_at
+    with pytest.raises(ConcurrentModificationError):
+        service.update_entry(
+            entry.id, user.id, EntryUpdate(title="Third", expected_updated_at=opened_at)
+        )
+
+
+def test_stale_version_is_refused_and_nothing_is_written():
+    session = _session()
+    user, entry = _fixtures(session)
+    service = EntryService(session)
+    stale = ensure_utc(entry.updated_at) - timedelta(seconds=5)
+
+    with pytest.raises(ConcurrentModificationError):
+        service.update_entry(
+            entry.id,
+            user.id,
+            EntryUpdate(title="Second", content_delta=_delta("two\n"),
+                        expected_updated_at=stale),
+        )
+
+    session.expire_all()
+    unchanged = session.get(Entry, entry.id)
+    assert unchanged.title == "First"
+    assert unchanged.content_delta == {"ops": [{"insert": "one\n"}]}
+
+
+def test_omitting_the_version_keeps_last_write_wins():
+    session = _session()
+    user, entry = _fixtures(session)
+    service = EntryService(session)
+
+    updated = service.update_entry(
+        entry.id, user.id, EntryUpdate(title="Second", content_delta=_delta("two\n"))
+    )
+
+    assert updated.title == "Second"
+
+
+def test_a_naive_timestamp_is_still_the_same_instant():
+    """The column may come back naive; the client always sends an offset.
+
+    Comparing those as strings would refuse every save. They are compared as
+    instants for exactly this reason.
+    """
+    session = _session()
+    user, entry = _fixtures(session)
+    service = EntryService(session)
+    naive = ensure_utc(entry.updated_at).replace(tzinfo=None)
+
+    updated = service.update_entry(
+        entry.id, user.id, EntryUpdate(title="Second", expected_updated_at=naive)
+    )
+
+    assert updated.title == "Second"
+
+
+def test_the_error_carries_the_version_that_is_actually_current():
+    session = _session()
+    user, entry = _fixtures(session)
+    service = EntryService(session)
+    stale = ensure_utc(entry.updated_at) - timedelta(minutes=1)
+
+    with pytest.raises(ConcurrentModificationError) as caught:
+        service.update_entry(
+            entry.id, user.id, EntryUpdate(title="x", expected_updated_at=stale)
+        )
+
+    assert caught.value.current_updated_at == ensure_utc(entry.updated_at)


### PR DESCRIPTION
Accept an optional expected_updated_at value on Entry updates and compare it with the persisted version before writing. Return HTTP 409 from both Entry and Moment update routes when another client has already changed the Entry.

Keep last-write-wins behavior for existing clients that omit the version and cover service, timestamp normalization, and endpoint behavior with unit and integration tests.

#400 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimistic concurrency protection for entry updates.
  * Clients can provide the last-seen update timestamp to prevent overwriting newer changes.
  * Conflicting edits now return HTTP 409 with the current version information.
  * Existing updates without a version remain supported.

* **Bug Fixes**
  * Prevented stale saves from silently replacing changes made elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->