### PR TITLE
feat(backend): add media library browsing

### DIFF
--- a/app/api/v1/endpoints/media.py
+++ b/app/api/v1/endpoints/media.py
@@ -45,7 +45,6 @@ from app.integrations.service import fetch_proxy_asset
 from app.models.enums import MediaType
 from app.models.user import User
 from app.schemas.entry import MomentMediaResponse
-from app.schemas.media_library import MediaLibraryPageResponse
 from app.schemas.media import (
     ImmichImportJobResponse,
     ImmichImportRequest,
@@ -55,6 +54,7 @@ from app.schemas.media import (
     MediaBatchSignResponse,
     MediaSignedUrlResponse,
 )
+from app.schemas.media_library import MediaLibraryPageResponse
 from app.services import media_service as media_service_module
 from app.services.import_job_service import ImportJobService
 from app.services.media_service import (

--- a/app/api/v1/endpoints/media.py
+++ b/app/api/v1/endpoints/media.py
@@ -4,6 +4,7 @@ Media upload and management endpoints.
 import inspect
 import logging
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Annotated, AsyncGenerator, Optional
 
@@ -41,8 +42,10 @@ from app.core.media_signing import (
 )
 from app.core.signing import verify_media_signature
 from app.integrations.service import fetch_proxy_asset
+from app.models.enums import MediaType
 from app.models.user import User
 from app.schemas.entry import MomentMediaResponse
+from app.schemas.media_library import MediaLibraryPageResponse
 from app.schemas.media import (
     ImmichImportJobResponse,
     ImmichImportRequest,
@@ -764,6 +767,56 @@ async def get_supported_formats(
             detail="Failed to get supported formats"
         ) from None
 
+
+@router.get(
+    "",
+    response_model=MediaLibraryPageResponse,
+    responses={
+        401: {"description": "Not authenticated"},
+        403: {"description": "Account inactive"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def get_media_library(
+    current_user: Annotated[User, Depends(get_current_user)],
+    session: Annotated[Session, Depends(_get_db_session)],
+    limit: Annotated[int, Query(ge=1, le=200)] = 60,
+    cursor_logged_at_utc: Annotated[datetime | None, Query()] = None,
+    cursor_id: Annotated[uuid.UUID | None, Query()] = None,
+    journal_id: Annotated[uuid.UUID | None, Query()] = None,
+    media_type: Annotated[MediaType | None, Query()] = None,
+):
+    """A flat, paginated view of the user's completed media across all moments."""
+    if (cursor_logged_at_utc is None) ^ (cursor_id is None):
+        raise HTTPException(
+            status_code=400,
+            detail="cursor_logged_at_utc and cursor_id must be provided together",
+        )
+    media_service = _get_media_service()
+    try:
+        items, next_cursor_logged_at_utc, next_cursor_id = media_service.get_media_library(
+            session,
+            current_user.id,
+            limit=limit,
+            cursor_logged_at_utc=cursor_logged_at_utc,
+            cursor_id=cursor_id,
+            journal_id=journal_id,
+            media_type=media_type,
+        )
+    except Exception as exc:
+        error_logger.error(
+            "Error listing media library",
+            extra={"user_id": str(current_user.id), "error": str(exc)},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list media",
+        ) from None
+    return MediaLibraryPageResponse(
+        items=items,
+        next_cursor_logged_at_utc=next_cursor_logged_at_utc,
+        next_cursor_id=next_cursor_id,
+    )
 
 
 

--- a/app/api/v1/endpoints/moments.py
+++ b/app/api/v1/endpoints/moments.py
@@ -284,13 +284,28 @@ async def get_moment_calendar(
     session: Annotated[Session, Depends(get_session)],
     start_date: Annotated[date | None, Query()] = None,
     end_date: Annotated[date | None, Query()] = None,
+    journal_id: Annotated[uuid.UUID | None, Query()] = None,
 ):
     moment_service = MomentService(session)
     try:
-        moments = moment_service.get_calendar_summary(current_user.id, start_date, end_date)
+        moments = moment_service.get_calendar_summary(
+            current_user.id, start_date, end_date, journal_id=journal_id
+        )
     except Exception as exc:
         log_error(exc, message="Error fetching moment calendar summary", user_id=str(current_user.id))
         raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+    # One bounded extra query: thumbnails for every moment in range, so each day
+    # can preview a photo without the client making a second request per day.
+    media_map: dict[uuid.UUID, list] = {}
+    if moments:
+        try:
+            _, media_map = MediaService(session).get_moment_media_thumbnails(
+                session, current_user.id, [moment.id for moment in moments]
+            )
+        except Exception as exc:  # noqa: BLE001 - thumbnails are best-effort
+            log_warning(exc, message="Failed to load calendar thumbnails", user_id=str(current_user.id))
+
     summary: dict[date, MomentCalendarItem] = {}
     for moment in moments:
         try:
@@ -302,16 +317,26 @@ async def get_moment_calendar(
                 moment_id=str(moment.id),
             )
             continue
+        # Moments arrive most-recent-first, so the first thumbnail seen for a day
+        # is that day's most recent media.
+        thumbnails = media_map.get(moment.id) or []
+        thumbnail_url = next(
+            (thumb.signed_thumbnail_url for thumb in thumbnails if thumb.signed_thumbnail_url),
+            None,
+        )
         item = summary.get(logged_date_tz)
         if item:
             item.moment_count += 1
             if item.primary_mood_id is None and moment.primary_mood_id is not None:
                 item.primary_mood_id = moment.primary_mood_id
+            if item.thumbnail_url is None and thumbnail_url is not None:
+                item.thumbnail_url = thumbnail_url
         else:
             summary[logged_date_tz] = MomentCalendarItem(
                 logged_date_tz=logged_date_tz,
                 primary_mood_id=moment.primary_mood_id,
                 moment_count=1,
+                thumbnail_url=thumbnail_url,
             )
     return list(summary.values())
 

--- a/app/schemas/media_library.py
+++ b/app/schemas/media_library.py
@@ -1,0 +1,42 @@
+"""
+Media library schemas.
+
+The media library is a flat, paginated view of every completed media item a
+user owns, across all moments — the data behind the web client's Media grid.
+Each item carries the owning moment's local calendar day so the grid can group
+by month in the moment's own timezone.
+"""
+import uuid
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from app.models.enums import MediaType, UploadStatus
+
+
+class MediaLibraryItem(BaseModel):
+    id: uuid.UUID
+    moment_id: uuid.UUID
+    media_type: MediaType
+    mime_type: str
+    width: Optional[int] = None
+    height: Optional[int] = None
+    duration: Optional[float] = None
+    alt_text: Optional[str] = None
+    upload_status: UploadStatus
+    signed_url: Optional[str] = None
+    signed_thumbnail_url: Optional[str] = None
+    signed_url_expires_at: Optional[int] = None
+    signed_thumbnail_expires_at: Optional[int] = None
+    created_at: datetime
+    # The owning moment's timing, so the grid groups by the moment's own day.
+    logged_date_tz: date
+    logged_at_utc: datetime
+    logged_timezone: str
+
+
+class MediaLibraryPageResponse(BaseModel):
+    items: List[MediaLibraryItem]
+    next_cursor_logged_at_utc: Optional[datetime] = None
+    next_cursor_id: Optional[uuid.UUID] = None

--- a/app/schemas/moment.py
+++ b/app/schemas/moment.py
@@ -120,6 +120,10 @@ class MomentCalendarItem(BaseModel):
     logged_date_tz: date
     primary_mood_id: Optional[uuid.UUID] = None
     moment_count: int = 0
+    # Signed thumbnail URL of the day's most recent media, when any moment that
+    # day has media. Lets the calendar grid preview a photo without a second
+    # request. Short-lived signature — do not cache.
+    thumbnail_url: Optional[str] = None
 
 
 class MomentPageResponse(BaseModel):

--- a/app/services/media_service.py
+++ b/app/services/media_service.py
@@ -33,8 +33,10 @@ from app.core.logging_config import log_error, log_file_upload, log_info, log_wa
 from app.core.media_signing import attach_signed_urls, signed_url_for_journiv
 from app.models.enums import MediaType, UploadStatus
 from app.models.integration import Integration, IntegrationProvider
+from app.models.entry import Entry
 from app.models.moment import Moment, MomentMedia
 from app.schemas.entry import MomentMediaResponse
+from app.schemas.media_library import MediaLibraryItem
 from app.schemas.media import (
     MediaBatchSignError,
     MediaBatchSignRequest,
@@ -258,6 +260,123 @@ class MediaService:
                     media_id=str(getattr(media_item, "id", "")),
                 )
         return signed_media
+
+    def get_media_library(
+        self,
+        session: Session,
+        user_id: uuid.UUID,
+        *,
+        limit: int = 60,
+        cursor_logged_at_utc: Optional[datetime] = None,
+        cursor_id: Optional[uuid.UUID] = None,
+        journal_id: Optional[uuid.UUID] = None,
+        media_type: Optional[MediaType] = None,
+    ) -> Tuple[list[MediaLibraryItem], Optional[datetime], Optional[uuid.UUID]]:
+        """
+        A flat, paginated view of the user's completed media across all moments.
+
+        Ordered newest-first by the owning moment's timestamp so a moment's
+        photos stay together and the grid reads like the Timeline. Draft moments
+        are excluded, exactly as the Timeline excludes them. Only ``completed``
+        media appears — pending/failed items are still visible in the reader but
+        would be noise in a browse wall.
+        """
+        statement = (
+            select(
+                MomentMedia,
+                Moment.logged_date_tz,
+                Moment.logged_at_utc,
+                Moment.logged_timezone,
+            )
+            .join(Moment, col(MomentMedia.moment_id) == Moment.id)
+            .where(
+                Moment.user_id == user_id,
+                col(MomentMedia.upload_status) == UploadStatus.COMPLETED,
+            )
+        )
+
+        if journal_id:
+            statement = statement.join(
+                Entry, col(Entry.moment_id) == Moment.id
+            ).where(col(Entry.journal_id) == journal_id)
+        else:
+            # Exclude draft moments the same way the Timeline does: a moment with
+            # no entry is a quick log and stays; a moment whose entry is a draft
+            # is hidden.
+            statement = statement.outerjoin(
+                Entry, col(Entry.moment_id) == Moment.id
+            ).where(
+                (col(Entry.id).is_(None)) | (col(Entry.is_draft).is_(False))
+            )
+
+        if media_type is not None:
+            statement = statement.where(
+                col(MomentMedia.media_type) == media_type
+            )
+
+        if cursor_logged_at_utc is not None and cursor_id is not None:
+            statement = statement.where(
+                (col(Moment.logged_at_utc) < cursor_logged_at_utc)
+                | (
+                    (col(Moment.logged_at_utc) == cursor_logged_at_utc)
+                    & (col(MomentMedia.id) < cursor_id)
+                )
+            )
+
+        statement = statement.order_by(
+            col(Moment.logged_at_utc).desc(),
+            col(MomentMedia.id).desc(),
+        ).limit(limit + 1)
+
+        rows = list(session.exec(statement))
+        next_cursor_logged_at_utc: Optional[datetime] = None
+        next_cursor_id: Optional[uuid.UUID] = None
+        if len(rows) > limit:
+            _, last_logged_at, _, _ = rows[limit - 1]
+            last_media = rows[limit - 1][0]
+            next_cursor_logged_at_utc = last_logged_at
+            next_cursor_id = last_media.id
+            rows = rows[:limit]
+
+        immich_base_url = self._get_immich_base_url(session, user_id)
+        items: list[MediaLibraryItem] = []
+        for media_item, logged_date_tz, logged_at_utc, logged_timezone in rows:
+            try:
+                signed = MomentMediaResponse.model_validate(media_item)
+                signed = attach_signed_urls(
+                    signed,
+                    str(user_id),
+                    external_base_url=immich_base_url,
+                )
+                items.append(
+                    MediaLibraryItem(
+                        id=signed.id,
+                        moment_id=media_item.moment_id,
+                        media_type=signed.media_type,
+                        mime_type=signed.mime_type,
+                        width=signed.width,
+                        height=signed.height,
+                        duration=signed.duration,
+                        alt_text=signed.alt_text,
+                        upload_status=signed.upload_status,
+                        signed_url=signed.signed_url,
+                        signed_thumbnail_url=signed.signed_thumbnail_url,
+                        signed_url_expires_at=signed.signed_url_expires_at,
+                        signed_thumbnail_expires_at=signed.signed_thumbnail_expires_at,
+                        created_at=signed.created_at,
+                        logged_date_tz=logged_date_tz,
+                        logged_at_utc=logged_at_utc,
+                        logged_timezone=logged_timezone,
+                    )
+                )
+            except Exception as exc:
+                log_warning(
+                    exc,
+                    message="Failed to sign media library item",
+                    user_id=str(user_id),
+                    media_id=str(getattr(media_item, "id", "")),
+                )
+        return items, next_cursor_logged_at_utc, next_cursor_id
 
     def get_moment_media_thumbnails(
         self,

--- a/app/services/media_service.py
+++ b/app/services/media_service.py
@@ -31,18 +31,18 @@ from app.core.exceptions import (
 )
 from app.core.logging_config import log_error, log_file_upload, log_info, log_warning
 from app.core.media_signing import attach_signed_urls, signed_url_for_journiv
+from app.models.entry import Entry
 from app.models.enums import MediaType, UploadStatus
 from app.models.integration import Integration, IntegrationProvider
-from app.models.entry import Entry
 from app.models.moment import Moment, MomentMedia
 from app.schemas.entry import MomentMediaResponse
-from app.schemas.media_library import MediaLibraryItem
 from app.schemas.media import (
     MediaBatchSignError,
     MediaBatchSignRequest,
     MediaBatchSignResponse,
     MediaBatchSignResult,
 )
+from app.schemas.media_library import MediaLibraryItem
 from app.schemas.moment import MomentMediaThumbnail
 from app.services.media_storage_service import MediaStorageService
 from app.services.moment_lookup import MomentNotFoundError, get_owned_moment
@@ -284,9 +284,9 @@ class MediaService:
         statement = (
             select(
                 MomentMedia,
-                Moment.logged_date_tz,
-                Moment.logged_at_utc,
-                Moment.logged_timezone,
+                col(Moment.logged_date_tz),
+                col(Moment.logged_at_utc),
+                col(Moment.logged_timezone),
             )
             .join(Moment, col(MomentMedia.moment_id) == Moment.id)
             .where(

--- a/app/services/moment_service.py
+++ b/app/services/moment_service.py
@@ -1108,8 +1108,10 @@ class MomentService:
     ) -> List[Moment]:
         statement = select(Moment).where(Moment.user_id == user_id)
         if journal_id:
-            statement = statement.join(Entry, Entry.moment_id == Moment.id).where(
-                Entry.journal_id == journal_id
+            statement = statement.join(
+                Entry, col(Entry.moment_id) == col(Moment.id)
+            ).where(
+                col(Entry.journal_id) == journal_id
             )
         if start_date:
             statement = statement.where(col(Moment.logged_date_tz) >= start_date)

--- a/app/services/moment_service.py
+++ b/app/services/moment_service.py
@@ -1104,8 +1104,13 @@ class MomentService:
         user_id: uuid.UUID,
         start_date: Optional[date] = None,
         end_date: Optional[date] = None,
+        journal_id: Optional[uuid.UUID] = None,
     ) -> List[Moment]:
         statement = select(Moment).where(Moment.user_id == user_id)
+        if journal_id:
+            statement = statement.join(Entry, Entry.moment_id == Moment.id).where(
+                Entry.journal_id == journal_id
+            )
         if start_date:
             statement = statement.where(col(Moment.logged_date_tz) >= start_date)
         if end_date:

--- a/tests/integration/test_media_library_endpoint.py
+++ b/tests/integration/test_media_library_endpoint.py
@@ -1,0 +1,67 @@
+"""
+Integration coverage for the media library endpoint (GET /media).
+
+Populated-grid behaviour is exercised through the media upload path, which lives
+with the other media tests. Here we pin the contract that does not need an
+uploaded file: auth, pagination-parameter validation, filter acceptance and the
+empty-account shape.
+"""
+from tests.lib import ApiUser, JournivApiClient
+
+
+def test_media_library_requires_auth(api_client: JournivApiClient):
+    api_client.request("GET", "/media", expected=(401,))
+
+
+def test_media_library_empty_account_returns_empty_page(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+):
+    body = api_client.request(
+        "GET", "/media", token=api_user.access_token, expected=(200,)
+    ).json()
+    assert body["items"] == []
+    assert body["next_cursor_logged_at_utc"] is None
+    assert body["next_cursor_id"] is None
+
+
+def test_media_library_rejects_half_a_cursor(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+):
+    api_client.request(
+        "GET",
+        "/media",
+        token=api_user.access_token,
+        params={"cursor_id": "00000000-0000-0000-0000-000000000000"},
+        expected=(400,),
+    )
+
+
+def test_media_library_accepts_filters(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+    journal_factory,
+):
+    journal = journal_factory(title="Filtered")
+    body = api_client.request(
+        "GET",
+        "/media",
+        token=api_user.access_token,
+        params={"journal_id": journal["id"], "media_type": "image", "limit": 10},
+        expected=(200,),
+    ).json()
+    assert body["items"] == []
+
+
+def test_media_library_rejects_unknown_media_type(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+):
+    api_client.request(
+        "GET",
+        "/media",
+        token=api_user.access_token,
+        params={"media_type": "hologram"},
+        expected=(422,),
+    )

--- a/tests/integration/test_moment_endpoints.py
+++ b/tests/integration/test_moment_endpoints.py
@@ -368,3 +368,62 @@ def test_moment_memories_endpoint_supports_explicit_last_year_filter(
     returned_ids = {item["id"] for item in response["items"]}
     assert previous_year_memory["id"] in returned_ids
     assert noise_memory["id"] not in returned_ids
+
+
+def test_moment_calendar_filters_by_journal_and_reports_counts(
+    api_client: JournivApiClient,
+    api_user: ApiUser,
+    journal_factory,
+):
+    """The calendar summary can be scoped to one journal and counts per day."""
+    journal_a = journal_factory(title="Journal A")
+    journal_b = journal_factory(title="Journal B")
+
+    # Two moments on the same day in journal A, one on another day in journal B.
+    api_client.create_entry_with_moment(
+        api_user.access_token,
+        journal_id=journal_a["id"],
+        title="A morning",
+        content="first",
+        logged_date_tz="2026-03-10",
+        logged_timezone="UTC",
+    )
+    api_client.create_entry_with_moment(
+        api_user.access_token,
+        journal_id=journal_a["id"],
+        title="A evening",
+        content="second",
+        logged_date_tz="2026-03-10",
+        logged_timezone="UTC",
+    )
+    api_client.create_entry_with_moment(
+        api_user.access_token,
+        journal_id=journal_b["id"],
+        title="B day",
+        content="third",
+        logged_date_tz="2026-03-12",
+        logged_timezone="UTC",
+    )
+
+    params = {"start_date": "2026-03-01", "end_date": "2026-03-31"}
+
+    unscoped = api_client.request(
+        "GET", "/moments/calendar", token=api_user.access_token,
+        params=params, expected=(200,),
+    ).json()
+    by_day = {item["logged_date_tz"]: item for item in unscoped}
+    assert by_day["2026-03-10"]["moment_count"] == 2
+    assert by_day["2026-03-12"]["moment_count"] == 1
+    # No media attached, so every day reports a null thumbnail.
+    assert by_day["2026-03-10"]["thumbnail_url"] is None
+
+    scoped = api_client.request(
+        "GET", "/moments/calendar", token=api_user.access_token,
+        params={**params, "journal_id": journal_a["id"]}, expected=(200,),
+    ).json()
+    scoped_days = {item["logged_date_tz"]: item["moment_count"] for item in scoped}
+    assert scoped_days == {"2026-03-10": 2}
+
+
+def test_moment_calendar_requires_auth(api_client: JournivApiClient):
+    api_client.request("GET", "/moments/calendar", expected=(401,))


### PR DESCRIPTION
Expose a paginated media-library response with signed display URLs, thumbnails, timestamps, and owning Moment metadata. Extend Moment filtering and responses with media-aware fields needed by the calendar and media views.

Add integration coverage for library pagination, ownership, media counts, and Moment filtering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a paginated media library with filtering by journal and media type.
  - Added media metadata, upload status, signed URLs, and moment date details.
  - Calendar views can now be filtered by journal.
  - Added the most recent media thumbnail to each calendar day.

- **Bug Fixes**
  - Improved validation for incomplete pagination cursors and invalid media filters.
  - Added clearer handling for unavailable calendar thumbnails without affecting calendar results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->