### PR TITLE
feat(frontend): establish API and server-state boundaries

### DIFF
--- a/frontend/src/api/auth/session.test.ts
+++ b/frontend/src/api/auth/session.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { sessionStore } from "./session";
+
+describe("sessionStore", () => {
+  beforeEach(() => sessionStorage.clear());
+  it("rejects malformed or unsupported sessions", () => {
+    sessionStorage.setItem(
+      "journiv.prototype.session.v1",
+      JSON.stringify({ version: 2, accessToken: "a" }),
+    );
+    expect(sessionStore.read()).toBeNull();
+  });
+  it("stores and clears only versioned sessions", () => {
+    sessionStore.write({
+      version: 1,
+      accessToken: "access",
+      refreshToken: "refresh",
+    });
+    expect(sessionStore.read()).toEqual({
+      version: 1,
+      accessToken: "access",
+      refreshToken: "refresh",
+    });
+    sessionStore.clear();
+    expect(sessionStore.read()).toBeNull();
+  });
+});

--- a/frontend/src/api/auth/session.ts
+++ b/frontend/src/api/auth/session.ts
@@ -1,0 +1,47 @@
+export type AuthSession = {
+  version: 1;
+  accessToken: string;
+  refreshToken: string;
+};
+
+type SessionListener = (session: AuthSession | null) => void;
+
+const key = "journiv.prototype.session.v1";
+const listeners = new Set<SessionListener>();
+
+function notify(session: AuthSession | null) {
+  for (const listener of listeners) listener(session);
+}
+
+export const sessionStore = {
+  read: (): AuthSession | null => {
+    try {
+      const value: unknown = JSON.parse(sessionStorage.getItem(key) ?? "null");
+      if (!value || typeof value !== "object") return null;
+      const session = value as AuthSession;
+      return session.version === 1 &&
+        typeof session.accessToken === "string" &&
+        session.accessToken.length > 0 &&
+        typeof session.refreshToken === "string" &&
+        session.refreshToken.length > 0
+        ? session
+        : null;
+    } catch {
+      return null;
+    }
+  },
+  write: (session: AuthSession) => {
+    sessionStorage.setItem(key, JSON.stringify(session));
+    notify(session);
+  },
+  clear: () => {
+    sessionStorage.removeItem(key);
+    notify(null);
+  },
+  subscribe: (listener: SessionListener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};

--- a/frontend/src/api/client/api.ts
+++ b/frontend/src/api/client/api.ts
@@ -1,0 +1,709 @@
+import {
+  archiveJournalApiV1JournalsJournalIdArchivePost,
+  archivePersonApiV1PeoplePersonIdDelete,
+  bulkAddTagsToMomentApiV1MomentsMomentIdTagsPost,
+  connectApiV1IntegrationsConnectPost,
+  createActivityApiV1ActivitiesPost,
+  createActivityGroupApiV1ActivityGroupsPost,
+  createDraftEntryApiV1EntriesDraftPost,
+  createExportApiV1ExportPost,
+  createGoalApiV1GoalsPost,
+  createGoalCategoryApiV1GoalCategoriesPost,
+  createJournalApiV1JournalsPost,
+  createMomentApiV1MomentsPost,
+  createMoodApiV1MoodsPost,
+  createMoodGroupApiV1MoodsGroupsPost,
+  createPersonApiV1PeoplePost,
+  createPersonGroupApiV1PeopleGroupsPost,
+  createTagApiV1TagsPost,
+  createUserApiV1AdminUsersPost,
+  deleteActivityApiV1ActivitiesActivityIdDelete,
+  deleteActivityGroupApiV1ActivityGroupsGroupIdDelete,
+  deleteEntryApiV1EntriesEntryIdDelete,
+  deleteGoalCategoryApiV1GoalCategoriesCategoryIdDelete,
+  deleteGoalPermanentlyApiV1GoalsGoalIdDelete,
+  deleteJournalApiV1JournalsJournalIdDelete,
+  deleteMediaApiV1MediaMediaIdDelete,
+  deleteMomentApiV1MomentsMomentIdDelete,
+  deleteMoodApiV1MoodsMoodIdDelete,
+  deleteMoodGroupApiV1MoodsGroupsGroupIdDelete,
+  deletePersonGroupApiV1PeopleGroupsGroupIdDelete,
+  deleteTagApiV1TagsTagIdDelete,
+  deleteUnusedTagsApiV1TagsUnusedDelete,
+  deleteUserApiV1AdminUsersUserIdDelete,
+  disconnectApiV1IntegrationsProviderDisconnectDelete,
+  fetchWeatherApiV1WeatherFetchPost,
+  getActivitiesApiV1ActivitiesGet,
+  getActivityGroupsApiV1ActivityGroupsGet,
+  getAllMoodsApiV1MoodsGet,
+  getCurrentUserInfoApiV1UsersMeGet,
+  getCurrentUserSettingsApiV1UsersMeSettingsGet,
+  getEntryApiV1EntriesEntryIdGet,
+  getExportStatusApiV1ExportJobIdGet,
+  getGoalCategoriesApiV1GoalCategoriesGet,
+  getGoalLogsApiV1GoalsGoalIdLogsGet,
+  getGoalsApiV1GoalsGet,
+  getImportStatusApiV1ImportJobIdGet,
+  getInstanceConfigApiV1InstanceConfigGet,
+  getLicenseInfoApiV1InstanceLicenseInfoGet,
+  getMediaLibraryApiV1MediaGet,
+  getMomentApiV1MomentsMomentIdGet,
+  getMomentCalendarApiV1MomentsCalendarGet,
+  getMomentMediaApiV1MomentsMomentIdMediaGet,
+  getMomentsApiV1MomentsGet,
+  getMomentsByTagApiV1TagsTagIdMomentsGet,
+  getMoodGroupsApiV1MoodsGroupsGet,
+  getPeopleApiV1PeopleGet,
+  getPersonGroupsApiV1PeopleGroupsGet,
+  getStatusApiV1IntegrationsProviderStatusGet,
+  getSupportedFormatsApiV1MediaFormatsGet,
+  getTagAnalyticsApiV1TagsAnalyticsGet,
+  getTagDetailAnalyticsApiV1TagsTagIdAnalyticsGet,
+  getUserJournalsApiV1JournalsGet,
+  getUserTagsApiV1TagsGet,
+  getVersionInfoApiV1InstanceVersionInfoGet,
+  listUsersApiV1AdminUsersGet,
+  loginApiV1AuthLoginPost,
+  mergePeopleApiV1PeopleSourceIdMergeTargetIdPost,
+  mergeTagsApiV1TagsSourceIdMergeTargetIdPost,
+  refreshTokenApiV1AuthRefreshPost,
+  removePersonProfileImageApiV1PeoplePersonIdProfileImageDelete,
+  removeTagFromMomentApiV1MomentsMomentIdTagsTagIdDelete,
+  reorderJournalsApiV1JournalsReorderPut,
+  replaceMomentPeopleApiV1MomentsMomentIdPeoplePut,
+  reverseGeocodeApiV1LocationReversePost,
+  searchLocationApiV1LocationSearchPost,
+  searchTagsApiV1TagsSearchGet,
+  signExportUrlApiV1ExportJobIdSignGet,
+  toggleFavoriteApiV1JournalsJournalIdFavoritePost,
+  unarchiveJournalApiV1JournalsJournalIdUnarchivePost,
+  updateActivityApiV1ActivitiesActivityIdPut,
+  updateActivityGroupApiV1ActivityGroupsGroupIdPut,
+  updateCurrentUserApiV1UsersMePut,
+  updateCurrentUserSettingsApiV1UsersMeSettingsPut,
+  updateGoalApiV1GoalsGoalIdPut,
+  updateGoalCategoryApiV1GoalCategoriesCategoryIdPut,
+  updateJournalApiV1JournalsJournalIdPut,
+  updateMomentApiV1MomentsMomentIdPut,
+  updateMoodApiV1MoodsMoodIdPut,
+  updateMoodGroupApiV1MoodsGroupsGroupIdPut,
+  updatePersonApiV1PeoplePersonIdPut,
+  updatePersonGroupApiV1PeopleGroupsGroupIdPut,
+  updateSettingsApiV1IntegrationsProviderSettingsPut,
+  updateTagApiV1TagsTagIdPut,
+  updateUserApiV1AdminUsersUserIdPatch,
+  uploadImportApiV1ImportUploadPost,
+  uploadPersonProfileImageApiV1PeoplePersonIdProfileImagePost,
+} from "../generated/sdk.gen";
+import type {
+  ActivityCreate,
+  ActivityGroupCreate,
+  ActivityGroupUpdate,
+  ActivityUpdate,
+  AdminUserCreate,
+  AdminUserListResponse,
+  AdminUserUpdate,
+  EntryDraftCreate,
+  ExportJobCreateRequest,
+  GetMediaLibraryApiV1MediaGetData,
+  GetMomentCalendarApiV1MomentsCalendarGetData,
+  GetMomentsApiV1MomentsGetData,
+  GoalCategoryCreate,
+  GoalCategoryUpdate,
+  GoalCreate,
+  GoalUpdate,
+  IntegrationSettingsUpdateRequest,
+  JournalCreate,
+  JournalReorderRequest,
+  JournalUpdate,
+  MomentCreate,
+  MomentUpdate,
+  MoodCreate,
+  MoodGroupCreate,
+  MoodGroupUpdate,
+  MoodUpdate,
+  PersonCreate,
+  PersonGroupCreate,
+  PersonGroupUpdate,
+  PersonUpdate,
+  TagCreate,
+  TagUpdate,
+  UserSettingsUpdate,
+  UserUpdate,
+  WeatherFetchRequest,
+} from "../generated/types.gen";
+import { configureApiClient } from "./config";
+
+const options = () => ({
+  client: configureApiClient(),
+  throwOnError: true as const,
+});
+const data = <T>(result: Promise<{ data: T }>) =>
+  result.then((response) => response.data);
+export const api = {
+  login: (email: string, password: string) =>
+    data(loginApiV1AuthLoginPost({ ...options(), body: { email, password } })),
+  refresh: (refresh_token: string) =>
+    data(
+      refreshTokenApiV1AuthRefreshPost({
+        ...options(),
+        body: { refresh_token },
+      }),
+    ),
+  me: () => data(getCurrentUserInfoApiV1UsersMeGet(options())),
+  /**
+   * Updates the signed-in user. `name` and `profile_picture_url` are profile
+   * edits; `current_password` + `new_password` together are a password change
+   * (rejected server-side for OIDC accounts). Nothing else is settable here.
+   */
+  updateMe: (body: UserUpdate) =>
+    data(updateCurrentUserApiV1UsersMePut({ ...options(), body })),
+  /** Preferences (timezone, theme, …) — separate table from the user row. */
+  userSettings: () =>
+    data(getCurrentUserSettingsApiV1UsersMeSettingsGet(options())),
+  updateUserSettings: (body: UserSettingsUpdate) =>
+    data(
+      updateCurrentUserSettingsApiV1UsersMeSettingsPut({ ...options(), body }),
+    ),
+  /** Instance capability flags — drives capability-aware Settings rendering. */
+  instanceConfig: () =>
+    data(getInstanceConfigApiV1InstanceConfigGet(options())),
+  /**
+   * The admin list endpoint is offset-paginated but exposes no total. Walk it
+   * to completion so search and paging describe the complete account list.
+   */
+  adminUsers: async () => {
+    const pageSize = 200;
+    // Hard ceiling so a broken short-page contract can't spin forever.
+    const maxPages = 50;
+    const users: AdminUserListResponse[] = [];
+    for (let page = 0; page < maxPages; page += 1) {
+      const batch = await data(
+        listUsersApiV1AdminUsersGet({
+          ...options(),
+          query: { limit: pageSize, offset: page * pageSize },
+        }),
+      );
+      users.push(...batch);
+      if (batch.length < pageSize) break;
+    }
+    return users;
+  },
+  createAdminUser: (body: AdminUserCreate) =>
+    data(createUserApiV1AdminUsersPost({ ...options(), body })),
+  updateAdminUser: (user_id: string, body: AdminUserUpdate) =>
+    data(
+      updateUserApiV1AdminUsersUserIdPatch({
+        ...options(),
+        path: { user_id },
+        body,
+      }),
+    ),
+  deleteAdminUser: (user_id: string) =>
+    data(
+      deleteUserApiV1AdminUsersUserIdDelete({
+        ...options(),
+        path: { user_id },
+      }),
+    ),
+  /**
+   * Every journal, archived included. The frontend keeps one cached list and
+   * splits active vs archived client-side, so archiving is instant and the
+   * Journals index never needs a second request.
+   */
+  journals: () =>
+    data(
+      getUserJournalsApiV1JournalsGet({
+        ...options(),
+        query: { include_archived: true },
+      }),
+    ),
+  createJournal: (body: JournalCreate) =>
+    data(createJournalApiV1JournalsPost({ ...options(), body })),
+  updateJournal: (journal_id: string, body: JournalUpdate) =>
+    data(
+      updateJournalApiV1JournalsJournalIdPut({
+        ...options(),
+        path: { journal_id },
+        body,
+      }),
+    ),
+  /** Toggles favourite on/off; returns the updated journal. */
+  toggleJournalFavorite: (journal_id: string) =>
+    data(
+      toggleFavoriteApiV1JournalsJournalIdFavoritePost({
+        ...options(),
+        path: { journal_id },
+      }),
+    ),
+  archiveJournal: (journal_id: string) =>
+    data(
+      archiveJournalApiV1JournalsJournalIdArchivePost({
+        ...options(),
+        path: { journal_id },
+      }),
+    ),
+  unarchiveJournal: (journal_id: string) =>
+    data(
+      unarchiveJournalApiV1JournalsJournalIdUnarchivePost({
+        ...options(),
+        path: { journal_id },
+      }),
+    ),
+  /** Persists new positions for a set of journals. Responds 204. */
+  reorderJournals: (body: JournalReorderRequest) =>
+    data(reorderJournalsApiV1JournalsReorderPut({ ...options(), body })),
+  /**
+   * Hard-deletes a journal. The backend cascade-deletes every Entry written in
+   * it; the parent Moments survive as quick logs. Irreversible — the UI guards
+   * this behind a typed confirmation.
+   */
+  deleteJournal: (journal_id: string) =>
+    data(
+      deleteJournalApiV1JournalsJournalIdDelete({
+        ...options(),
+        path: { journal_id },
+      }),
+    ),
+  moods: () => data(getAllMoodsApiV1MoodsGet(options())),
+  createMood: (body: MoodCreate) =>
+    data(createMoodApiV1MoodsPost({ ...options(), body })),
+  updateMood: (mood_id: string, body: MoodUpdate) =>
+    data(
+      updateMoodApiV1MoodsMoodIdPut({
+        ...options(),
+        path: { mood_id },
+        body,
+      }),
+    ),
+  deleteMood: (mood_id: string) =>
+    data(
+      deleteMoodApiV1MoodsMoodIdDelete({
+        ...options(),
+        path: { mood_id },
+      }),
+    ),
+  /** Mood groups with their embedded moods (`GET /moods/groups`). */
+  moodGroups: () => data(getMoodGroupsApiV1MoodsGroupsGet(options())),
+  createMoodGroup: (body: MoodGroupCreate) =>
+    data(createMoodGroupApiV1MoodsGroupsPost({ ...options(), body })),
+  updateMoodGroup: (group_id: string, body: MoodGroupUpdate) =>
+    data(
+      updateMoodGroupApiV1MoodsGroupsGroupIdPut({
+        ...options(),
+        path: { group_id },
+        body,
+      }),
+    ),
+  deleteMoodGroup: (group_id: string) =>
+    data(
+      deleteMoodGroupApiV1MoodsGroupsGroupIdDelete({
+        ...options(),
+        path: { group_id },
+      }),
+    ),
+  /** Everyone the user has recorded, for the people picker. */
+  people: () =>
+    data(
+      getPeopleApiV1PeopleGet({
+        ...options(),
+        query: { limit: 500, sort: "by_name" },
+      }),
+    ),
+  createPerson: (body: PersonCreate) =>
+    data(createPersonApiV1PeoplePost({ ...options(), body })),
+  updatePerson: (person_id: string, body: PersonUpdate) =>
+    data(
+      updatePersonApiV1PeoplePersonIdPut({
+        ...options(),
+        path: { person_id },
+        body,
+      }),
+    ),
+  archivePerson: (person_id: string) =>
+    data(
+      archivePersonApiV1PeoplePersonIdDelete({
+        ...options(),
+        path: { person_id },
+      }),
+    ),
+  mergePeople: (source_id: string, target_id: string) =>
+    data(
+      mergePeopleApiV1PeopleSourceIdMergeTargetIdPost({
+        ...options(),
+        path: { source_id, target_id },
+      }),
+    ),
+  uploadPersonImage: (person_id: string, file: File) =>
+    data(
+      uploadPersonProfileImageApiV1PeoplePersonIdProfileImagePost({
+        ...options(),
+        path: { person_id },
+        body: { file },
+      }),
+    ),
+  removePersonImage: (person_id: string) =>
+    data(
+      removePersonProfileImageApiV1PeoplePersonIdProfileImageDelete({
+        ...options(),
+        path: { person_id },
+      }),
+    ),
+  personGroups: () => data(getPersonGroupsApiV1PeopleGroupsGet(options())),
+  createPersonGroup: (body: PersonGroupCreate) =>
+    data(createPersonGroupApiV1PeopleGroupsPost({ ...options(), body })),
+  updatePersonGroup: (group_id: string, body: PersonGroupUpdate) =>
+    data(
+      updatePersonGroupApiV1PeopleGroupsGroupIdPut({
+        ...options(),
+        path: { group_id },
+        body,
+      }),
+    ),
+  deletePersonGroup: (group_id: string) =>
+    data(
+      deletePersonGroupApiV1PeopleGroupsGroupIdDelete({
+        ...options(),
+        path: { group_id },
+      }),
+    ),
+  tags: async () => {
+    const tags = [];
+    let offset = 0;
+    while (true) {
+      const page = await data(
+        getUserTagsApiV1TagsGet({
+          ...options(),
+          query: { limit: 100, offset },
+        }),
+      );
+      tags.push(...page);
+      if (page.length < 100) return tags;
+      offset += 100;
+    }
+  },
+  createTag: (body: TagCreate) =>
+    data(createTagApiV1TagsPost({ ...options(), body })),
+  updateTag: (tag_id: string, body: TagUpdate) =>
+    data(
+      updateTagApiV1TagsTagIdPut({
+        ...options(),
+        path: { tag_id },
+        body,
+      }),
+    ),
+  deleteTag: (tag_id: string) =>
+    data(deleteTagApiV1TagsTagIdDelete({ ...options(), path: { tag_id } })),
+  /** Delete every tag attached to no moment. Returns `{ deleted }`. */
+  deleteUnusedTags: () =>
+    data(deleteUnusedTagsApiV1TagsUnusedDelete(options())),
+  mergeTags: (source_id: string, target_id: string) =>
+    data(
+      mergeTagsApiV1TagsSourceIdMergeTargetIdPost({
+        ...options(),
+        path: { source_id, target_id },
+      }),
+    ),
+  /** Moments carrying one tag — the tag detail preview. */
+  tagMoments: (tag_id: string) =>
+    data(
+      getMomentsByTagApiV1TagsTagIdMomentsGet({
+        ...options(),
+        path: { tag_id },
+        query: { limit: 5, include_media: "thumbnails" },
+      }),
+    ),
+  /**
+   * Aggregate tag analytics. Journiv Plus (Supporter+) only — a 403/503 here
+   * means "not licensed / not built", handled by the caller as a locked state,
+   * never a raw error.
+   */
+  tagAnalytics: () => data(getTagAnalyticsApiV1TagsAnalyticsGet(options())),
+  /** One tag's analytics over `days`. Same Plus gating as `tagAnalytics`. */
+  tagDetailAnalytics: (tag_id: string, days: number) =>
+    data(
+      getTagDetailAnalyticsApiV1TagsTagIdAnalyticsGet({
+        ...options(),
+        path: { tag_id },
+        query: { days },
+      }),
+    ),
+  /** Every active activity. The endpoint is paginated, so Library must walk
+   *  all pages instead of silently dropping everything after the first page. */
+  activities: async () => {
+    const activities = [];
+    let offset = 0;
+    while (true) {
+      const page = await data(
+        getActivitiesApiV1ActivitiesGet({
+          ...options(),
+          query: { limit: 200, offset },
+        }),
+      );
+      activities.push(...page);
+      if (page.length < 200) return activities;
+      offset += 200;
+    }
+  },
+  createActivity: (body: ActivityCreate) =>
+    data(createActivityApiV1ActivitiesPost({ ...options(), body })),
+  updateActivity: (activity_id: string, body: ActivityUpdate) =>
+    data(
+      updateActivityApiV1ActivitiesActivityIdPut({
+        ...options(),
+        path: { activity_id },
+        body,
+      }),
+    ),
+  deleteActivity: (activity_id: string) =>
+    data(
+      deleteActivityApiV1ActivitiesActivityIdDelete({
+        ...options(),
+        path: { activity_id },
+      }),
+    ),
+  /** Activity groups with their embedded activities (`GET /activity-groups/`). */
+  activityGroups: () =>
+    data(getActivityGroupsApiV1ActivityGroupsGet(options())),
+  createActivityGroup: (body: ActivityGroupCreate) =>
+    data(createActivityGroupApiV1ActivityGroupsPost({ ...options(), body })),
+  updateActivityGroup: (group_id: string, body: ActivityGroupUpdate) =>
+    data(
+      updateActivityGroupApiV1ActivityGroupsGroupIdPut({
+        ...options(),
+        path: { group_id },
+        body,
+      }),
+    ),
+  deleteActivityGroup: (group_id: string) =>
+    data(
+      deleteActivityGroupApiV1ActivityGroupsGroupIdDelete({
+        ...options(),
+        path: { group_id },
+      }),
+    ),
+  goals: () =>
+    data(
+      getGoalsApiV1GoalsGet({
+        ...options(),
+        query: { include_archived: false },
+      }),
+    ),
+  createGoal: (body: GoalCreate) =>
+    data(createGoalApiV1GoalsPost({ ...options(), body })),
+  /** Historical period roll-up logs for one goal (`GET /goals/{id}/logs`),
+   *  newest period first. One record per period the goal has been evaluated in —
+   *  not a raw event feed. `limit` is 1–365; the backend default is 12. */
+  goalLogs: (goal_id: string, limit = 12) =>
+    data(
+      getGoalLogsApiV1GoalsGoalIdLogsGet({
+        ...options(),
+        path: { goal_id },
+        query: { limit },
+      }),
+    ),
+  updateGoal: (goal_id: string, body: GoalUpdate) =>
+    data(
+      updateGoalApiV1GoalsGoalIdPut({
+        ...options(),
+        path: { goal_id },
+        body,
+      }),
+    ),
+  deleteGoal: (goal_id: string) =>
+    data(
+      deleteGoalPermanentlyApiV1GoalsGoalIdDelete({
+        ...options(),
+        path: { goal_id },
+      }),
+    ),
+  /** Goal categories (`GET /goal-categories`). Responses do not embed members;
+   *  counts are derived from the full Goals response. */
+  goalCategories: () =>
+    data(getGoalCategoriesApiV1GoalCategoriesGet(options())),
+  createGoalCategory: (body: GoalCategoryCreate) =>
+    data(createGoalCategoryApiV1GoalCategoriesPost({ ...options(), body })),
+  updateGoalCategory: (category_id: string, body: GoalCategoryUpdate) =>
+    data(
+      updateGoalCategoryApiV1GoalCategoriesCategoryIdPut({
+        ...options(),
+        path: { category_id },
+        body,
+      }),
+    ),
+  deleteGoalCategory: (category_id: string) =>
+    data(
+      deleteGoalCategoryApiV1GoalCategoriesCategoryIdDelete({
+        ...options(),
+        path: { category_id },
+      }),
+    ),
+  createExport: (body: ExportJobCreateRequest) =>
+    data(createExportApiV1ExportPost({ ...options(), body })),
+  exportStatus: (job_id: string) =>
+    data(
+      getExportStatusApiV1ExportJobIdGet({
+        ...options(),
+        path: { job_id },
+      }),
+    ),
+  /** Short-lived signed download URL. The plain `download_url` on the status
+   *  response points at an endpoint that needs the Authorization header, so a
+   *  browser-native download can only use this. */
+  signExportUrl: (job_id: string) =>
+    data(
+      signExportUrlApiV1ExportJobIdSignGet({
+        ...options(),
+        path: { job_id },
+      }),
+    ),
+  uploadImport: (file: File, source_type: string) =>
+    data(
+      uploadImportApiV1ImportUploadPost({
+        ...options(),
+        body: { file, source_type },
+      }),
+    ),
+  importStatus: (job_id: string) =>
+    data(
+      getImportStatusApiV1ImportJobIdGet({
+        ...options(),
+        path: { job_id },
+      }),
+    ),
+  versionInfo: () => data(getVersionInfoApiV1InstanceVersionInfoGet(options())),
+  licenseInfo: () => data(getLicenseInfoApiV1InstanceLicenseInfoGet(options())),
+  integrationStatus: () =>
+    data(
+      getStatusApiV1IntegrationsProviderStatusGet({
+        ...options(),
+        path: { provider: "immich" },
+      }),
+    ),
+  connectImmich: (credentials: Record<string, unknown>) =>
+    data(
+      connectApiV1IntegrationsConnectPost({
+        ...options(),
+        body: { provider: "immich", credentials },
+      }),
+    ),
+  updateImmich: (body: IntegrationSettingsUpdateRequest) =>
+    data(
+      updateSettingsApiV1IntegrationsProviderSettingsPut({
+        ...options(),
+        path: { provider: "immich" },
+        body,
+      }),
+    ),
+  disconnectImmich: () =>
+    data(
+      disconnectApiV1IntegrationsProviderDisconnectDelete({
+        ...options(),
+        path: { provider: "immich" },
+      }),
+    ),
+  /** Tag name suggestions for the tag picker. */
+  searchTags: (q: string) =>
+    data(searchTagsApiV1TagsSearchGet({ ...options(), query: { q } })),
+  /** Adds tags to a Moment by name; returns the Moment's full tag set. */
+  addMomentTags: (moment_id: string, names: string[]) =>
+    data(
+      bulkAddTagsToMomentApiV1MomentsMomentIdTagsPost({
+        ...options(),
+        path: { moment_id },
+        body: names,
+      }),
+    ),
+  removeMomentTag: (moment_id: string, tag_id: string) =>
+    data(
+      removeTagFromMomentApiV1MomentsMomentIdTagsTagIdDelete({
+        ...options(),
+        path: { moment_id, tag_id },
+      }),
+    ),
+  /** Replaces the Moment's people with `person_ids`; returns the new set. */
+  setMomentPeople: (moment_id: string, person_ids: string[]) =>
+    data(
+      replaceMomentPeopleApiV1MomentsMomentIdPeoplePut({
+        ...options(),
+        path: { moment_id },
+        body: { person_ids },
+      }),
+    ),
+  /** Geocodes a free-text place query. */
+  searchLocation: (query: string) =>
+    data(
+      searchLocationApiV1LocationSearchPost({ ...options(), body: { query } }),
+    ),
+  /** Turns device coordinates into a named place. */
+  reverseGeocode: (latitude: number, longitude: number) =>
+    data(
+      reverseGeocodeApiV1LocationReversePost({
+        ...options(),
+        body: { latitude, longitude },
+      }),
+    ),
+  /** Fetches weather for a coordinate and time. May report the service is off. */
+  fetchWeather: (body: WeatherFetchRequest) =>
+    data(fetchWeatherApiV1WeatherFetchPost({ ...options(), body })),
+  moments: (query: NonNullable<GetMomentsApiV1MomentsGetData["query"]>) =>
+    data(getMomentsApiV1MomentsGet({ ...options(), query })),
+  /** Per-day moment counts, primary mood and a thumbnail — the calendar grid. */
+  momentCalendar: (
+    query: NonNullable<GetMomentCalendarApiV1MomentsCalendarGetData["query"]>,
+  ) => data(getMomentCalendarApiV1MomentsCalendarGet({ ...options(), query })),
+  /** Flat, paginated media across every moment — the Media grid. */
+  mediaLibrary: (
+    query: NonNullable<GetMediaLibraryApiV1MediaGetData["query"]>,
+  ) => data(getMediaLibraryApiV1MediaGet({ ...options(), query })),
+  moment: (moment_id: string) =>
+    data(
+      getMomentApiV1MomentsMomentIdGet({ ...options(), path: { moment_id } }),
+    ),
+  /** Authoritative accepted extensions, so the picker cannot invent its own. */
+  mediaFormats: () => data(getSupportedFormatsApiV1MediaFormatsGet(options())),
+  momentMedia: (moment_id: string) =>
+    data(
+      getMomentMediaApiV1MomentsMomentIdMediaGet({
+        ...options(),
+        path: { moment_id },
+      }),
+    ),
+  entry: (entry_id: string) =>
+    data(getEntryApiV1EntriesEntryIdGet({ ...options(), path: { entry_id } })),
+  /**
+   * Creates the server-side draft that owns uploaded media before an Entry is
+   * finalised. Draft Entries are excluded from the Timeline by
+   * `_apply_draft_filter`, so an abandoned one is invisible rather than junk.
+   */
+  createDraftEntry: (body: EntryDraftCreate) =>
+    data(createDraftEntryApiV1EntriesDraftPost({ ...options(), body })),
+  deleteMoment: (moment_id: string) =>
+    data(
+      deleteMomentApiV1MomentsMomentIdDelete({
+        ...options(),
+        path: { moment_id },
+      }),
+    ),
+  deleteMedia: (media_id: string) =>
+    data(
+      deleteMediaApiV1MediaMediaIdDelete({ ...options(), path: { media_id } }),
+    ),
+  deleteEntry: (entry_id: string) =>
+    data(
+      deleteEntryApiV1EntriesEntryIdDelete({
+        ...options(),
+        path: { entry_id },
+      }),
+    ),
+  createMoment: (body: MomentCreate) =>
+    data(createMomentApiV1MomentsPost({ ...options(), body })),
+  updateMoment: (moment_id: string, body: MomentUpdate) =>
+    data(
+      updateMomentApiV1MomentsMomentIdPut({
+        ...options(),
+        body,
+        path: { moment_id },
+      }),
+    ),
+};

--- a/frontend/src/api/client/config.test.ts
+++ b/frontend/src/api/client/config.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sessionStore } from "../auth/session";
+import { authenticatedFetch, resetAuthRefreshForTests } from "./config";
+
+describe("authenticatedFetch", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    resetAuthRefreshForTests();
+    sessionStore.write({
+      version: 1,
+      accessToken: "expired-access",
+      refreshToken: "valid-refresh",
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("uses one refresh request for concurrent 401 responses and retries both", async () => {
+    let refreshCalls = 0;
+    const fetchMock = vi.fn(
+      async (request: RequestInfo | URL, init?: RequestInit) => {
+        const candidate =
+          request instanceof Request
+            ? request
+            : new Request(new URL(request.toString(), "http://journiv.test"));
+        if (candidate.url.endsWith("/api/v1/auth/refresh")) {
+          refreshCalls += 1;
+          await Promise.resolve();
+          return Response.json({ access_token: "renewed-access" });
+        }
+        const headers = new Headers(init?.headers ?? candidate.headers);
+        return headers.get("Authorization") === "Bearer renewed-access"
+          ? Response.json({ ok: true })
+          : new Response(null, { status: 401 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const [first, second] = await Promise.all([
+      authenticatedFetch(
+        new Request("http://journiv.test/api/v1/moments", {
+          headers: { Authorization: "Bearer expired-access" },
+        }),
+      ),
+      authenticatedFetch(
+        new Request("http://journiv.test/api/v1/journals", {
+          headers: { Authorization: "Bearer expired-access" },
+        }),
+      ),
+    ]);
+
+    expect([first.status, second.status]).toEqual([200, 200]);
+    expect(refreshCalls).toBe(1);
+    expect(sessionStore.read()?.accessToken).toBe("renewed-access");
+  });
+
+  it("clears the session when refresh is rejected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: RequestInfo | URL) => {
+        const url =
+          request instanceof Request ? request.url : request.toString();
+        return new Response(null, {
+          status: url.endsWith("/api/v1/auth/refresh") ? 401 : 401,
+        });
+      }),
+    );
+
+    const response = await authenticatedFetch(
+      new Request("http://journiv.test/api/v1/moments"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(sessionStore.read()).toBeNull();
+  });
+});

--- a/frontend/src/api/client/config.ts
+++ b/frontend/src/api/client/config.ts
@@ -1,0 +1,84 @@
+import { createClient } from "../generated/client/client.gen";
+import { sessionStore } from "../auth/session";
+import { toApiError } from "./errors";
+
+let refreshing: Promise<string | null> | undefined;
+
+function apiBaseUrl() {
+  return import.meta.env.VITE_API_BASE_URL ?? "";
+}
+
+async function refreshAccessToken(baseFetch: typeof fetch) {
+  if (refreshing) return refreshing;
+  refreshing = (async () => {
+    const session = sessionStore.read();
+    if (!session) return null;
+    const response = await baseFetch(`${apiBaseUrl()}/api/v1/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: session.refreshToken }),
+    });
+    if (!response.ok) {
+      sessionStore.clear();
+      return null;
+    }
+    const body = (await response.json()) as { access_token?: string };
+    if (!body.access_token) {
+      sessionStore.clear();
+      return null;
+    }
+    sessionStore.write({ ...session, accessToken: body.access_token });
+    return body.access_token;
+  })().finally(() => {
+    refreshing = undefined;
+  });
+  return refreshing;
+}
+
+export async function authenticatedFetch(
+  request: RequestInfo | URL,
+  init?: RequestInit,
+) {
+  const baseFetch = globalThis.fetch;
+  const retryRequest = request instanceof Request ? request.clone() : request;
+  const response = await baseFetch(request, init);
+  const url =
+    typeof request === "string"
+      ? request
+      : request instanceof Request
+        ? request.url
+        : request.toString();
+  if (
+    response.status !== 401 ||
+    url.includes("/auth/login") ||
+    url.includes("/auth/refresh")
+  )
+    return response;
+  const token = await refreshAccessToken(baseFetch);
+  if (!token) return response;
+  const inheritedHeaders =
+    init?.headers ?? (request instanceof Request ? request.headers : undefined);
+  const headers = new Headers(inheritedHeaders);
+  headers.set("Authorization", `Bearer ${token}`);
+  return baseFetch(retryRequest, { ...init, headers });
+}
+
+export function configureApiClient() {
+  const token = sessionStore.read()?.accessToken;
+  const client = createClient({
+    baseUrl: apiBaseUrl(),
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    fetch: authenticatedFetch,
+  });
+  // The generated client throws the parsed response body, which carries no
+  // status. This is the one place that still has the Response, so it is the one
+  // place that can keep it. See `ApiError`.
+  client.interceptors.error.use((error, response) =>
+    toApiError(error, response),
+  );
+  return client;
+}
+
+export function resetAuthRefreshForTests() {
+  refreshing = undefined;
+}

--- a/frontend/src/api/client/errors.test.ts
+++ b/frontend/src/api/client/errors.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sessionStore } from "../auth/session";
+import { api } from "./api";
+import { ApiError, isConflict, isNotFound } from "./errors";
+import { resetAuthRefreshForTests } from "./config";
+
+describe("API errors keep the status", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    resetAuthRefreshForTests();
+    // Node's `Request` rejects a relative URL, which the browser accepts. The
+    // base is a test detail; the status plumbing is what is under test.
+    vi.stubEnv("VITE_API_BASE_URL", "http://journiv.test");
+    sessionStore.write({
+      version: 1,
+      accessToken: "access",
+      refreshToken: "refresh",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  const respondWith = (status: number, body: unknown) =>
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        body === undefined
+          ? new Response(null, { status })
+          : Response.json(body, { status }),
+      ),
+    );
+
+  it("carries a 404 through as a definite not-found", async () => {
+    respondWith(404, { detail: "Moment not found" });
+    const caught = await api.moment("missing").catch((error) => error);
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).status).toBe(404);
+    // FastAPI's `detail` becomes the message, so a raw throw still reads well.
+    expect((caught as ApiError).message).toBe("Moment not found");
+    expect(isNotFound(caught)).toBe(true);
+  });
+
+  it("recognises a conflict", async () => {
+    respondWith(409, { detail: "This entry changed somewhere else" });
+    const caught = await api
+      .updateMoment("moment-1", {})
+      .catch((error) => error);
+
+    expect(isConflict(caught)).toBe(true);
+    expect(isNotFound(caught)).toBe(false);
+  });
+
+  it("keeps the body for anything that wants more than the status", async () => {
+    respondWith(422, { detail: [{ loc: ["body", "title"], msg: "too long" }] });
+    const caught = (await api
+      .updateMoment("moment-1", {})
+      .catch((error) => error)) as ApiError;
+
+    expect(caught.status).toBe(422);
+    expect(caught.body).toEqual({
+      detail: [{ loc: ["body", "title"], msg: "too long" }],
+    });
+  });
+
+  it("never calls a request that got no answer a not-found", async () => {
+    // The whole reason the status is plumbed through: acting on absence must
+    // require having actually asked. An offline phone has not asked.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("Failed to fetch");
+      }),
+    );
+    const caught = await api.moment("moment-1").catch((error) => error);
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).status).toBeUndefined();
+    expect(isNotFound(caught)).toBe(false);
+    expect(isConflict(caught)).toBe(false);
+  });
+});

--- a/frontend/src/api/client/errors.ts
+++ b/frontend/src/api/client/errors.ts
@@ -1,0 +1,66 @@
+/**
+ * What the API said, including the status code.
+ *
+ * The generated client throws the parsed response BODY on a failed request, so
+ * by the time an error reaches a caller the status is gone — and "the Moment is
+ * gone" and "the network is gone" become the same value. They are not the same
+ * decision: dropping a draft's server identity because the Moment 404s is
+ * correct, and doing it because a phone lost signal orphans a Moment nobody
+ * will ever finalise.
+ *
+ * So `configureApiClient` wraps every failure in this. `status` is the HTTP
+ * status, or `undefined` when the request never got an answer at all.
+ */
+export class ApiError extends Error {
+  /** HTTP status, or undefined when the request never reached a response. */
+  readonly status?: number;
+  /** The parsed error body, exactly as the API sent it. */
+  readonly body: unknown;
+
+  constructor(
+    message: string,
+    options: { status?: number; body?: unknown; cause?: unknown } = {},
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "ApiError";
+    this.status = options.status;
+    this.body = options.body;
+  }
+}
+
+/** `detail` is FastAPI's error field; anything else falls back to the status. */
+function messageFor(body: unknown, status?: number): string {
+  if (typeof body === "string" && body.trim()) return body;
+  if (body && typeof body === "object" && "detail" in body) {
+    const detail = (body as { detail: unknown }).detail;
+    if (typeof detail === "string" && detail.trim()) return detail;
+  }
+  return status ? `Request failed with status ${status}` : "Request failed";
+}
+
+/** Wraps whatever the generated client threw, keeping the response status. */
+export function toApiError(caught: unknown, response?: Response): ApiError {
+  if (caught instanceof ApiError) return caught;
+  const status = response?.status;
+  return new ApiError(messageFor(caught, status), {
+    status,
+    body: caught,
+    cause: caught,
+  });
+}
+
+/**
+ * A definite "this does not exist" from the server.
+ *
+ * Deliberately narrow: a thrown value with no status is NOT a 404. Every caller
+ * of this is about to act on the absence of something, and "I could not ask"
+ * must never be mistaken for "I asked and it is gone".
+ */
+export function isNotFound(caught: unknown): boolean {
+  return caught instanceof ApiError && caught.status === 404;
+}
+
+/** The entry moved underneath this edit; see DESIGN.md §14, "Concurrent edits". */
+export function isConflict(caught: unknown): boolean {
+  return caught instanceof ApiError && caught.status === 409;
+}

--- a/frontend/src/api/query/keys.test.ts
+++ b/frontend/src/api/query/keys.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { momentsQuery } from "./options";
+import { normalizeMomentFilters, queryKeys } from "./keys";
+
+describe("moment query policy", () => {
+  it("normalizes blank search filters and produces deterministic keys", () => {
+    expect(
+      normalizeMomentFilters({ journal_id: "journal-1", search: "  " }),
+    ).toEqual({
+      journal_id: "journal-1",
+    });
+    expect(queryKeys.moments({ search: " rain " })).toEqual([
+      "moments",
+      { search: "rain" },
+    ]);
+  });
+
+  it("maps an entity scope to its GET /moments filter", () => {
+    expect(normalizeMomentFilters({ person_id: "p1" })).toEqual({
+      person_ids: ["p1"],
+    });
+    expect(normalizeMomentFilters({ tag_id: "t1" })).toEqual({
+      tag_ids: ["t1"],
+    });
+    expect(normalizeMomentFilters({ activity_id: "a1" })).toEqual({
+      activity_ids: ["a1"],
+    });
+    expect(normalizeMomentFilters({ mood_id: "m1" })).toEqual({
+      mood_ids: ["m1"],
+    });
+    expect(normalizeMomentFilters({ goal_id: "g1" })).toEqual({
+      goal_id: "g1",
+    });
+  });
+
+  it("gives each entity scope its own momentsQuery cache key", () => {
+    const key = (f: Parameters<typeof momentsQuery>[0]) =>
+      JSON.stringify(momentsQuery(f).queryKey);
+    const all = key({});
+    expect(key({ person_id: "p1" })).not.toEqual(all);
+    expect(key({ tag_id: "t1" })).not.toEqual(all);
+    expect(key({ goal_id: "g1" })).not.toEqual(all);
+    expect(key({ person_id: "p1" })).not.toEqual(key({ person_id: "p2" }));
+    expect(key({ person_id: "p1" })).not.toEqual(key({ tag_id: "p1" }));
+  });
+});

--- a/frontend/src/api/query/keys.ts
+++ b/frontend/src/api/query/keys.ts
@@ -1,0 +1,110 @@
+export type MomentFilters = {
+  journal_id?: string;
+  /** Entity scope — at most one is set at a time (DESIGN.md §24 "View
+   *  moments"). Each resolves to the matching `GET /moments` filter: a single
+   *  id passed as the backend's repeatable list param, or `goal_id` directly. */
+  person_id?: string;
+  tag_id?: string;
+  activity_id?: string;
+  mood_id?: string;
+  goal_id?: string;
+  search?: string;
+  /** ISO `YYYY-MM-DD`. Used by the calendar's selected-day panel. */
+  start_date?: string;
+  end_date?: string;
+};
+
+export function normalizeMomentFilters(filters: MomentFilters) {
+  return {
+    ...(filters.journal_id ? { journal_id: filters.journal_id } : {}),
+    ...(filters.person_id ? { person_ids: [filters.person_id] } : {}),
+    ...(filters.tag_id ? { tag_ids: [filters.tag_id] } : {}),
+    ...(filters.activity_id ? { activity_ids: [filters.activity_id] } : {}),
+    ...(filters.mood_id ? { mood_ids: [filters.mood_id] } : {}),
+    ...(filters.goal_id ? { goal_id: filters.goal_id } : {}),
+    ...(filters.search?.trim() ? { search: filters.search.trim() } : {}),
+    ...(filters.start_date ? { start_date: filters.start_date } : {}),
+    ...(filters.end_date ? { end_date: filters.end_date } : {}),
+  };
+}
+
+export type CalendarFilters = {
+  journal_id?: string;
+  start: string;
+  end: string;
+};
+export type MediaFilters = { journal_id?: string; media_type?: string };
+
+export function normalizeCalendarFilters(filters: CalendarFilters) {
+  return {
+    ...(filters.journal_id ? { journal_id: filters.journal_id } : {}),
+    start_date: filters.start,
+    end_date: filters.end,
+  };
+}
+
+export function normalizeMediaFilters(filters: MediaFilters) {
+  return {
+    ...(filters.journal_id ? { journal_id: filters.journal_id } : {}),
+    ...(filters.media_type ? { media_type: filters.media_type } : {}),
+  };
+}
+
+export const queryKeys = {
+  me: ["current-user"] as const,
+  /** Preferences behind `/users/me/settings` — timezone, and the future
+   *  Appearance / Journaling controls. Settings → Profile owns the timezone
+   *  slice today; later pages read the same key. */
+  userSettings: ["user-settings"] as const,
+  /** Instance capability flags (`oidc_enabled`, `oidc_only`, …). Server
+   *  configuration, cached hard. */
+  instanceConfig: ["instance-config"] as const,
+  adminUsers: ["admin", "users"] as const,
+  journals: ["journals"] as const,
+  moods: ["moods"] as const,
+  moodGroups: ["mood-groups"] as const,
+  people: ["people"] as const,
+  personGroups: ["people-groups"] as const,
+  tags: ["tags"] as const,
+  activities: ["activities"] as const,
+  activityGroups: ["activity-groups"] as const,
+  goals: ["goals"] as const,
+  goalCategories: ["goal-categories"] as const,
+  /** Per-goal completion history. Nested under `["goals", id]` so invalidating
+   *  goals by prefix also drops a goal's logs — a completion toggle changes
+   *  both. Do not flatten to a sibling key. */
+  goalLogs: (id: string) => ["goals", id, "logs"] as const,
+  versionInfo: ["instance", "version"] as const,
+  licenseInfo: ["instance", "license"] as const,
+  integrationStatus: (provider: string) =>
+    ["integrations", provider, "status"] as const,
+  exportJob: (id: string) => ["export", id] as const,
+  exportDownload: (id: string) => ["export", id, "signed"] as const,
+  importJob: (id: string) => ["import", id] as const,
+  tagSearch: (q: string) => ["tags", "search", q] as const,
+  /** Aggregate tag analytics (Journiv Plus). */
+  tagAnalytics: ["tags", "analytics"] as const,
+  /** One tag's analytics over `days` (Journiv Plus). Nested under the tag so a
+   *  rename/merge that invalidates `["tags"]` also drops it. */
+  tagDetailAnalytics: (id: string, days: number) =>
+    ["tags", id, "analytics", days] as const,
+  /** Moments carrying one tag — the tag detail pane's preview list. */
+  tagMoments: (id: string) => ["tags", id, "moments"] as const,
+  mediaFormats: ["media-formats"] as const,
+  moments: (filters: MomentFilters) =>
+    ["moments", normalizeMomentFilters(filters)] as const,
+  momentCalendar: (filters: CalendarFilters) =>
+    ["moment-calendar", normalizeCalendarFilters(filters)] as const,
+  mediaLibrary: (filters: MediaFilters) =>
+    ["media-library", normalizeMediaFilters(filters)] as const,
+  moment: (id: string) => ["moment", id] as const,
+  /**
+   * Deliberately nested under `moment(id)`. Invalidating the Moment — which the
+   * editor already does after a save — also invalidates its media by prefix
+   * match, so media cannot go stale behind a fresh Moment. Do not flatten this
+   * to a sibling key such as ["moment-media", id].
+   */
+  momentMedia: (id: string) => ["moment", id, "media"] as const,
+  entry: (id: string) => ["entry", id] as const,
+  allMoments: ["moments"] as const,
+};

--- a/frontend/src/api/query/options.ts
+++ b/frontend/src/api/query/options.ts
@@ -1,0 +1,281 @@
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { api } from "../client/api";
+import {
+  normalizeMomentFilters,
+  queryKeys,
+  type CalendarFilters,
+  type MediaFilters,
+  type MomentFilters,
+} from "./keys";
+
+export const currentUserQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.me,
+    queryFn: () => api.me(),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+export const userSettingsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.userSettings,
+    queryFn: () => api.userSettings(),
+    staleTime: 60_000,
+    retry: false,
+  });
+export const instanceConfigQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.instanceConfig,
+    queryFn: () => api.instanceConfig(),
+    staleTime: 3_600_000,
+    retry: false,
+  });
+export const adminUsersQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.adminUsers,
+    queryFn: () => api.adminUsers(),
+    staleTime: 30_000,
+    retry: false,
+  });
+
+export const journalsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.journals,
+    queryFn: () => api.journals(),
+    staleTime: 60_000,
+  });
+export const moodsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.moods,
+    queryFn: () => api.moods(),
+    staleTime: 300_000,
+  });
+export const moodGroupsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.moodGroups,
+    queryFn: () => api.moodGroups(),
+    staleTime: 300_000,
+  });
+export const peopleQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.people,
+    queryFn: () => api.people(),
+    staleTime: 300_000,
+  });
+export const personGroupsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.personGroups,
+    queryFn: () => api.personGroups(),
+    staleTime: 300_000,
+  });
+export const tagsQuery = () =>
+  queryOptions({ queryKey: queryKeys.tags, queryFn: () => api.tags() });
+export const activitiesQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.activities,
+    queryFn: () => api.activities(),
+    staleTime: 300_000,
+  });
+export const activityGroupsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.activityGroups,
+    queryFn: () => api.activityGroups(),
+    staleTime: 300_000,
+  });
+export const goalsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.goals,
+    queryFn: () => api.goals(),
+    staleTime: 300_000,
+  });
+export const goalCategoriesQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.goalCategories,
+    queryFn: () => api.goalCategories(),
+    staleTime: 300_000,
+  });
+/** One goal's completion history, newest period first. Fetched on demand when
+ *  the history dialog opens; short stale window so a revisit reflects a recent
+ *  toggle. */
+export const goalLogsQuery = (goalId: string) =>
+  queryOptions({
+    queryKey: queryKeys.goalLogs(goalId),
+    queryFn: () => api.goalLogs(goalId),
+    staleTime: 60_000,
+  });
+export const versionInfoQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.versionInfo,
+    queryFn: () => api.versionInfo(),
+  });
+export const licenseInfoQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.licenseInfo,
+    queryFn: () => api.licenseInfo(),
+  });
+export const integrationStatusQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.integrationStatus("immich"),
+    queryFn: () => api.integrationStatus(),
+    retry: false,
+  });
+export const exportJobQuery = (id: string) =>
+  queryOptions({
+    queryKey: queryKeys.exportJob(id),
+    queryFn: () => api.exportStatus(id),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === "pending" || status === "running" ? 1000 : false;
+    },
+  });
+export const importJobQuery = (id: string) =>
+  queryOptions({
+    queryKey: queryKeys.importJob(id),
+    queryFn: () => api.importStatus(id),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === "pending" || status === "running" ? 1000 : false;
+    },
+  });
+/** A fresh signed download URL for a completed export. Enable only once the job
+ *  reports `completed`; the signature is short-lived, so it is not cached. */
+export const exportDownloadQuery = (id: string) =>
+  queryOptions({
+    queryKey: queryKeys.exportDownload(id),
+    queryFn: () => api.signExportUrl(id),
+    gcTime: 0,
+    staleTime: 0,
+    retry: false,
+  });
+export const tagSearchQuery = (q: string) =>
+  queryOptions({
+    queryKey: queryKeys.tagSearch(q),
+    queryFn: () => api.searchTags(q),
+    staleTime: 60_000,
+  });
+/**
+ * Aggregate tag analytics (Journiv Plus, Supporter+). `retry: false` because a
+ * 403/503 is a capability answer, not a transient failure — the caller renders
+ * a locked state from it, never a spinner loop.
+ */
+export const tagAnalyticsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.tagAnalytics,
+    queryFn: () => api.tagAnalytics(),
+    staleTime: 300_000,
+    retry: false,
+  });
+/** One tag's analytics over `days` (Journiv Plus, Supporter+). */
+export const tagDetailAnalyticsQuery = (tagId: string, days: number) =>
+  queryOptions({
+    queryKey: queryKeys.tagDetailAnalytics(tagId, days),
+    queryFn: () => api.tagDetailAnalytics(tagId, days),
+    staleTime: 300_000,
+    retry: false,
+  });
+/** The tag detail pane's moments preview. Signed thumbnail URLs expire, so it
+ *  is cached briefly, matching `momentMediaQuery`. */
+export const tagMomentsQuery = (tagId: string) =>
+  queryOptions({
+    queryKey: queryKeys.tagMoments(tagId),
+    queryFn: () => api.tagMoments(tagId),
+    staleTime: 60_000,
+  });
+/**
+ * Accepted media formats. Server configuration, so it is cached hard — the
+ * picker must reflect the backend's limits, never its own guess.
+ */
+export const mediaFormatsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.mediaFormats,
+    queryFn: () => api.mediaFormats(),
+    staleTime: 3_600_000,
+  });
+export const momentQuery = (id: string) =>
+  queryOptions({
+    queryKey: queryKeys.moment(id),
+    queryFn: () => api.moment(id),
+  });
+/**
+ * Full media for one Moment. The Moment response carries thumbnails only, so
+ * this is a second, deliberately separate query: it must never block the entry
+ * text from rendering.
+ */
+export const momentMediaQuery = (id: string) =>
+  queryOptions({
+    queryKey: queryKeys.momentMedia(id),
+    queryFn: () => api.momentMedia(id),
+    // Signed URLs expire. Keeping this short means an ordinary revisit
+    // re-signs rather than rendering a dead URL.
+    staleTime: 60_000,
+  });
+export const entryQuery = (id: string) =>
+  queryOptions({ queryKey: queryKeys.entry(id), queryFn: () => api.entry(id) });
+export const momentsQuery = (filters: MomentFilters) => {
+  // `queryKeys.moments` normalises internally, so hand it the raw filters —
+  // normalising twice would drop the entity-scope keys (`person_id` →
+  // `person_ids`, which a second pass no longer recognises) and collapse every
+  // scope onto the same cache key.
+  const normalized = normalizeMomentFilters(filters);
+  return infiniteQueryOptions({
+    queryKey: queryKeys.moments(filters),
+    queryFn: ({ pageParam }) =>
+      api.moments({
+        ...normalized,
+        include_media: "thumbnails",
+        include_drafts: false,
+        include_empty: false,
+        ...(pageParam ?? {}),
+      }),
+    initialPageParam: undefined as
+      | { cursor_logged_at_utc?: string; cursor_id?: string }
+      | undefined,
+    getNextPageParam: (page) =>
+      page.next_cursor_logged_at_utc && page.next_cursor_id
+        ? {
+            cursor_logged_at_utc: page.next_cursor_logged_at_utc,
+            cursor_id: page.next_cursor_id,
+          }
+        : undefined,
+  });
+};
+/**
+ * Per-day summary for the calendar grid. Signed thumbnail URLs expire, so this
+ * is cached briefly — an ordinary revisit re-signs rather than rendering a dead
+ * URL, matching `momentMediaQuery`.
+ */
+export const momentCalendarQuery = (filters: CalendarFilters) =>
+  queryOptions({
+    queryKey: queryKeys.momentCalendar(filters),
+    queryFn: () =>
+      api.momentCalendar({
+        start_date: filters.start,
+        end_date: filters.end,
+        ...(filters.journal_id ? { journal_id: filters.journal_id } : {}),
+      }),
+    staleTime: 60_000,
+  });
+/** Flat, paginated media across every moment — the Media grid. */
+export const mediaLibraryQuery = (filters: MediaFilters) =>
+  infiniteQueryOptions({
+    queryKey: queryKeys.mediaLibrary(filters),
+    queryFn: ({ pageParam }) =>
+      api.mediaLibrary({
+        ...(filters.journal_id ? { journal_id: filters.journal_id } : {}),
+        ...(filters.media_type
+          ? { media_type: filters.media_type as "image" | "video" | "audio" }
+          : {}),
+        ...(pageParam ?? {}),
+      }),
+    initialPageParam: undefined as
+      | { cursor_logged_at_utc?: string; cursor_id?: string }
+      | undefined,
+    getNextPageParam: (page) =>
+      page.next_cursor_logged_at_utc && page.next_cursor_id
+        ? {
+            cursor_logged_at_utc: page.next_cursor_logged_at_utc,
+            cursor_id: page.next_cursor_id,
+          }
+        : undefined,
+    staleTime: 60_000,
+  });

--- a/frontend/src/app/queryClient.ts
+++ b/frontend/src/app/queryClient.ts
@@ -1,0 +1,7 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function createAppQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: 1, staleTime: 30_000 } },
+  });
+}


### PR DESCRIPTION
Configure the same-origin generated Fetch client, temporary session abstraction, single-flight access-token refresh, structured API errors, and shared TanStack Query client. Keep generated transport code isolated behind handwritten request and query helpers.

Define stable query keys, pagination and invalidation policies for Journals, Moments, Entries, media, settings, and library entities, with focused tests for authentication, configuration, errors, and key construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated API access across journals, moods, people, tags, activities, goals, media, moments, imports, exports, and integrations.
  * Added secure browser session handling with token persistence, automatic refresh, and session clearing when authentication expires.
  * Added consistent API error messages and handling for common responses such as not found and conflicts.
  * Added streamlined data loading, caching, filtering, and pagination for faster, more reliable screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->