### PR TITLE
feat(backend): expose public Plus capabilities

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -316,6 +316,34 @@ async def get_plus_factory(
         ) from None
 
 
+# Paid Plus tiers. "member" is the free / unlicensed state. A registered
+# license is always "supporter" or "believer" today; asserting the tier (rather
+# than mere signature validity) keeps a future free-tier license from unlocking
+# tier-gated features.
+PLUS_SUPPORTER_TIERS = frozenset({"supporter", "believer"})
+
+
+def require_supporter_tier(license_data: Dict[str, Any]) -> None:
+    """
+    Assert a verified license is at least the "supporter" tier.
+
+    Call directly after :func:`get_plus_factory` on endpoints that need a paid
+    tier. Raises 403 with a human message otherwise.
+    """
+    from app.core.config import JOURNIV_PLUS_DOC_URL
+
+    tier = license_data.get("tier")
+    if tier not in PLUS_SUPPORTER_TIERS:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "plus_tier_required",
+                "message": "This feature requires a Journiv Plus Supporter licence or higher.",
+                "upgrade_url": JOURNIV_PLUS_DOC_URL,
+            },
+        )
+
+
 async def get_current_admin_user(
     current_user: Annotated[User, Depends(get_current_user)]
 ) -> User:

--- a/app/api/v1/endpoints/instance_config.py
+++ b/app/api/v1/endpoints/instance_config.py
@@ -1,9 +1,14 @@
 """
 Instance configuration endpoints.
 """
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
 
 from app.core.config import settings
+from app.core.database import get_session
+from app.core.plus_capability import get_plus_capability
 from app.schemas.instance import InstanceConfigResponse
 
 router = APIRouter(prefix="/instance", tags=["instance"])
@@ -18,12 +23,15 @@ router = APIRouter(prefix="/instance", tags=["instance"])
         500: {"description": "Internal server error"},
     }
 )
-async def get_instance_config() -> InstanceConfigResponse:
+async def get_instance_config(
+    session: Annotated[Session, Depends(get_session)],
+) -> InstanceConfigResponse:
     """
     Get public instance configuration.
 
     Returns non-sensitive instance configuration settings for the frontend,
-    including import/export file size limits and signup status.
+    including import/export file size limits, signup status, and this
+    instance's Journiv Plus capability (see ``PlusCapability``).
     """
     return InstanceConfigResponse(
         import_export_max_file_size_mb=settings.import_export_max_file_size_mb,
@@ -34,4 +42,5 @@ async def get_instance_config() -> InstanceConfigResponse:
         immich_base_url=settings.immich_base_url,
         oidc_enabled=settings.oidc_enabled,
         oidc_only=settings.oidc_only,
+        plus=get_plus_capability(session),
     )

