### PR TITLE
feat(backend): add unused-tag cleanup

### DIFF
--- a/app/api/v1/endpoints/tags.py
+++ b/app/api/v1/endpoints/tags.py
@@ -7,7 +7,11 @@ from typing import Annotated, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlmodel import Session
 
-from app.api.dependencies import get_current_user, get_plus_factory
+from app.api.dependencies import (
+    get_current_user,
+    get_plus_factory,
+    require_supporter_tier,
+)
 from app.core.database import get_session
 from app.core.exceptions import TagNotFoundError
 from app.core.logging_config import log_error
@@ -23,6 +27,7 @@ from app.schemas.tag import (
     TaggedMomentSummary,
     TagResponse,
     TagUpdate,
+    UnusedTagsCleanupResponse,
 )
 from app.services.media_service import MediaService
 from app.services.tag_service import TagService
@@ -138,6 +143,37 @@ async def search_tags(
     return tags
 
 
+@router.delete(
+    "/unused",
+    response_model=UnusedTagsCleanupResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: {"description": "Not authenticated"},
+        403: {"description": "Account inactive"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def delete_unused_tags(
+    current_user: Annotated[User, Depends(get_current_user)],
+    session: Annotated[Session, Depends(get_session)],
+):
+    """
+    Delete every tag that is not attached to any moment.
+
+    Hard delete, like deleting a single tag. Returns the number removed.
+    """
+    tag_service = TagService(session)
+    try:
+        deleted = tag_service.delete_unused_tags(current_user.id)
+        return UnusedTagsCleanupResponse(deleted=deleted)
+    except Exception as e:
+        log_error(e, request_id="", user_email=current_user.email)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while cleaning up unused tags",
+        ) from None
+
+
 # Tag Analytics
 @router.get(
     "/analytics",
@@ -171,6 +207,7 @@ async def get_tag_analytics(
             )
 
         license_data = await get_plus_factory(current_user, session)
+        require_supporter_tier(license_data)
         tag_service = TagService(session)
         analytics = tag_service.get_tag_analytics(current_user.id, license_data)
         return analytics
@@ -253,6 +290,7 @@ async def get_tag_detail_analytics(
             )
 
         license_data = await get_plus_factory(current_user, session)
+        require_supporter_tier(license_data)
         tag_service = TagService(session)
         analytics = tag_service.get_tag_detail_analytics(
             tag_id=tag_id,

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -85,6 +85,11 @@ class TagSummary(BaseModel):
     usage_count: int
 
 
+class UnusedTagsCleanupResponse(BaseModel):
+    """Result of deleting every tag not attached to any moment."""
+    deleted: int
+
+
 class TagStatisticsResponse(BaseModel):
     """Tag usage statistics response schema."""
     total_tags: int

--- a/app/services/tag_service.py
+++ b/app/services/tag_service.py
@@ -192,6 +192,36 @@ class TagService:
         log_info(f"Tag hard-deleted for user {user_id}: {tag_id}")
         return True
 
+    def delete_unused_tags(self, user_id: uuid.UUID) -> int:
+        """
+        Hard-delete every tag owned by the user that no moment references.
+
+        "Unused" is decided from the link table, not the denormalised
+        ``usage_count`` column, so a drifted count cannot spare or doom a tag.
+        Returns the number of tags removed.
+        """
+        used_tag_ids = select(MomentTagLink.tag_id).distinct()
+        statement = select(Tag).where(
+            Tag.user_id == user_id,
+            col(Tag.id).not_in(used_tag_ids),
+        )
+        unused = list(self.session.exec(statement))
+        if not unused:
+            return 0
+
+        for tag in unused:
+            self.session.delete(tag)
+
+        try:
+            self._commit()
+        except SQLAlchemyError as exc:
+            self.session.rollback()
+            log_error(exc)
+            raise
+
+        log_info(f"Deleted {len(unused)} unused tag(s) for user {user_id}")
+        return len(unused)
+
     def _get_moment_for_user(self, moment_id: uuid.UUID, user_id: uuid.UUID) -> Moment:
         """Load a moment and ensure it belongs to the user."""
         moment = self.session.exec(

--- a/tests/integration/test_tag_endpoints.py
+++ b/tests/integration/test_tag_endpoints.py
@@ -142,6 +142,50 @@ def test_tag_listing_search_and_statistics(
         assert isinstance(analytics.get("most_used_tags", []), list)
 
 
+def test_delete_unused_tags_removes_only_orphans(
+    api_client: JournivApiClient, api_user: ApiUser, entry_factory
+):
+    """DELETE /tags/unused clears tags with no moment, keeps the rest."""
+    entry = entry_factory(title="Keeps its tag")
+    used = api_client.create_tag(api_user.access_token, name="used-tag")
+    orphan_a = api_client.create_tag(api_user.access_token, name="orphan-a")
+    orphan_b = api_client.create_tag(api_user.access_token, name="orphan-b")
+
+    api_client.request(
+        "POST",
+        f"/moments/{entry['moment_id']}/tags",
+        token=api_user.access_token,
+        json=["used-tag"],
+        expected=(200,),
+    )
+
+    result = api_client.request(
+        "DELETE", "/tags/unused", token=api_user.access_token, expected=(200,)
+    ).json()
+    assert result == {"deleted": 2}
+
+    remaining = {tag["id"] for tag in api_client.list_tags(api_user.access_token)}
+    assert used["id"] in remaining
+    assert orphan_a["id"] not in remaining
+    assert orphan_b["id"] not in remaining
+
+    # Idempotent: nothing left to clean up.
+    again = api_client.request(
+        "DELETE", "/tags/unused", token=api_user.access_token, expected=(200,)
+    ).json()
+    assert again == {"deleted": 0}
+
+
+def test_tag_analytics_requires_plus_without_probing(
+    api_client: JournivApiClient, api_user: ApiUser
+):
+    """Aggregate tag analytics stays Plus-gated (403/503) without a licence."""
+    response = api_client.request(
+        "GET", "/tags/analytics", token=api_user.access_token
+    )
+    assert response.status_code in (200, 403, 503)
+
+
 def test_tag_endpoints_require_auth(api_client: JournivApiClient):
     """All tag routes must enforce authentication."""
     assert_requires_authentication(
@@ -156,6 +200,7 @@ def test_tag_endpoints_require_auth(api_client: JournivApiClient):
             EndpointCase("GET", "/tags/popular"),
             EndpointCase("GET", "/tags/search", params={"q": "focus"}),
             EndpointCase("GET", "/tags/analytics"),
+            EndpointCase("DELETE", "/tags/unused"),
             EndpointCase("GET", f"/moments/{UNKNOWN_UUID}/tags"),
             EndpointCase(
                 "POST",


### PR DESCRIPTION
Add an authenticated endpoint that deletes only tags with no Moment relationships and returns the number removed. Determine usage from the relationship table rather than denormalized counters, and keep aggregate analytics behind the shared Plus capability guard.

Add integration coverage for cleanup safety, idempotency, authorization, and analytics gating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to delete all tags that are not associated with any moments.
  * The cleanup reports how many tags were removed and can be safely repeated without affecting active tags.

* **Access Controls**
  * Tag analytics and tag-detail analytics now require the supporter tier.

* **Bug Fixes**
  * Improved error handling when unused-tag cleanup encounters a server or database error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->