### PR TITLE
fix(backend): preserve an active administrator

### DIFF
--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -148,6 +148,17 @@ class AdminUserCreate(UserBase):
             raise ValueError('Name cannot be empty')
         return v.strip()
 
+    @validator('password')
+    def validate_password(cls, v):
+        """Validate password strength (matches AdminUserUpdate and signup)."""
+        if len(v) < 8:
+            raise ValueError('Password must be at least 8 characters long')
+        has_letter = any(c.isalpha() for c in v)
+        has_digit = any(c.isdigit() for c in v)
+        if not (has_letter and has_digit):
+            raise ValueError('Password must contain at least one letter and one number')
+        return v
+
 
 class AdminUserUpdate(BaseModel):
     """Admin user update schema (can change role, active status)."""

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -87,12 +87,19 @@ class UserService:
             log_error(exc, context="is_first_user check")
             return False
 
-    def count_admin_users(self) -> int:
-        """Count the number of admin users."""
+    def count_admin_users(self, active_only: bool = False) -> int:
+        """Count admin users.
+
+        Args:
+            active_only: When True, exclude deactivated admins. A disabled
+                admin cannot sign in, so it must not satisfy the "at least one
+                admin must exist" guards.
+        """
         from sqlalchemy import func
-        return self.session.exec(
-            select(func.count(User.id)).where(User.role == UserRole.ADMIN)
-        ).one() or 0
+        statement = select(func.count(User.id)).where(User.role == UserRole.ADMIN)
+        if active_only:
+            statement = statement.where(User.is_active.is_(True))
+        return self.session.exec(statement).one() or 0
 
     def can_delete_user(self, user_id: str) -> tuple[bool, Optional[str]]:
         """
@@ -108,11 +115,10 @@ class UserService:
         if not user:
             return False, "User not found"
 
-        # Cannot delete the last admin
-        if user.role == UserRole.ADMIN:
-            admin_count = self.count_admin_users()
-            if admin_count <= 1:
-                return False, "Cannot delete the last admin user. At least one admin must exist."
+        # Cannot delete the last admin who can still sign in
+        if user.role == UserRole.ADMIN and user.is_active:
+            if self.count_admin_users(active_only=True) <= 1:
+                return False, "Cannot delete the last admin user. At least one active admin must exist."
 
         return True, None
 
@@ -131,11 +137,40 @@ class UserService:
         if not user:
             return False, "User not found"
 
-        # If demoting from admin to user, check if this is the last admin
-        if user.role == UserRole.ADMIN and new_role != UserRole.ADMIN:
-            admin_count = self.count_admin_users()
-            if admin_count <= 1:
-                return False, "Cannot demote the last admin user. At least one admin must exist."
+        # If demoting from admin to user, check this is not the last active admin
+        if user.role == UserRole.ADMIN and new_role != UserRole.ADMIN and user.is_active:
+            if self.count_admin_users(active_only=True) <= 1:
+                return False, "Cannot demote the last admin user. At least one active admin must exist."
+
+        return True, None
+
+    def can_change_active_status(
+        self, user_id: str, is_active: bool
+    ) -> tuple[bool, Optional[str]]:
+        """
+        Check if a user's active status can be changed.
+
+        Deactivating the last admin who can still sign in would lock every
+        administrator out of the instance, so it is refused.
+
+        Args:
+            user_id: User ID to check
+            is_active: The requested active status
+
+        Returns:
+            tuple: (can_change: bool, error_message: Optional[str])
+        """
+        user = self.get_user_by_id(user_id)
+        if not user:
+            return False, "User not found"
+
+        if (
+            user.role == UserRole.ADMIN
+            and user.is_active
+            and not is_active
+            and self.count_admin_users(active_only=True) <= 1
+        ):
+            return False, "Cannot deactivate the last admin user. At least one active admin must exist."
 
         return True, None
 
@@ -658,6 +693,14 @@ class UserService:
         if user_data.role is not None and user_data.role != user.role:
             can_update, error_msg = self.can_update_user_role(user_id, user_data.role)
             if not can_update:
+                raise ValueError(error_msg)
+
+        # Check active-status change protection (never strand the last admin)
+        if user_data.is_active is not None and user_data.is_active != user.is_active:
+            can_change, error_msg = self.can_change_active_status(
+                user_id, user_data.is_active
+            )
+            if not can_change:
                 raise ValueError(error_msg)
 
         # Update fields

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,6 +1,7 @@
 """
 User service for handling users and user settings.
 """
+
 import secrets
 import time
 import uuid
@@ -76,7 +77,7 @@ class UserService:
                 bind_url = bind.url
             elif isinstance(bind, Connection):
                 bind_url = bind.engine.url
-            if bind_url and 'sqlite' in str(bind_url).lower():
+            if bind_url and "sqlite" in str(bind_url).lower():
                 count = self.session.exec(select(func.count(User.id))).one() or 0
                 return count == 0
             else:
@@ -96,9 +97,10 @@ class UserService:
                 admin must exist" guards.
         """
         from sqlalchemy import func
