### PR TITLE
feat(frontend): add shared Journiv domain utilities

### DIFF
--- a/frontend/src/lib/color.ts
+++ b/frontend/src/lib/color.ts
@@ -1,0 +1,37 @@
+import { JOURNAL_COLORS } from "./journalColors";
+
+/**
+ * The Flutter client stores colours as ARGB integers (`primary_mood_id`,
+ * `PersonGroup.color_value`, …). Journiv's chrome needs a CSS hex string, and
+ * only the low 24 bits carry the hue — the alpha byte is ignored. This is the
+ * one translation; `MomentMeta` re-exports it as `moodColor` for its callers.
+ * Returns `undefined` (not a guessed colour) when there is no usable value, so
+ * `JournalDot`-style fallbacks (`var(--entity-accent, var(--line-strong))`)
+ * take over. See DESIGN.md §3.
+ */
+export function colorFromArgb(value?: number | null): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return `#${(value & 0xffffff).toString(16).padStart(6, "0")}`;
+}
+
+/**
+ * Inverse of {@link colorFromArgb}: a `#rrggbb` preset back to a full-opacity
+ * ARGB integer for `color_value` writes. Returns `null` for anything that is not
+ * a six-digit hex string.
+ */
+export function argbFromHex(hex: string): number | null {
+  const match = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!match) return null;
+  return (0xff000000 | Number.parseInt(match[1], 16)) >>> 0;
+}
+
+/**
+ * The colour presets offered when a Library entity (a person group, later a
+ * mood or activity) carries a `color_value`. The palette is shared with the
+ * journal picker so the product reads as one system; the values are plain
+ * hues here, not an API enum contract.
+ */
+export const ENTITY_COLOR_PRESETS: ReadonlyArray<{
+  hex: string;
+  label: string;
+}> = JOURNAL_COLORS.map((color) => ({ hex: color.value, label: color.label }));

--- a/frontend/src/lib/datetime.test.ts
+++ b/frontend/src/lib/datetime.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  dayGroupLabel,
+  formatDayMedium,
   wallTimePartsInZone,
   zonedWallTimeToUtcIso,
   type WallTimeParts,