--- a/app/core/plus_capability.py
+++ b/app/core/plus_capability.py
@@ -1,0 +1,110 @@
+"""
+Derive this instance's public Journiv Plus capability.
+
+Used by ``GET /instance/config`` so the frontend can gate Plus-only surfaces
+(tag analytics, publishing, …) without probing a protected endpoint and
+interpreting 403/503. The result carries capability flags only — see
+:class:`app.schemas.instance.PlusCapability`.
+
+Enforcement still lives on the protected endpoints themselves
+(:func:`app.api.dependencies.get_plus_factory` + tier checks); this is a hint
+for the UI, computed locally with no network call.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from datetime import datetime, timezone
+from importlib import import_module
+from typing import Any, Dict, Optional
+
+from sqlmodel import Session, select
+
+from app.core.config import JOURNIV_PLUS_DOC_URL
+from app.core.logging_config import LogCategory
+from app.models.instance_detail import InstanceDetail
+from app.schemas.instance import PlusCapability
+
+logger = logging.getLogger(LogCategory.PLUS)
+
+# Paid tiers. "member" is the unlicensed / free state.
+SUPPORTER_TIERS = frozenset({"supporter", "believer"})
+DEFAULT_TIER = "member"
+
+
+def _decode_claim_unverified(signed_license_b64: str) -> Optional[Dict[str, Any]]:
+    """
+    Read the license claim payload WITHOUT checking its signature.
+
+    Only used when the compiled Plus module (which owns real verification) is
+    not importable in this process — i.e. proxy mode, where the sidecar is the
+    authority. Good enough for a UI hint; never for enforcement.
+    """
+    try:
+        envelope = json.loads(base64.b64decode(signed_license_b64, validate=True))
+        payload = json.loads(base64.b64decode(envelope["payload"], validate=True))
+        return payload if isinstance(payload, dict) else None
+    except Exception:  # noqa: BLE001 - any malformed input is simply "no claim"
+        return None
+
+
+def _claim_is_current(claim: Dict[str, Any]) -> bool:
+    """True when neither the signed-license nor the subscription window has passed."""
+    now = datetime.now(timezone.utc)
+    for key in ("signed_license_expires_at", "subscription_expires_at"):
+        raw = claim.get(key)
+        if not raw:
+            continue
+        try:
+            expires = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=timezone.utc)
+        if now > expires:
+            return False
+    return True
+
+
+def _resolve_tier(signed_license_b64: str, install_id: str) -> str:
+    """Resolve the tier from a stored signed license, verifying it when possible."""
+    try:
+        security = import_module("app.plus.core.security")
+    except (ModuleNotFoundError, ImportError):
+        security = None
+
+    if security is not None:
+        try:
+            claim: Optional[Dict[str, Any]] = security.verify_license_signature(
+                signed_license_base64=signed_license_b64,
+                install_id=install_id,
+            )
+        except Exception as exc:  # noqa: BLE001 - expired / tampered / not configured
+            logger.debug("Plus capability: license not usable (%s)", exc)
+            return DEFAULT_TIER
+    else:
+        # Proxy mode: the .so is not in this image. Fall back to an unverified
+        # read; the sidecar enforces the real thing on the analytics call.
+        claim = _decode_claim_unverified(signed_license_b64)
+        if claim is None or not _claim_is_current(claim):
+            return DEFAULT_TIER
+
+    tier = claim.get("tier") if isinstance(claim, dict) else None
+    return tier if tier in SUPPORTER_TIERS else DEFAULT_TIER
+
+
+def get_plus_capability(session: Session) -> PlusCapability:
+    """Build the :class:`PlusCapability` block for the public instance config."""
+    from app.plus import PLUS_AVAILABLE  # local import: avoids a startup cycle
+
+    tier = DEFAULT_TIER
+    instance = session.exec(select(InstanceDetail)).first()
+    if instance is not None and instance.signed_license:
+        tier = _resolve_tier(instance.signed_license, str(instance.install_id))
+
+    return PlusCapability(
+        available=bool(PLUS_AVAILABLE),
+        tier=tier,
+        upgrade_url=JOURNIV_PLUS_DOC_URL,
+    )

--- a/app/schemas/instance.py
+++ b/app/schemas/instance.py
@@ -3,6 +3,21 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 
+class PlusCapability(BaseModel):
+    """
+    Public, non-sensitive summary of this instance's Journiv Plus capability.
+
+    Lets the frontend gate Plus-only surfaces (e.g. tag analytics) without
+    probing a protected endpoint and interpreting its error codes. Contains
+    only capability flags — never install_id, registered email, expiry or the
+    signed license blob (those stay on the admin-only /instance/license/info).
+    """
+
+    available: bool  # Plus code is deployable here (binary loaded, or proxy configured)
+    tier: str  # "member" (unlicensed / invalid), "supporter" or "believer"
+    upgrade_url: str  # Where to learn about / buy Journiv Plus
+
+
 class InstanceConfigResponse(BaseModel):
     """Public instance configuration safe for frontend consumption."""
 
@@ -14,3 +29,4 @@ class InstanceConfigResponse(BaseModel):
     immich_base_url: Optional[str] = None
     oidc_enabled: bool  # Whether OIDC authentication is available
     oidc_only: bool  # Whether OIDC is the only allowed authentication method
+    plus: PlusCapability

--- a/tests/integration/test_instance_config_endpoints.py
+++ b/tests/integration/test_instance_config_endpoints.py
@@ -6,3 +6,19 @@ def test_instance_config_returns_public_settings(api_client):
     assert "disable_signup" in payload
     assert isinstance(payload["import_export_max_file_size_mb"], int)
     assert isinstance(payload["disable_signup"], bool)
+
+
+def test_instance_config_exposes_plus_capability(api_client):
+    """The public config carries a Plus capability block for UI gating."""
+    payload = api_client.request("GET", "/instance/config", expected=(200,)).json()
+
+    assert "plus" in payload
+    plus = payload["plus"]
+    assert isinstance(plus["available"], bool)
+    assert plus["tier"] in {"member", "supporter", "believer"}
+    assert plus["upgrade_url"].startswith("http")
+    # No license is registered in the test instance.
+    assert plus["tier"] == "member"
+    # Non-sensitive block only — never the signed license or binding details.
+    assert "signed_license" not in plus
+    assert "install_id" not in plus


### PR DESCRIPTION
Add a non-sensitive Plus capability summary to the public instance configuration so clients can gate licensed surfaces without probing protected endpoints. Resolve availability and tier centrally while keeping license identifiers and signed license data private.

Provide a reusable capability dependency and integration coverage for the public response contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Instance configuration now reports Journiv Plus availability, current tier, and upgrade information.
  - Plus-protected features now require an eligible paid tier.
  - Upgrade details are provided when access requires a higher tier.
  - Capability information is limited to safe public details; sensitive license data remains hidden.

- **Tests**
  - Added coverage confirming Plus capability reporting, valid tier values, upgrade links, and protection of sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->