+
         statement = select(func.count(User.id)).where(User.role == UserRole.ADMIN)
         if active_only:
-            statement = statement.where(User.is_active.is_(True))
+            statement = statement.where(User.is_active)
         return self.session.exec(statement).one() or 0
 
     def can_delete_user(self, user_id: str) -> tuple[bool, Optional[str]]:
@@ -118,11 +120,16 @@ class UserService:
         # Cannot delete the last admin who can still sign in
         if user.role == UserRole.ADMIN and user.is_active:
             if self.count_admin_users(active_only=True) <= 1:
-                return False, "Cannot delete the last admin user. At least one active admin must exist."
+                return (
+                    False,
+                    "Cannot delete the last admin user. At least one active admin must exist.",
+                )
 
         return True, None
 
-    def can_update_user_role(self, user_id: str, new_role: UserRole) -> tuple[bool, Optional[str]]:
+    def can_update_user_role(
+        self, user_id: str, new_role: UserRole
+    ) -> tuple[bool, Optional[str]]:
         """
         Check if a user's role can be updated.
 
@@ -138,9 +145,16 @@ class UserService:
             return False, "User not found"
 
         # If demoting from admin to user, check this is not the last active admin
-        if user.role == UserRole.ADMIN and new_role != UserRole.ADMIN and user.is_active:
+        if (
+            user.role == UserRole.ADMIN
+            and new_role != UserRole.ADMIN
+            and user.is_active
+        ):
             if self.count_admin_users(active_only=True) <= 1:
-                return False, "Cannot demote the last admin user. At least one active admin must exist."
+                return (
+                    False,
+                    "Cannot demote the last admin user. At least one active admin must exist.",
+                )
 
         return True, None
 
@@ -170,7 +184,10 @@ class UserService:
             and not is_active
             and self.count_admin_users(active_only=True) <= 1
         ):
-            return False, "Cannot deactivate the last admin user. At least one active admin must exist."
+            return (
+                False,
+                "Cannot deactivate the last admin user. At least one active admin must exist.",
+            )
 
         return True, None
 
@@ -192,7 +209,9 @@ class UserService:
         """Check if user is an OIDC user by checking for ExternalIdentity."""
         try:
             user_uuid = uuid.UUID(user_id)
-            statement = select(ExternalIdentity).where(ExternalIdentity.user_id == user_uuid)
+            statement = select(ExternalIdentity).where(
+                ExternalIdentity.user_id == user_uuid
+            )
             external_identity = self.session.exec(statement).first()
             return external_identity is not None
         except ValueError:
@@ -205,7 +224,9 @@ class UserService:
         """
         return settings.disable_signup
 
-    def create_user(self, user_data: UserCreate, role: Optional[UserRole] = None) -> User:
+    def create_user(
+        self, user_data: UserCreate, role: Optional[UserRole] = None
+    ) -> User:
         """Create a new user.
 
         Args:
@@ -234,7 +255,7 @@ class UserService:
             email=user_data.email,
             password=hashed_password,
             name=user_data.name,
-            role=user_role
+            role=user_role,
         )
 
         self.session.add(user)
@@ -266,13 +287,16 @@ class UserService:
             raise UserNotFoundError("User not found")
 
         # Handle password change if provided
-        if user_data.current_password is not None and user_data.new_password is not None:
+        if (
+            user_data.current_password is not None
+            and user_data.new_password is not None
+        ):
             # Check if user is OIDC user - OIDC users cannot change password
             if self.is_oidc_user(user_id):
-                log_warning(
-                    f"Password change rejected for OIDC user: {user.email}"
+                log_warning(f"Password change rejected for OIDC user: {user.email}")
+                raise ValueError(
+                    "Password cannot be changed for OIDC users. Please change your password through your OIDC provider."
                 )
-                raise ValueError("Password cannot be changed for OIDC users. Please change your password through your OIDC provider.")
 
             # Verify current password
             if not verify_password(user_data.current_password, user.password):
@@ -363,13 +387,10 @@ class UserService:
         user_id: uuid.UUID,
         settings_data: UserSettingsCreate,
         *,
-        commit: bool = True
+        commit: bool = True,
     ) -> UserSettings:
         """Create user settings."""
-        settings = UserSettings(
-            user_id=user_id,
-            **_schema_dump(settings_data)
-        )
+        settings = UserSettings(user_id=user_id, **_schema_dump(settings_data))
 
         self.session.add(settings)
         if commit:
@@ -397,7 +418,9 @@ class UserService:
         except ValueError:
             raise UserNotFoundError("Invalid user ID format") from None
 
-    def update_user_settings(self, user_id: str, settings_data: UserSettingsUpdate) -> UserSettings:
+    def update_user_settings(
+        self, user_id: str, settings_data: UserSettingsUpdate
+    ) -> UserSettings:
         """Update user settings."""
         settings = self.get_user_settings(user_id)
 
@@ -444,7 +467,7 @@ class UserService:
         email: Optional[str],
         name: Optional[str],
         picture: Optional[str],
-        auto_provision: bool
+        auto_provision: bool,
     ) -> User:
         """
         Get or create user from OIDC authentication.