@@ -64,5 +66,29 @@ describe("wallTimePartsInZone", () => {
     expect(
       wallTimePartsInZone("2026-02-15T23:30:00.000Z", "Asia/Kolkata"),
     ).toEqual({ year: 2026, month: 2, day: 16, hour: 5, minute: 0 });
+  });
+});
+
+describe("dayGroupLabel", () => {
+  it("uses the viewer's local year at the New Year boundary", () => {
+    const resolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions;
+    const spy = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockImplementation(function (this: Intl.DateTimeFormat) {
+        return {
+          ...resolvedOptions.call(this),
+          timeZone: "America/Los_Angeles",
+        };
+      });
+
+    try {
+      const now = new Date("2027-01-01T00:30:00.000Z");
+      const utc = "2026-12-30T17:00:00.000Z";
+      expect(dayGroupLabel("2026-12-30", "America/New_York", utc, now)).toBe(
+        formatDayMedium(utc, "America/New_York"),
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/frontend/src/lib/datetime.test.ts
+++ b/frontend/src/lib/datetime.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  wallTimePartsInZone,
+  zonedWallTimeToUtcIso,
+  type WallTimeParts,
+} from "./datetime";
+
+describe("zonedWallTimeToUtcIso", () => {
+  it("interprets the same wall-clock differently per zone", () => {
+    const parts: WallTimeParts = {
+      year: 2026,
+      month: 1,
+      day: 15,
+      hour: 20,
+      minute: 0,
+    };
+    // Warsaw is UTC+1 in January; Los Angeles is UTC-8.
+    expect(zonedWallTimeToUtcIso(parts, "Europe/Warsaw")).toBe(
+      "2026-01-15T19:00:00.000Z",
+    );
+    expect(zonedWallTimeToUtcIso(parts, "America/Los_Angeles")).toBe(
+      "2026-01-16T04:00:00.000Z",
+    );
+  });
+
+  it("round-trips through wallTimePartsInZone", () => {
+    const parts: WallTimeParts = {
+      year: 2025,
+      month: 7,
+      day: 4,
+      hour: 8,
+      minute: 30,
+    };
+    for (const tz of ["Europe/Warsaw", "America/Los_Angeles", "Asia/Kolkata"]) {
+      const utc = zonedWallTimeToUtcIso(parts, tz);
+      expect(wallTimePartsInZone(utc, tz)).toEqual(parts);
+    }
+  });
+
+  it("pushes a nonexistent spring-forward local time past the gap", () => {
+    // 2025-03-09 02:30 does not exist in New York (02:00 -> 03:00).
+    const utc = zonedWallTimeToUtcIso(
+      { year: 2025, month: 3, day: 9, hour: 2, minute: 30 },
+      "America/New_York",
+    );
+    // date-fns-tz resolves it deterministically with the pre-gap offset
+    // (EST, -5), so the instant lands just after the skipped hour.
+    expect(utc).toBe("2025-03-09T07:30:00.000Z");
+  });
+
+  it("resolves an ambiguous fall-back local time to the earlier offset", () => {
+    // 2025-11-02 01:30 happens twice in New York; the first is EDT (-4).
+    const utc = zonedWallTimeToUtcIso(
+      { year: 2025, month: 11, day: 2, hour: 1, minute: 30 },
+      "America/New_York",
+    );
+    expect(utc).toBe("2025-11-02T05:30:00.000Z");
+  });
+});
+
+describe("wallTimePartsInZone", () => {
+  it("reads the calendar day in the target zone, not the caller's", () => {
+    // 23:30 UTC on the 15th is already the 16th in Kolkata (+5:30).
+    expect(
+      wallTimePartsInZone("2026-02-15T23:30:00.000Z", "Asia/Kolkata"),
+    ).toEqual({ year: 2026, month: 2, day: 16, hour: 5, minute: 0 });
+  });
+});

--- a/frontend/src/lib/datetime.ts
+++ b/frontend/src/lib/datetime.ts
@@ -1,0 +1,146 @@
+/**
+ * All Moment dates are rendered in the timezone the Moment happened in, not the
+ * viewer's. `logged_date_tz` is the authoritative local calendar day and is what
+ * the Timeline groups by. See DESIGN.md "Time and grouping".
+ */
+import { fromZonedTime, toZonedTime } from "date-fns-tz";
+
+const viewerTimezone = () =>
+  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+
+/** The viewer's own IANA timezone (e.g. `Europe/Vienna`). */
+export function browserTimeZone() {
+  return viewerTimezone();
+}
+
+/** A wall-clock date/time with no zone of its own. `month` is 1-based. */
+export type WallTimeParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+};
+
+/**
+ * The wall-clock a UTC instant shows as in `timeZone`. Use this to seed a date
+ * picker so the highlighted day is the day *in the entry's own zone*, not the
+ * viewer's.
+ */
+export function wallTimePartsInZone(
+  utcIso: string,
+  timeZone: string,
+): WallTimeParts {
+  const zoned = toZonedTime(utcIso, timeZone);
+  return {
+    year: zoned.getFullYear(),
+    month: zoned.getMonth() + 1,
+    day: zoned.getDate(),
+    hour: zoned.getHours(),
+    minute: zoned.getMinutes(),
+  };
+}
+
+/**
+ * The UTC instant (ISO string) for a wall-clock time interpreted in `timeZone`.
+ * DST-correct via `date-fns-tz`: a nonexistent spring-forward time is shifted
+ * past the gap; an ambiguous fall-back time resolves to the earlier offset.
+ * `react-day-picker` hands back a `Date` at browser-local midnight — take only
+ * its y/m/d, combine with the time field, and pass the parts here; never
+ * persist that `Date`'s own `toISOString()`.
+ */
+export function zonedWallTimeToUtcIso(
+  { year, month, day, hour, minute }: WallTimeParts,
+  timeZone: string,
+): string {
+  const floating = new Date(year, month - 1, day, hour, minute, 0, 0);
+  return fromZonedTime(floating, timeZone).toISOString();
+}
+
+function format(
+  value: string,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions,
+) {
+  return new Intl.DateTimeFormat(undefined, {
+    ...options,
+    timeZone: timezone,
+  }).format(new Date(value));
+}
+
+export function formatTimeOfDay(utc: string, timezone: string) {
+  return format(utc, timezone, { hour: "numeric", minute: "2-digit" });
+}
+
+export function formatDayLong(utc: string, timezone: string) {
+  return format(utc, timezone, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function formatDayMedium(utc: string, timezone: string) {
+  return format(utc, timezone, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+/**
+ * A short absolute date ("17 August 2026") in the viewer's timezone. For
+ * journal-level aggregates such as `last_entry_at`, which — unlike a Moment —
+ * have no timezone of their own, so the ambiguity rules in §12 do not apply.
+ */
+export function formatDateMedium(utc: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: viewerTimezone(),
+  }).format(new Date(utc));
+}
+
+/** Today's calendar date (YYYY-MM-DD) in the given timezone. */
+export function todayInTimezone(timezone: string, now = new Date()) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+export function shiftIsoDate(isoDate: string, days: number) {
+  const date = new Date(`${isoDate}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Heading for a day group.
+ *
+ * "Today" / "Yesterday" are only used when the Moment was logged in the
+ * viewer's own timezone. Across timezones those words are ambiguous, so the
+ * explicit date is shown instead. This is deliberate — do not "simplify" it.
+ */
+export function dayGroupLabel(
+  loggedDateTz: string,
+  loggedTimezone: string,
+  loggedAtUtc: string,
+  now = new Date(),
+) {
+  const viewer = viewerTimezone();
+  if (loggedTimezone === viewer) {
+    const today = todayInTimezone(viewer, now);
+    if (loggedDateTz === today) return "Today";
+    if (loggedDateTz === shiftIsoDate(today, -1)) return "Yesterday";
+  }
+  const thisYear = new Date(now).getUTCFullYear();
+  const momentYear = Number(loggedDateTz.slice(0, 4));
+  return momentYear === thisYear
+    ? formatDayMedium(loggedAtUtc, loggedTimezone)
+    : formatDayLong(loggedAtUtc, loggedTimezone);
+}

--- a/frontend/src/lib/datetime.ts
+++ b/frontend/src/lib/datetime.ts
@@ -158,12 +158,12 @@ export function dayGroupLabel(
   now = new Date(),
 ) {
   const viewer = viewerTimezone();
+  const today = todayInTimezone(viewer, now);
   if (loggedTimezone === viewer) {
-    const today = todayInTimezone(viewer, now);
     if (loggedDateTz === today) return "Today";
     if (loggedDateTz === shiftIsoDate(today, -1)) return "Yesterday";
   }
-  const thisYear = new Date(now).getUTCFullYear();
+  const thisYear = Number(today.slice(0, 4));
   const momentYear = Number(loggedDateTz.slice(0, 4));
   return momentYear === thisYear
     ? formatDayMedium(loggedAtUtc, loggedTimezone)

--- a/frontend/src/lib/datetime.ts
+++ b/frontend/src/lib/datetime.ts
@@ -22,6 +22,18 @@ export type WallTimeParts = {
   minute: number;
 };
 
+function wallTimeValue({ year, month, day, hour, minute }: WallTimeParts) {
+  return Date.UTC(year, month - 1, day, hour, minute);
+}
+
+function wallTimeIso({ year, month, day, hour, minute }: WallTimeParts) {
+  return `${year.toString().padStart(4, "0")}-${month
+    .toString()
+    .padStart(2, "0")}-${day.toString().padStart(2, "0")}T${hour
+    .toString()
+    .padStart(2, "0")}:${minute.toString().padStart(2, "0")}:00`;
+}
+
 /**
  * The wall-clock a UTC instant shows as in `timeZone`. Use this to seed a date
  * picker so the highlighted day is the day *in the entry's own zone*, not the
@@ -53,8 +65,21 @@ export function zonedWallTimeToUtcIso(
   { year, month, day, hour, minute }: WallTimeParts,
   timeZone: string,
 ): string {
-  const floating = new Date(year, month - 1, day, hour, minute, 0, 0);
-  return fromZonedTime(floating, timeZone).toISOString();
+  const parts = { year, month, day, hour, minute };
+  // Passing a string avoids `new Date(y, m, …)` normalizing a nonexistent
+  // time in the browser's own timezone before it reaches `date-fns-tz`.
+  const utc = fromZonedTime(wallTimeIso(parts), timeZone);
+
+  // For a nonexistent time, date-fns-tz's result round-trips to a wall-clock
+  // time before the requested one. Add that difference to preserve the
+  // position in the gap: 02:30 becomes 03:30.
+  const rendered = wallTimePartsInZone(utc.toISOString(), timeZone);
+  const gapMilliseconds = wallTimeValue(parts) - wallTimeValue(rendered);
+  if (gapMilliseconds > 0) {
+    return new Date(utc.getTime() + gapMilliseconds).toISOString();
+  }
+
+  return utc.toISOString();
 }
 
 function format(

--- a/frontend/src/lib/geolocation.test.ts
+++ b/frontend/src/lib/geolocation.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  coordinateLabel,
+  geolocationErrorMessage,
+  GeolocationUnavailableError,
+  getCurrentPosition,
+} from "./geolocation";
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, "geolocation");
+  Reflect.deleteProperty(window, "isSecureContext");
+});
+
+function stub(getCurrentPosition: unknown) {
+  Object.defineProperty(navigator, "geolocation", {
+    configurable: true,
+    value: { getCurrentPosition },
+  });
+}
+
+describe("getCurrentPosition", () => {
+  it("resolves plain coordinates from the browser position", async () => {
+    stub((ok: (p: unknown) => void) =>
+      ok({ coords: { latitude: 51.5, longitude: -0.12, accuracy: 10 } }),
+    );
+    await expect(getCurrentPosition()).resolves.toEqual({
+      latitude: 51.5,
+      longitude: -0.12,
+    });
+  });
+
+  it("rejects with GeolocationUnavailableError when the API is absent", async () => {
+    await expect(getCurrentPosition()).rejects.toBeInstanceOf(
+      GeolocationUnavailableError,
+    );
+  });
+
+  it("passes through the browser's own position error", async () => {
+    const failure = { code: 3, message: "timeout" };
+    stub((_ok: unknown, err: (e: unknown) => void) => err(failure));
+    await expect(getCurrentPosition()).rejects.toBe(failure);
+  });
+});
+
+describe("geolocationErrorMessage", () => {
+  it("explains an insecure context before anything else", () => {
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    expect(geolocationErrorMessage({ code: 1 })).toMatch(/secure \(https\)/i);
+  });
+
+  it("maps the standard position-error codes to sentences", () => {
+    expect(geolocationErrorMessage({ code: 1 })).toMatch(
+      /permission was denied/i,
+    );
+    expect(geolocationErrorMessage({ code: 2 })).toMatch(/isn't available/i);
+    expect(geolocationErrorMessage({ code: 3 })).toMatch(/too long/i);
+  });
+
+  it("handles a missing API and unknown failures", () => {
+    expect(geolocationErrorMessage(new GeolocationUnavailableError())).toMatch(
+      /can't share your location/i,
+    );
+    expect(geolocationErrorMessage(new Error("weird"))).toMatch(
+      /couldn't get your location/i,
+    );
+  });
+});
+
+describe("coordinateLabel", () => {
+  it("formats to four decimal places", () => {
+    expect(coordinateLabel({ latitude: 12.34567, longitude: -8.2 })).toBe(
+      "12.3457, -8.2000",
+    );
+  });
+});

--- a/frontend/src/lib/geolocation.ts
+++ b/frontend/src/lib/geolocation.ts
@@ -1,0 +1,73 @@
+/**
+ * Thin promise wrapper around the browser Geolocation API, used by the editor's
+ * "Use current location" control.
+ *
+ * Geolocation is a secure-context API. A self-hosted Journiv reached over plain
+ * HTTP on a LAN is not a secure context, so `getCurrentPosition` there fails
+ * rather than prompting. That is acceptable **only because** the failure is
+ * always surfaced (`geolocationErrorMessage`) and the manual place search is
+ * always available — nothing here may fail silently.
+ */
+
+export type GeoCoords = { latitude: number; longitude: number };
+
+/** Thrown when the API is not present at all (very old or locked-down browser). */
+export class GeolocationUnavailableError extends Error {
+  constructor() {
+    super("Geolocation is not available in this browser");
+    this.name = "GeolocationUnavailableError";
+  }
+}
+
+export function getCurrentPosition(
+  options?: PositionOptions,
+): Promise<GeoCoords> {
+  return new Promise((resolve, reject) => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      reject(new GeolocationUnavailableError());
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (position) =>
+        resolve({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        }),
+      (error) => reject(error),
+      {
+        enableHighAccuracy: false,
+        timeout: 15_000,
+        maximumAge: 60_000,
+        ...options,
+      },
+    );
+  });
+}
+
+/** A human sentence for any geolocation failure — never a raw error. */
+export function geolocationErrorMessage(error: unknown): string {
+  if (typeof window !== "undefined" && window.isSecureContext === false) {
+    return "Sharing your location needs a secure (https) connection. Search for a place instead.";
+  }
+  if (error instanceof GeolocationUnavailableError) {
+    return "This browser can't share your location. Search for a place instead.";
+  }
+  // GeolocationPositionError: 1 = permission denied, 2 = position unavailable,
+  // 3 = timeout. It is not an `Error`, so match structurally.
+  if (typeof error === "object" && error !== null && "code" in error) {
+    switch ((error as GeolocationPositionError).code) {
+      case 1:
+        return "Location permission was denied. You can search for a place instead.";
+      case 2:
+        return "Your location isn't available right now. Try again, or search for a place.";
+      case 3:
+        return "Finding your location took too long. Try again.";
+    }
+  }
+  return "Couldn't get your location. Search for a place instead.";
+}
+
+/** Fallback label when reverse geocoding yields nothing usable. */
+export function coordinateLabel({ latitude, longitude }: GeoCoords): string {
+  return `${latitude.toFixed(4)}, ${longitude.toFixed(4)}`;
+}

--- a/frontend/src/lib/journalColors.ts
+++ b/frontend/src/lib/journalColors.ts
@@ -1,0 +1,45 @@
+import type { JournalColor } from "../api/generated/types.gen";
+
+/**
+ * The journal colour palette. These are **API contract values**, not design
+ * tokens: they mirror the backend `JournalColor` enum
+ * (journiv-backend/app/models/enums.py) exactly, so the picker can only offer
+ * what `POST /journals` will accept. Like a mood's colour, a journal's colour
+ * is API-provided data that `JournalDot` passes straight to `--journal-accent`;
+ * it never enters a stylesheet. See DESIGN.md §3.
+ */
+export const JOURNAL_COLORS: ReadonlyArray<{
+  value: JournalColor;
+  label: string;
+}> = [
+  { value: "#EF4444", label: "Red" },
+  { value: "#F97316", label: "Orange" },
+  { value: "#F59E0B", label: "Amber" },
+  { value: "#EAB308", label: "Yellow" },
+  { value: "#84CC16", label: "Lime" },
+  { value: "#22C55E", label: "Green" },
+  { value: "#10B981", label: "Emerald" },
+  { value: "#14B8A6", label: "Teal" },
+  { value: "#06B6D4", label: "Cyan" },
+  { value: "#0EA5E9", label: "Sky blue" },
+  { value: "#3B82F6", label: "Blue" },
+  { value: "#6366F1", label: "Indigo" },
+  { value: "#8B5CF6", label: "Violet" },
+  { value: "#A855F7", label: "Purple" },
+  { value: "#D946EF", label: "Fuchsia" },
+  { value: "#EC4899", label: "Pink" },
+  { value: "#F43F5E", label: "Rose" },
+  { value: "#64748B", label: "Slate" },
+  { value: "#6B7280", label: "Gray" },
+  { value: "#71717A", label: "Zinc" },
+  { value: "#737373", label: "Neutral" },
+  { value: "#78716C", label: "Stone" },
+];
+
+const LABELS = new Map<string, string>(
+  JOURNAL_COLORS.map((c) => [c.value, c.label]),
+);
+
+export function journalColorLabel(value?: string | null): string | null {
+  return value ? (LABELS.get(value) ?? null) : null;
+}

--- a/frontend/src/lib/journalIcons.test.ts
+++ b/frontend/src/lib/journalIcons.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { JOURNAL_ICONS, resolveJournalIcon } from "./journalIcons";
+
+describe("resolveJournalIcon", () => {
+  it("resolves a known key to a component", () => {
+    expect(resolveJournalIcon("book-open")).toBe(
+      JOURNAL_ICONS.find((i) => i.key === "book-open")?.Icon,
+    );
+  });
+
+  it("returns null for an empty or missing value", () => {
+    expect(resolveJournalIcon(null)).toBeNull();
+    expect(resolveJournalIcon(undefined)).toBeNull();
+    expect(resolveJournalIcon("")).toBeNull();
+  });
+
+  it("returns null for a value that is not one of our keys", () => {
+    // A Material Symbols name written by the Flutter client, for example.
+    expect(resolveJournalIcon("sentiment_very_satisfied")).toBeNull();
+    expect(resolveJournalIcon("BookOpen")).toBeNull();
+  });
+
+  it("every catalogue key resolves", () => {
+    for (const { key } of JOURNAL_ICONS) {
+      expect(resolveJournalIcon(key)).toBeTruthy();
+    }
+  });
+});

--- a/frontend/src/lib/journalIcons.ts
+++ b/frontend/src/lib/journalIcons.ts
@@ -1,0 +1,115 @@
+import {
+  Anchor,
+  Baby,
+  Bike,
+  BookMarked,
+  BookOpen,
+  Brain,
+  Briefcase,
+  CalendarHeart,
+  Camera,
+  Cat,
+  Coffee,
+  Compass,
+  Dog,
+  Dumbbell,
+  Feather,
+  Flower,
+  Footprints,
+  Globe,
+  GraduationCap,
+  Heart,
+  HeartPulse,
+  House,
+  Leaf,
+  Lightbulb,
+  type LucideIcon,
+  MapPin,
+  Moon,
+  Mountain,
+  Music,
+  NotebookPen,
+  Palette,
+  PenLine,
+  Plane,
+  Sparkles,
+  Sprout,
+  Star,
+  Sun,
+  Target,
+  Tent,
+  TreePine,
+  Users,
+  Utensils,
+  Waves,
+} from "lucide-react";
+
+/**
+ * A journal may carry an icon, rendered tinted with the journal's own colour by
+ * `JournalDot`. The stored value is one of these keys — a small curated subset
+ * of the Lucide set the app already bundles, never an arbitrary lookup.
+ *
+ * The Flutter client stores Material Symbols names in the same backend field, so
+ * a value written there will not match a key here. That is expected: an
+ * unrecognised value falls back to the plain colour dot on both clients. See
+ * DESIGN.md §7.
+ */
+export const JOURNAL_ICONS: ReadonlyArray<{
+  key: string;
+  label: string;
+  Icon: LucideIcon;
+}> = [
+  { key: "book-open", label: "Open book", Icon: BookOpen },
+  { key: "book-marked", label: "Bookmarked book", Icon: BookMarked },
+  { key: "pen-line", label: "Pen", Icon: PenLine },
+  { key: "notebook-pen", label: "Notebook", Icon: NotebookPen },
+  { key: "feather", label: "Feather", Icon: Feather },
+  { key: "heart", label: "Heart", Icon: Heart },
+  { key: "heart-pulse", label: "Heartbeat", Icon: HeartPulse },
+  { key: "calendar-heart", label: "Calendar heart", Icon: CalendarHeart },
+  { key: "sparkles", label: "Sparkles", Icon: Sparkles },
+  { key: "star", label: "Star", Icon: Star },
+  { key: "sun", label: "Sun", Icon: Sun },
+  { key: "moon", label: "Moon", Icon: Moon },
+  { key: "brain", label: "Brain", Icon: Brain },
+  { key: "lightbulb", label: "Lightbulb", Icon: Lightbulb },
+  { key: "target", label: "Target", Icon: Target },
+  { key: "briefcase", label: "Briefcase", Icon: Briefcase },
+  { key: "graduation-cap", label: "Graduation cap", Icon: GraduationCap },
+  { key: "house", label: "House", Icon: House },
+  { key: "users", label: "People", Icon: Users },
+  { key: "baby", label: "Baby", Icon: Baby },
+  { key: "dog", label: "Dog", Icon: Dog },
+  { key: "cat", label: "Cat", Icon: Cat },
+  { key: "plane", label: "Plane", Icon: Plane },
+  { key: "compass", label: "Compass", Icon: Compass },
+  { key: "globe", label: "Globe", Icon: Globe },
+  { key: "map-pin", label: "Map pin", Icon: MapPin },
+  { key: "mountain", label: "Mountain", Icon: Mountain },
+  { key: "tent", label: "Tent", Icon: Tent },
+  { key: "tree-pine", label: "Pine tree", Icon: TreePine },
+  { key: "leaf", label: "Leaf", Icon: Leaf },
+  { key: "sprout", label: "Sprout", Icon: Sprout },
+  { key: "flower", label: "Flower", Icon: Flower },
+  { key: "waves", label: "Waves", Icon: Waves },
+  { key: "anchor", label: "Anchor", Icon: Anchor },
+  { key: "dumbbell", label: "Dumbbell", Icon: Dumbbell },
+  { key: "bike", label: "Bicycle", Icon: Bike },
+  { key: "footprints", label: "Footprints", Icon: Footprints },
+  { key: "camera", label: "Camera", Icon: Camera },
+  { key: "music", label: "Music note", Icon: Music },
+  { key: "palette", label: "Palette", Icon: Palette },
+  { key: "coffee", label: "Coffee", Icon: Coffee },
+  { key: "utensils", label: "Utensils", Icon: Utensils },
+];
+
+const BY_KEY = new Map(JOURNAL_ICONS.map((entry) => [entry.key, entry.Icon]));
+
+/**
+ * Resolve a stored icon value to a renderable component, or `null` when it is
+ * empty or not one of our keys (e.g. a Material Symbols name from Flutter).
+ */
+export function resolveJournalIcon(value?: string | null): LucideIcon | null {
+  if (!value) return null;
+  return BY_KEY.get(value) ?? null;
+}

--- a/frontend/src/lib/journalOrder.test.ts
+++ b/frontend/src/lib/journalOrder.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { JournalResponse } from "../api/generated/types.gen";
+import {
+  compareJournals,
+  defaultJournalId,
+  groupJournals,
+  reorderWithinGroup,
+  sortJournals,
+} from "./journalOrder";
+
+const make = (
+  over: Partial<JournalResponse> & { id: string },
+): JournalResponse => ({
+  user_id: "u",
+  title: over.title ?? over.id,
+  is_favorite: false,
+  is_archived: false,
+  position: null,
+  entry_count: 0,
+  total_words: 0,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  ...over,
+});
+
+describe("compareJournals / sortJournals", () => {
+  it("puts favourites first, then by position, then newest first", () => {
+    const list = [
+      make({ id: "old-plain", created_at: "2026-01-01T00:00:00Z" }),
+      make({ id: "new-plain", created_at: "2026-06-01T00:00:00Z" }),
+      make({ id: "fav-b", is_favorite: true, position: 1 }),
+      make({ id: "fav-a", is_favorite: true, position: 0 }),
+      make({ id: "positioned", position: 5 }),
+    ];
+    expect(sortJournals(list).map((j) => j.id)).toEqual([
+      "fav-a",
+      "fav-b",
+      "positioned",
+      "new-plain",
+      "old-plain",
+    ]);
+  });
+
+  it("treats a missing position as after any explicit one", () => {
+    const withPos = make({ id: "with", position: 9 });
+    const without = make({ id: "without", position: null });
+    expect(compareJournals(withPos, without)).toBeLessThan(0);
+  });
+});
+
+describe("groupJournals", () => {
+  it("splits active / archived / favourites, each sorted", () => {
+    const list = [
+      make({ id: "arch", is_archived: true }),
+      make({ id: "fav", is_favorite: true, position: 0 }),
+      make({ id: "plain", position: 1 }),
+    ];
+    const groups = groupJournals(list);
+    expect(groups.active.map((j) => j.id)).toEqual(["fav", "plain"]);
+    expect(groups.archived.map((j) => j.id)).toEqual(["arch"]);
+    expect(groups.favorites.map((j) => j.id)).toEqual(["fav"]);
+  });
+});
+
+describe("defaultJournalId", () => {
+  it("is the first active journal in canonical order", () => {
+    const list = [
+      make({ id: "plain", position: 0 }),
+      make({ id: "fav", is_favorite: true, position: 3 }),
+    ];
+    expect(defaultJournalId(list)).toBe("fav");
+  });
+  it("is undefined when every journal is archived", () => {
+    expect(
+      defaultJournalId([make({ id: "a", is_archived: true })]),
+    ).toBeUndefined();
+  });
+});
+
+describe("reorderWithinGroup", () => {
+  const list = [
+    make({ id: "a", position: 0 }),
+    make({ id: "b", position: 1 }),
+    make({ id: "c", position: 2 }),
+    make({ id: "fav", is_favorite: true, position: 0 }),
+  ];
+
+  it("moves a journal down within its own non-favourite peer group", () => {
+    expect(reorderWithinGroup(list, "a", "down")).toEqual([
+      { id: "b", position: 0 },
+      { id: "a", position: 1 },
+      { id: "c", position: 2 },
+    ]);
+  });
+
+  it("moves a journal up", () => {
+    expect(reorderWithinGroup(list, "c", "up")).toEqual([
+      { id: "a", position: 0 },
+      { id: "c", position: 1 },
+      { id: "b", position: 2 },
+    ]);
+  });
+
+  it("returns null at the edge of the group", () => {
+    expect(reorderWithinGroup(list, "a", "up")).toBeNull();
+    expect(reorderWithinGroup(list, "c", "down")).toBeNull();
+    // The lone favourite cannot move even though non-favourites sit "below" it.
+    expect(reorderWithinGroup(list, "fav", "down")).toBeNull();
+  });
+});

--- a/frontend/src/lib/journalOrder.ts
+++ b/frontend/src/lib/journalOrder.ts
@@ -1,0 +1,78 @@
+import type {
+  JournalReorderItem,
+  JournalResponse,
+} from "../api/generated/types.gen";
+
+const POS = (j: JournalResponse) => j.position ?? Number.MAX_SAFE_INTEGER;
+
+/**
+ * The order the backend itself uses: favourites first, then by explicit
+ * position (unset sinks to the end), then newest first as a stable fallback.
+ * Every surface that lists journals sorts through this so they agree.
+ */
+export function compareJournals(
+  a: JournalResponse,
+  b: JournalResponse,
+): number {
+  if (a.is_favorite !== b.is_favorite) return a.is_favorite ? -1 : 1;
+  if (POS(a) !== POS(b)) return POS(a) - POS(b);
+  return b.created_at.localeCompare(a.created_at);
+}
+
+export function sortJournals(journals: JournalResponse[]): JournalResponse[] {
+  return [...journals].sort(compareJournals);
+}
+
+export type JournalGroups = {
+  /** Non-archived, sorted. Favourites lead. */
+  active: JournalResponse[];
+  /** Archived, sorted. */
+  archived: JournalResponse[];
+  /** Non-archived favourites, sorted — the sidebar's quick scopes. */
+  favorites: JournalResponse[];
+};
+
+export function groupJournals(journals: JournalResponse[]): JournalGroups {
+  const active = sortJournals(journals.filter((j) => !j.is_archived));
+  return {
+    active,
+    archived: sortJournals(journals.filter((j) => j.is_archived)),
+    favorites: active.filter((j) => j.is_favorite),
+  };
+}
+
+/**
+ * The journal a brand-new entry should be filed in when the route names none:
+ * the first in canonical order. Favouriting or reordering a journal on the
+ * Journals screen is therefore how you pick the default.
+ */
+export function defaultJournalId(
+  journals: JournalResponse[],
+): string | undefined {
+  return groupJournals(journals).active[0]?.id;
+}
+
+/**
+ * Positions to persist to move `id` one step within its own favourite/archived
+ * peer group (the two groups the backend orders independently). Returns `null`
+ * when the move is a no-op — already at the group edge.
+ */
+export function reorderWithinGroup(
+  journals: JournalResponse[],
+  id: string,
+  direction: "up" | "down",
+): JournalReorderItem[] | null {
+  const target = journals.find((j) => j.id === id);
+  if (!target) return null;
+  const peers = sortJournals(
+    journals.filter(
+      (j) => j.is_favorite === target.is_favorite && !j.is_archived,
+    ),
+  );
+  const from = peers.findIndex((j) => j.id === id);
+  const to = direction === "up" ? from - 1 : from + 1;
+  if (from < 0 || to < 0 || to >= peers.length) return null;
+  const next = [...peers];
+  [next[from], next[to]] = [next[to], next[from]];
+  return next.map((j, index) => ({ id: j.id, position: index }));
+}

--- a/frontend/src/lib/moment.test.ts
+++ b/frontend/src/lib/moment.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { MomentResponse } from "../api/generated/types.gen";
+import {
+  mediaCountLabel,
+  momentKind,
+  momentKindLabel,
+  momentLeadText,
+  momentTitle,
+} from "./moment";
+
+const base = {
+  id: "m1",
+  user_id: "u1",
+  logged_at_utc: "2026-08-17T18:04:00Z",
+  logged_date_tz: "2026-08-17",
+  logged_timezone: "America/Los_Angeles",
+  is_pinned: false,
+  mood_activity: [],
+  tags: [],
+  people: [],
+  media: [],
+} as unknown as MomentResponse;
+
+const withMedia = (count: number, types: string[]) =>
+  ({
+    ...base,
+    media_count: count,
+    media: types.map((media_type, index) => ({ id: `m${index}`, media_type })),
+  }) as unknown as MomentResponse;
+
+const withEntry = (title: string | null, text = "Some writing.") =>
+  ({
+    ...base,
+    entry: { id: "e1", title, content_plain_text: text },
+  }) as unknown as MomentResponse;
+
+describe("Moment rendering semantics", () => {
+  it("classifies each kind of Moment", () => {
+    expect(momentKind(withEntry("Kyoto"))).toBe("titled-entry");
+    expect(momentKind(withEntry(null))).toBe("untitled-entry");
+    expect(
+      momentKind({ ...base, note: "Saw a heron." } as MomentResponse),
+    ).toBe("note-only");
+    expect(momentKind({ ...base, media_count: 2 } as MomentResponse)).toBe(
+      "media-only",
+    );
+    expect(momentKind({ ...base, is_pinned: true } as MomentResponse)).toBe(
+      "marker-only",
+    );
+  });
+
+  it("never invents a title", () => {
+    expect(momentTitle(withEntry("Kyoto"))).toBe("Kyoto");
+    expect(momentTitle(withEntry(null))).toBeNull();
+    expect(momentTitle(withEntry("   "))).toBeNull();
+    expect(
+      momentTitle({ ...base, note: "Saw a heron." } as MomentResponse),
+    ).toBeNull();
+  });
+
+  it("does not promote a note into the title slot", () => {
+    const noteOnly = { ...base, note: "Saw a heron." } as MomentResponse;
+    expect(momentTitle(noteOnly)).toBeNull();
+    expect(momentLeadText(noteOnly)).toBe("Saw a heron.");
+    expect(momentKindLabel(noteOnly)).toBe("Note");
+  });
+
+  it("labels media-only Moments by their real count and type", () => {
+    expect(momentKindLabel(withMedia(1, ["image"]))).toBe("1 photo");
+    expect(momentKindLabel(withMedia(3, ["image", "image", "image"]))).toBe(
+      "3 photos",
+    );
+    expect(momentKindLabel(withEntry("Kyoto"))).toBeNull();
+  });
+
+  it("never assumes an attachment is a photo", () => {
+    expect(mediaCountLabel(withMedia(1, ["video"]))).toBe("1 video");
+    expect(mediaCountLabel(withMedia(2, ["video", "video"]))).toBe("2 videos");
+    expect(mediaCountLabel(withMedia(1, ["audio"]))).toBe("1 audio clip");
+    // Mixed kinds, and unknown kinds, both fall back to neutral wording.
+    expect(mediaCountLabel(withMedia(2, ["image", "video"]))).toBe("2 items");
+    expect(mediaCountLabel({ ...base, media_count: 4 } as MomentResponse)).toBe(
+      "4 items",
+    );
+    expect(mediaCountLabel(base)).toBeNull();
+  });
+});

--- a/frontend/src/lib/moment.test.ts
+++ b/frontend/src/lib/moment.test.ts
@@ -6,6 +6,7 @@ import {
   momentKindLabel,
   momentLeadText,
   momentTitle,
+  truncate,
 } from "./moment";
 
 const base = {
@@ -83,5 +84,11 @@ describe("Moment rendering semantics", () => {
       "4 items",
     );
     expect(mediaCountLabel(base)).toBeNull();
+  });
+
+  it("returns no text for a non-positive truncation limit", () => {
+    expect(truncate("Some writing.", 0)).toBe("");
+    expect(truncate("Some writing.", -1)).toBe("");
+    expect(truncate("Some writing.", 5)).toBe("Some…");
   });
 });

--- a/frontend/src/lib/moment.ts
+++ b/frontend/src/lib/moment.ts
@@ -1,0 +1,82 @@
+import type { MomentResponse } from "../api/generated/types.gen";
+
+/**
+ * A Moment is a container. An Entry is optional, and so is everything else.
+ * Journiv must never fabricate a title for a Moment that does not have one:
+ * see DESIGN.md "Moment rendering semantics".
+ */
+export type MomentKind =
+  | "titled-entry"
+  | "untitled-entry"
+  | "note-only"
+  | "media-only"
+  | "marker-only";
+
+export function momentKind(moment: MomentResponse): MomentKind {
+  if (moment.entry) {
+    return moment.entry.title?.trim() ? "titled-entry" : "untitled-entry";
+  }
+  if (moment.note?.trim()) return "note-only";
+  if ((moment.media_count ?? 0) > 0) return "media-only";
+  return "marker-only";
+}
+
+/**
+ * The Moment's own title, or null. Callers must handle null by falling back to
+ * the date as the heading — never by inventing placeholder text.
+ */
+export function momentTitle(moment: MomentResponse): string | null {
+  return moment.entry?.title?.trim() || null;
+}
+
+/**
+ * The text a list row should show as its body. For a titled entry this is a
+ * supporting excerpt; for the other kinds it is the Moment's actual content and
+ * is therefore the row's primary content.
+ */
+export function momentLeadText(moment: MomentResponse): string | null {
+  const kind = momentKind(moment);
+  if (kind === "note-only") return moment.note?.trim() || null;
+  return moment.entry?.content_plain_text?.trim() || null;
+}
+
+const MEDIA_NOUNS = {
+  image: ["photo", "photos"],
+  video: ["video", "videos"],
+  audio: ["audio clip", "audio clips"],
+} as const;
+
+/**
+ * Counts are type-aware: not every attachment is a photo. When the Moment
+ * carries more than one kind — or when the thumbnail list is unavailable so the
+ * kinds are unknown — fall back to the neutral "item" wording rather than
+ * guessing.
+ */
+export function mediaCountLabel(moment: MomentResponse): string | null {
+  const count = moment.media_count ?? 0;
+  if (count === 0) return null;
+  const kinds = new Set((moment.media ?? []).map((item) => item.media_type));
+  const only = kinds.size === 1 ? [...kinds][0] : null;
+  const nouns =
+    only && only in MEDIA_NOUNS
+      ? MEDIA_NOUNS[only as keyof typeof MEDIA_NOUNS]
+      : null;
+  const [singular, plural] = nouns ?? ["item", "items"];
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+/** Short human label for Moments that are not a written entry. */
+export function momentKindLabel(
+  moment: MomentResponse,
+  kind = momentKind(moment),
+): string | null {
+  if (kind === "note-only") return "Note";
+  if (kind === "media-only") return mediaCountLabel(moment);
+  if (kind === "marker-only") return "No writing yet";
+  return null;
+}
+
+export function truncate(value: string, max = 220) {
+  const text = value.trim();
+  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
+}

--- a/frontend/src/lib/moment.ts
+++ b/frontend/src/lib/moment.ts
@@ -77,6 +77,7 @@ export function momentKindLabel(
 }
 
 export function truncate(value: string, max = 220) {
+  if (max <= 0) return "";
   const text = value.trim();
   return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
 }

--- a/frontend/src/lib/useJournalLookup.ts
+++ b/frontend/src/lib/useJournalLookup.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { journalsQuery } from "../api/query/options";
+import type { JournalResponse } from "../api/generated/types.gen";
+
+/**
+ * Journals are the only sanctioned source of hue in the product chrome.
+ * Resolving id -> journal is cheap because the journal list is already cached.
+ */
+export function useJournalLookup() {
+  const journals = useQuery(journalsQuery());
+  const byId = new Map<string, JournalResponse>(
+    (journals.data ?? []).map((journal) => [journal.id, journal]),
+  );
+  return {
+    journals: journals.data ?? [],
+    isLoading: journals.isLoading,
+    isError: journals.isError,
+    refetch: journals.refetch,
+    get: (id?: string | null) => (id ? byId.get(id) : undefined),
+  };
+}

--- a/frontend/src/lib/useMoodLookup.ts
+++ b/frontend/src/lib/useMoodLookup.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { moodsQuery } from "../api/query/options";
+import type { MoodResponse } from "../api/generated/types.gen";
+
+/**
+ * Resolve a mood id to its record. Mirrors `useJournalLookup` — the mood list is
+ * small and cached, so id -> mood is cheap. Mood colour is the only hue a mood
+ * contributes; render it as a dot, never as a valence scale (DESIGN.md §21.6).
+ */
+export function useMoodLookup() {
+  const moods = useQuery(moodsQuery());
+  const byId = new Map<string, MoodResponse>(
+    (moods.data ?? []).map((mood) => [mood.id, mood]),
+  );
+  return {
+    moods: moods.data ?? [],
+    isLoading: moods.isLoading,
+    isError: moods.isError,
+    get: (id?: string | null) => (id ? byId.get(id) : undefined),
+  };
+}

--- a/frontend/src/lib/uuid.test.ts
+++ b/frontend/src/lib/uuid.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { uuid } from "./uuid";
+
+const V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("uuid", () => {
+  it("works when crypto.randomUUID exists", () => {
+    expect(uuid()).toMatch(V4);
+  });
+
+  it("works without a secure context, where randomUUID is undefined", () => {
+    // A self-hosted Journiv reached over plain HTTP on a LAN is not a secure
+    // context, so `crypto.randomUUID` is undefined there. Calling it threw, and
+    // attaching a photo did nothing at all.
+    vi.stubGlobal("crypto", {
+      getRandomValues: globalThis.crypto.getRandomValues.bind(
+        globalThis.crypto,
+      ),
+    });
+    expect(typeof globalThis.crypto.randomUUID).toBe("undefined");
+    expect(uuid()).toMatch(V4);
+  });
+
+  it("still works with no crypto at all", () => {
+    vi.stubGlobal("crypto", undefined);
+    expect(uuid()).toMatch(V4);
+  });
+
+  it("does not repeat itself", () => {
+    const seen = new Set(Array.from({ length: 500 }, () => uuid()));
+    expect(seen.size).toBe(500);
+  });
+});

--- a/frontend/src/lib/uuid.ts
+++ b/frontend/src/lib/uuid.ts
@@ -1,0 +1,34 @@
+/**
+ * A v4 UUID that works outside a secure context.
+ *
+ * `crypto.randomUUID` is only defined in secure contexts (HTTPS or localhost).
+ * A self-hosted Journiv reached over plain HTTP on a LAN — a completely normal
+ * deployment — does not get it, and calling it there throws. Do not use
+ * `crypto.randomUUID` directly anywhere in this app.
+ */
+export function uuid(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.getRandomValues === "function"
+  ) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+  // Version 4, variant 1.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
Centralize Moment classification, date and timezone formatting, journal ordering, color conversion, icon selection, geolocation, UUID handling, and query lookups. These helpers keep Timeline, reader, editor, and management screens aligned on the same domain semantics.

Add focused tests for Moment kinds, date boundaries, journal ordering, icon fallbacks, geolocation errors, colors, and UUID generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added timezone-aware date and time handling, including localized “Today” and “Yesterday” labels.
  - Added journal color and icon palettes for clearer customization and consistent display.
  - Added journal sorting, grouping, favorites, archiving, and reordering.
  - Added “Use current location” support with helpful permission and availability messages.
  - Improved Moment classification, titles, summaries, media labels, and text truncation.
  - Added reliable mood and journal lookups, plus UUID generation across browser environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->