@@ -467,8 +490,7 @@ class UserService:
         """
         # Find existing ExternalIdentity by (issuer, subject)
         statement = select(ExternalIdentity).where(
-            ExternalIdentity.issuer == issuer,
-            ExternalIdentity.subject == subject
+            ExternalIdentity.issuer == issuer, ExternalIdentity.subject == subject
         )
         external_identity = self.session.exec(statement).first()
 
@@ -494,7 +516,9 @@ class UserService:
             # Load and return the associated user
             user = self.get_user_by_id(str(external_identity.user_id))
             if not user:
-                raise UserNotFoundError(f"User {external_identity.user_id} not found for external identity")
+                raise UserNotFoundError(
+                    f"User {external_identity.user_id} not found for external identity"
+                )
 
             if not user.is_active:
                 log_warning(f"OIDC login rejected for inactive user: {user.email}")
@@ -505,7 +529,9 @@ class UserService:
 
         # External identity not found - check if auto-provisioning is enabled
         if not auto_provision:
-            log_warning(f"OIDC auto-provisioning disabled, rejecting new user from {issuer}")
+            log_warning(
+                f"OIDC auto-provisioning disabled, rejecting new user from {issuer}"
+            )
             raise UnauthorizedError(
                 "Your account is not registered. Please contact the administrator or "
                 "register with email/password first."
@@ -537,7 +563,7 @@ class UserService:
                 password=get_password_hash(random_password),
                 name=name or email.split("@")[0],  # Use email prefix as default name
                 is_active=True,
-                role=user_role
+                role=user_role,
             )
 
             self.session.add(user)
@@ -548,14 +574,18 @@ class UserService:
 
                 # Create default user settings
                 self.create_user_settings(user.id, UserSettingsCreate(), commit=False)
-                StarterDataService(self.session).ensure_user_seeded(user.id, commit=False)
+                StarterDataService(self.session).ensure_user_seeded(
+                    user.id, commit=False
+                )
 
                 # Commit user creation
                 self.session.commit()
                 self.session.refresh(user)
 
                 if is_first:
-                    log_info(f"First user auto-provisioned from OIDC as admin: {user.email}")
+                    log_info(
+                        f"First user auto-provisioned from OIDC as admin: {user.email}"
+                    )
                 else:
                     log_info(f"Auto-provisioned new user from OIDC: {user.email}")
             except IntegrityError as exc:
@@ -564,7 +594,9 @@ class UserService:
                 user = self.get_user_by_email(email)
                 if not user:
                     raise UserAlreadyExistsError("Failed to create user") from exc
-                log_info(f"User {email} created by another request, using existing user")
+                log_info(
+                    f"User {email} created by another request, using existing user"
+                )
             except SQLAlchemyError as exc:
                 self.session.rollback()
                 log_error(exc, email=email)
@@ -578,7 +610,7 @@ class UserService:
             email=email,
             name=name,
             picture=picture,
-            last_login_at=datetime.now(timezone.utc)
+            last_login_at=datetime.now(timezone.utc),
         )
 
         self.session.add(external_identity)
@@ -591,12 +623,13 @@ class UserService:
             self.session.rollback()
             # External identity already exists (race)
             statement = select(ExternalIdentity).where(
-                ExternalIdentity.issuer == issuer,
-                ExternalIdentity.subject == subject
+                ExternalIdentity.issuer == issuer, ExternalIdentity.subject == subject
             )
             existing = self.session.exec(statement).first()
             if existing:
-                log_info(f"External identity for {issuer}/{subject} created by another request")
+                log_info(
+                    f"External identity for {issuer}/{subject} created by another request"
+                )
                 # Update last login
                 existing.last_login_at = datetime.now(timezone.utc)
                 self.session.add(existing)
@@ -651,7 +684,7 @@ class UserService:
             email=user_data.email,
             password=hashed_password,
             name=user_data.name,
-            role=user_data.role
+            role=user_data.role,
         )
 
         self.session.add(user)
@@ -707,18 +740,18 @@ class UserService:
         update_data = _schema_dump(user_data, exclude_unset=True)
 
         # Handle password separately
-        if 'password' in update_data and update_data['password']:
-            user.password = get_password_hash(update_data['password'])
-            del update_data['password']
+        if "password" in update_data and update_data["password"]:
+            user.password = get_password_hash(update_data["password"])
+            del update_data["password"]
 
         # Handle role separately - ensure it's an enum instance, not a string
-        if 'role' in update_data:
-            role_value = update_data['role']
+        if "role" in update_data:
+            role_value = update_data["role"]
             if isinstance(role_value, str):
                 user.role = UserRole(role_value)
             else:
                 user.role = role_value
-            del update_data['role']
+            del update_data["role"]
 
         # Update other fields
         for field, value in update_data.items():
@@ -732,7 +765,7 @@ class UserService:
             log_info(f"Admin updated user: {user.email}")
         except IntegrityError as exc:
             self.session.rollback()
-            if 'email' in str(exc).lower():
+            if "email" in str(exc).lower():
                 raise UserAlreadyExistsError("Email already registered") from exc
             raise
         except SQLAlchemyError as exc:

--- a/tests/integration/test_admin_role_management.py
+++ b/tests/integration/test_admin_role_management.py
@@ -291,3 +291,72 @@ def test_multiple_admins_supported(api_client: JournivApiClient):
 
     assert response1.status_code == 200, "First admin should access admin endpoints"
     assert response2.status_code == 200, "Promoted admin should access admin endpoints"
+
+
+def test_cannot_deactivate_last_admin(api_client: JournivApiClient):
+    """Deactivating the last admin who can sign in must be refused."""
+    admin = _ensure_admin_user(api_client)
+
+    # Attempt to deactivate self (mirrors test_cannot_demote_last_admin).
+    response = api_client.request(
+        "PATCH",
+        f"/admin/users/{admin.user_id}",
+        headers={"Authorization": f"Bearer {admin.access_token}"},
+        json={"is_active": False},
+    )
+
+    assert response.status_code == 400, "Should prevent deactivating the last admin"
+    error_detail = response.json().get("detail", "")
+    assert "last admin" in error_detail.lower() or "active admin" in error_detail.lower()
+
+
+def test_admin_can_deactivate_another_admin_when_one_remains(
+    api_client: JournivApiClient,
+):
+    """With more than one active admin, deactivating one is allowed."""
+    admin = _ensure_admin_user(api_client)
+    second = _ensure_regular_user(api_client, admin)
+
+    promote = api_client.request(
+        "PATCH",
+        f"/admin/users/{second.user_id}",
+        headers={"Authorization": f"Bearer {admin.access_token}"},
+        json={"role": "admin"},
+    )
+    assert promote.status_code == 200
+
+    deactivate = api_client.request(
+        "PATCH",
+        f"/admin/users/{second.user_id}",
+        headers={"Authorization": f"Bearer {admin.access_token}"},
+        json={"is_active": False},
+    )
+    assert deactivate.status_code == 200
+    assert deactivate.json()["is_active"] is False
+
+    # Clean up so the shared instance keeps a spare active admin.
+    api_client.request(
+        "DELETE",
+        f"/admin/users/{second.user_id}",
+        headers={"Authorization": f"Bearer {admin.access_token}"},
+    )
+
+
+def test_admin_create_rejects_weak_password(api_client: JournivApiClient):
+    """Admin-created accounts are held to the same password policy as signup."""
+    admin = _ensure_admin_user(api_client)
+    email, _ = _unique_credentials("weak-pass")
+
+    response = api_client.request(
+        "POST",
+        "/admin/users",
+        headers={"Authorization": f"Bearer {admin.access_token}"},
+        json={
+            "email": email,
+            "password": "short",
+            "name": "Weak Password User",
+            "role": "user",
+        },
+    )
+
+    assert response.status_code in (400, 422), "Weak password should be rejected"

--- a/tests/unit/services/test_user_service_admin_guards.py
+++ b/tests/unit/services/test_user_service_admin_guards.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for the admin-protection guards in UserService.
+
+These cover the "there must always be at least one admin who can sign in"
+invariant across deletion, demotion and deactivation, including the case where
+a stale deactivated admin row must not count towards the quota.
+"""
+
+import uuid
+
+import pytest
+from sqlmodel import Session, create_engine
+
+from app.models.base import BaseModel
+from app.models.enums import UserRole
+from app.models.user import User
+from app.schemas.user import AdminUserUpdate
+from app.services.user_service import UserService
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def test_db():
+    engine = create_engine("sqlite:///:memory:")
+    BaseModel.metadata.create_all(engine)
+    session = Session(engine)
+    yield session
+    session.close()
+
+
+def _make_user(
+    session: Session,
+    *,
+    role: UserRole = UserRole.USER,
+    is_active: bool = True,
+) -> User:
+    user = User(
+        email=f"user_{uuid.uuid4().hex[:8]}@example.com",
+        password="hashed",
+        name="Test User",
+        role=role,
+        is_active=is_active,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def test_count_admin_users_can_exclude_deactivated(test_db: Session):
+    service = UserService(test_db)
+    _make_user(test_db, role=UserRole.ADMIN, is_active=True)
+    _make_user(test_db, role=UserRole.ADMIN, is_active=False)
+    _make_user(test_db, role=UserRole.USER, is_active=True)
+
+    assert service.count_admin_users() == 2
+    assert service.count_admin_users(active_only=True) == 1
+
+
+def test_cannot_deactivate_last_active_admin(test_db: Session):
+    service = UserService(test_db)
+    admin = _make_user(test_db, role=UserRole.ADMIN, is_active=True)
+
+    can_change, message = service.can_change_active_status(str(admin.id), False)
+
+    assert can_change is False
+    assert "last admin" in message.lower()
+
+
+def test_can_deactivate_admin_when_another_active_admin_exists(test_db: Session):
+    service = UserService(test_db)
+    admin_a = _make_user(test_db, role=UserRole.ADMIN, is_active=True)
+    _make_user(test_db, role=UserRole.ADMIN, is_active=True)
+
+    can_change, message = service.can_change_active_status(str(admin_a.id), False)
+
+    assert can_change is True
+    assert message is None
+
+
+def test_deactivating_regular_user_is_always_allowed(test_db: Session):
+    service = UserService(test_db)
+    _make_user(test_db, role=UserRole.ADMIN, is_active=True)
+    member = _make_user(test_db, role=UserRole.USER, is_active=True)
+
+    can_change, _ = service.can_change_active_status(str(member.id), False)
+
+    assert can_change is True
+
+
+def test_reactivating_an_admin_is_allowed(test_db: Session):
+    service = UserService(test_db)
+    admin = _make_user(test_db, role=UserRole.ADMIN, is_active=False)
+
+    can_change, _ = service.can_change_active_status(str(admin.id), True)
+
+    assert can_change is True
+
+
+def test_deactivated_admin_does_not_shield_the_last_active_admin(test_db: Session):
+    """A stale deactivated admin row must not satisfy the delete/demote quota."""
+    service = UserService(test_db)
+    active_admin = _make_user(test_db, role=UserRole.ADMIN, is_active=True)
+    _make_user(test_db, role=UserRole.ADMIN, is_active=False)
+
+    can_delete, delete_msg = service.can_delete_user(str(active_admin.id))
+    can_demote, demote_msg = service.can_update_user_role(
+        str(active_admin.id), UserRole.USER
+    )
+
+    assert can_delete is False
+    assert "active admin" in delete_msg.lower()
+    assert can_demote is False
+    assert "active admin" in demote_msg.lower()
+
+
+def test_update_user_as_admin_refuses_deactivating_last_admin(test_db: Session):
+    service = UserService(test_db)
+    admin = _make_user(test_db, role=UserRole.ADMIN, is_active=True)
+
+    with pytest.raises(ValueError, match="last admin"):
+        service.update_user_as_admin(
+            str(admin.id), AdminUserUpdate(is_active=False)
+        )
+
+    test_db.refresh(admin)
+    assert admin.is_active is True


### PR DESCRIPTION
Prevent deleting, demoting, or deactivating the final administrator who can still sign in. Count only active administrators for lockout protection and validate admin-created passwords against the same strength requirements as signup.

Add service and endpoint tests for single-admin lockout prevention, multiple-admin transitions, inactive administrators, and weak passwords.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password-strength requirements for administrator account creation.
  * Prevented deactivation, deletion, or role changes that would leave no active administrator.
  * Allowed deactivated administrator accounts to be excluded from active-admin safeguards.

* **Bug Fixes**
  * Improved protection against accidentally removing the last active administrator.
  * Ensured weak passwords are rejected during administrator creation.

* **Tests**
  * Added coverage for administrator lifecycle protections and password validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->