### PR TITLE
docs(frontend): document the Journiv design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,8 @@ pytest-results-*.xml
 
 # frontend
 frontend/.claude/
+# Screenshot of UI for visual regression testing
+frontend/docs/design/reference
 
 # ===============================================================
 # END OF FILE

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,52 @@
+# journiv-backend/frontend
+
+This is the React/Tailwind/shadcn web frontend — the one being actively built
+and the one that replaces the Flutter app. See the root `CLAUDE.md` for how
+this fits into the rest of the monorepo.
+
+## Before writing any UI here
+
+Read [`DESIGN.md`](DESIGN.md) §1–9, §16–18 and §20 first. They are the rules
+that apply to everything: tokens, typography, shape, states, iconography,
+motion, responsive behaviour, accessibility, file placement, and the checklist.
+
+Then read the section for the surface you are touching (§10–§15, §21–§25).
+Do not skip this because the change looks small — inventing a colour, size,
+spacing value or radius instead of using a token is the single most common way
+this codebase drifts from its own design system.
+
+**When DESIGN.md and the code disagree, the code is the fact and DESIGN.md is
+the bug.** Fix DESIGN.md in the same change that touches the code, or that you
+notice the disagreement in. Do not silently follow a stale rule, and do not
+silently ignore one you know is wrong.
+
+## Verify before reporting anything done
+
+```bash
+npm run verify
+```
+
+Runs formatting, lint, the design guard (`lint:design` —
+`scripts/check-design-system.mjs`), types, tests, the production build and the
+OpenAPI drift check. A green run is not proof the UI looks right — open the
+screen at 1440 / 1024 / 390, in light and dark, and look.
+
+If the visuals changed, regenerate the design reference screenshots (see
+DESIGN.md §19) and review the diff before calling the work finished.
+
+## Common commands
+
+```bash
+npm run dev          # vite dev server
+npm test             # vitest
+npm run lint:design  # design-system guard only
+npm run api:pull     # refresh openapi/openapi.json from the running backend
+npm run api:generate # regenerate src/api/generated/ from openapi.json
+```
+
+Both `openapi/openapi.json` (minified to one line) and the generated client
+under `src/api/generated/` are committed — the root `.gitignore` has a generic
+`generated/` rule with explicit `!frontend/src/api/generated/**` negations
+below it. After any backend API change: restart the backend, `api:pull`,
+re-minify `openapi.json`, `api:generate`, then commit the regenerated
+`src/api/generated/` output alongside `openapi.json`.

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -1,0 +1,1698 @@
+# Journiv Design System — v0.2
+
+**Status:** v0.2 — design foundation, shell, Timeline, reader, and editor media
+attachment. Refine again as the remaining screens land.
+
+**Audience:** anyone — human or agent — building UI in `journiv-backend/frontend`.
+Read sections 1–9 before writing any component. Read the specification for the
+surface you are touching (§10–§25) before changing it.
+
+**The one rule that matters most:** if you are about to invent a value — a colour,
+a font size, a spacing number, a radius — stop. Use a token or a role. If none
+fits, add one here first and explain why.
+
+**When this file and the code disagree, the code is the fact and this file is
+the bug.** Fix this file in the same change — do not silently follow a rule you
+can see the code has outgrown, and do not silently ignore one you know is being
+violated. If you cannot fix it in the same change, record it under §21 as a
+release blocker, not as a footnote.
+
+**Verify with one command:** `npm run verify`. It runs formatting, lint, the
+design guard, types, tests, the production build and the OpenAPI drift check.
+`scripts/check-design-system.mjs` is a **static, source-level** guard — it
+parses `.css`/`.ts`/`.tsx` files and this file's own prose, and never launches
+a browser. It mechanically enforces: raw colours (in CSS, inline styles, and
+bracketed Tailwind utilities), px font sizes, stray `!important`, arbitrary
+spacing/font-size Tailwind values, direct `crypto.randomUUID` calls, an
+undefined CSS custom property (a `var(--x)` that resolves to nothing), a dead
+token (declared, never consumed), an unlisted `@media` breakpoint, a broken
+link from this file to a `src/...` path, and a handful of literal token facts
+(the radius scale, the spacing scale, `--bar-height`, `--tap-target`, …) that
+must match between `tokens.css` and this file's prose — all fail the build
+with the fix printed. **What it does not check:** anything that requires a
+rendered page — computed contrast, actual visual layout, whether a component
+looks right. That is Playwright's job (§19), once it lands; this script stays
+static and cheap. A green run is not proof the UI looks right: open the screen
+at 1440 / 1024 / 390,
+in light and dark, and look.
+
+---
+
+## 1. What Journiv is
+
+Journiv is a private personal journal. The nearest relatives are Day One and
+Apple Journal. It is **not** Linear, Notion, Jira, an analytics dashboard, or an
+email client, even though the desktop layout happens to have three panes.
+
+The product exists for one loop:
+
+> I sit down. I write about my day. I come back months later. I enjoy reading it.
+
+Every visual decision is judged against that loop.
+
+**It should feel:** calm, personal, refined, quiet, trustworthy, content-first,
+excellent to read and to write in for half an hour at a time.
+
+**It should not feel:** sterile, generic, prototype-like, enterprise, busy,
+decorative, or like components pulled straight out of a library.
+
+---
+
+## 2. Design principles
+
+1. **Content before chrome.** The journal is the product. Navigation, bars and
+   toolbars support it and recede when they are not needed.
+2. **Paper, not panel.** Surfaces are warm and quiet. The reading page is the lit
+   one; the chrome sits slightly behind it. This ordering holds in both themes.
+3. **Calm density.** Navigation and lists may be compact. Reading and writing get
+   generous space. Same tokens, different scale steps.
+4. **Colour means something.** Hue is reserved for journal identity, mood, media
+   and the primary action. It is never decoration.
+5. **One way to say each thing.** One focus ring. One selected state. One empty
+   state pattern. One prose stylesheet shared by reading and writing.
+6. **Never invent data.** If the API did not return it, it does not appear on
+   screen. A missing title is a missing title, not "Untitled".
+7. **Honest states.** Loading, empty and error are designed screens, not
+   leftover sentences.
+
+---
+
+## 3. Tokens
+
+The colour system is **stock shadcn "base-vega"** (neutral base colour), defined
+in [`src/styles/tokens.css`](src/styles/tokens.css) + the `@theme inline` block
+in [`src/styles/index.css`](src/styles/index.css). Components consume the stock
+semantic names — `--background`, `--card`, `--popover`, `--muted`, `--primary`,
+`--border`, `--ring`, `--sidebar` … — never a raw colour. The radius scale is
+four literal tokens, not one variable — see below.
+
+Dark mode is the **`.dark` class** on `<html>` (set by
+[`src/app/theme.ts`](src/app/theme.ts)), matched by `@custom-variant dark` in
+`index.css`. The `system` / `light` / `dark` tri-state and the per-device
+storage key are unchanged.
+
+### Journiv's own values
+
+Only a handful. Everything else is stock.
+
+- **Brand** — `--primary` / `--primary-foreground` / `--ring` are Journiv's blue
+  (hue 269, the `#405DE6` the Flutter client ships). This is the one identity
+  colour and the thing a user's accent picker rewrites.
+- **Fonts** — `--font-sans` is DM Sans (bundled); `--font-reader` is the
+  reader/editor prose font (falls back to `--font-sans`). Alternates load lazily
+  via [`src/features/theme/fonts.ts`](src/features/theme/fonts.ts). No remote
+  fonts.
+- **Derived roles** — `--accent-surface`, `--accent-border`, `--state-hover`,
+  `--state-selected`, `--state-selected-rail`, `--danger-surface`,
+  `--danger-border`, `--line-strong`, `--focus-ring`. Product CSS (reader,
+  editor, timeline, shell) needs roles the stock set doesn't name; they are
+  **`color-mix` of the stock tokens**, so an imported user theme flows through
+  them for free. There is no `--accent-hover` — the primary `Button` variant
+  gets its hover from Tailwind's own `hover:bg-primary/80` (§6), and nothing
+  else needs an accent-tinted hover.
+- **`--success`, `--surface-overlay`** — two more Journiv values, undocumented
+  until now. `--success` is a semantic colour used only for a saved/success
+  `role="status"` notice (editor autosave-style confirmations) — it is not a
+  general "positive" accent and should not be reached for outside that one
+  role. `--surface-overlay` is the backdrop behind Settings and the compact
+  nav drawer — a translucent scrim, not a solid overlay surface.
+- **Layout / motion constants** — `--nav-width`, `--bar-height`,
+  `--reader-measure`, `--reader-gutter`, `--tap-target`, `--space-*`, `--ease`,
+  `--duration-*`. Not theming.
+- **On-media** — `--overlay-scrim`, `--text-on-overlay` are deliberately
+  theme-independent (they sit on a photograph, not a Journiv surface).
+
+`--journal-accent`, `--mood-accent` and `--entity-accent` are **not** defined
+globally. They are set inline from API data by `JournalDot`, `MomentMeta` and
+`EntityGlyph`, and fall back to `--border` when absent. They are the only hue
+that enters the chrome. ARGB→hex is `colorFromArgb` in
+[`src/lib/color.ts`](src/lib/color.ts).
+
+### Rule
+
+Product CSS goes through `var(--token)` — never a raw `#hex` / `oklch()` /
+`rgb()` (the design guard enforces this in every `.css` outside the value
+layer). This is what keeps the app themeable: a pasted theme reaches the reader
+and editor only because they resolve from the same stock tokens. shadcn
+registry components in `src/components/ui/` are Tailwind-class-only and read the
+`--color-*` map in `index.css`; do not add a scoped stylesheet for one.
+
+**The one sanctioned exception is a data palette, not a theme colour.**
+[`src/lib/journalColors.ts`](src/lib/journalColors.ts) (22 `JournalColor`
+presets) and `ENTITY_COLOR_PRESETS` (people/activity/goal-group colours) are
+literal hex arrays. They are content a user picks per-journal or per-group —
+matching the Flutter client's own fixed palette — not a piece of Journiv's
+theme, so they sit outside `color-mix`/token derivation on purpose. Do not add
+a third such array without naming it here; do not use either array's literals
+for anything that *is* chrome.
+
+### Shape, depth, spacing, layout
+
+Radius scale: `--radius-xs` 6px (chips, inputs, toolbar buttons) ·
+`--radius-sm` 10px (buttons, list rows) · `--radius-md` 14px (cards, popovers,
+media) · `--radius-lg` 20px (sheets, drawers, dialogs). Never `calc()` a radius —
+each is a literal in [`tokens.css`](src/styles/tokens.css). There is no fifth
+step: a surface that reads as bigger than a dialog does not exist, so nothing
+needs `--radius-xl`. There is also no corner-radius personalization control —
+unlike colour, shape is not user-configurable.
+
+Shadows: `--shadow-overlay` and `--shadow-dialog`. Two values, **overlays only**.
+A shadow on a header, toolbar or list row is a bug. There is no backdrop blur in
+Journiv.
+
+Spacing: 4 / 8 / 12 / 16 / 24 / 32 / 48 / 64 as `--space-1 … --space-16`. Do not
+write `mt-[13px]`.
+
+Layout: `--nav-width`, `--list-width-min/max`, `--bar-height` 52px,
+`--reader-measure` 68ch, `--reader-gutter`, `--tap-target` 44px.
+
+### Measured contrast
+
+"page" is `--background` (the reader/card reading surface); "canvas" is
+`--sidebar` (the app shell ground behind the panes, and `body`'s own
+background — see `base.css`). Ratios are WCAG relative-luminance contrast,
+computed from the `oklch` literals in `tokens.css` — Oklab → linear sRGB →
+relative luminance, not eyeballed.
+
+|                                | light  | dark   |
+| ------------------------------ | ------ | ------ |
+| `--foreground` on page         | 19.8:1 | 19.0:1 |
+| `--foreground` on canvas       | 19.0:1 | 17.2:1 |
+| `--muted-foreground` on page   | 5.5:1  | 7.6:1  |
+| `--muted-foreground` on canvas | 5.3:1  | 6.9:1  |
+
+All four clear AA (4.5:1) with real margin in both themes. `--muted-foreground`
+is the tightest pair by design — it is metadata, not body copy — so treat
+anything below **5:1** on either surface as a regression, not a rounding error.
+
+Disabled text (`opacity: 0.55` on `--foreground`, §6) lands around 4.4:1 in
+light mode, under the AA floor. This is expected and not a bug: WCAG 1.4.3
+explicitly exempts inactive UI components and their text, precisely because a
+disabled control's whole job is to read as visually muted. Do not "fix" a
+disabled state by boosting its contrast — that defeats the state.
+
+These numbers describe the *stock* tokens. A user's imported accent or theme
+(§25) can shift any of them; personalization is opt-in and deliberately not
+contrast-checked on the way in.
+
+---
+
+## 4. Typography
+
+DM Sans only, self-hosted. **Do not add a second family.** Do not add a monospace
+face until a real product feature needs one.
+
+Roles are classes in [`src/styles/base.css`](src/styles/base.css). Compose them;
+do not invent size/weight pairs.
+
+| Role                | Size / weight / leading  | Used for                           |
+| ------------------- | ------------------------ | ---------------------------------- |
+| `.jv-display`       | 28 / 680 / 1.2           | pane titles                        |
+| `.jv-entry-title`   | clamp 30–39 / 650 / 1.14 | entry title, **reader and editor** |
+| `.jv-section-title` | 15 / 620                 | section headings                   |
+| `.jv-body`          | 15 / 400 / 1.55          | UI prose                           |
+| `.jv-moment-title`  | 15 / 600 / 1.35          | Timeline row title                 |
+| `.jv-excerpt`       | 14 / 400 / 1.5           | Timeline excerpt                   |
+| `.jv-label`         | 13 / 500                 | form labels, nav                   |
+| `.jv-meta`          | 12.5 / 500, tabular-nums | metadata, times                    |
+| `.jv-caption`       | 12 / 400                 | captions, notices                  |
+
+**Sentence case everywhere.** Journiv has no uppercase letterspaced eyebrows.
+
+Long-form prose lives in [`src/styles/prose.css`](src/styles/prose.css) as
+`.jv-prose`: **17.5px / 1.7 / 68ch**, paragraph spacing 0.85em, in-body headings
+at 1.4 / 1.2 / 1.05em. In-body headings must stay visually subordinate to the
+entry title.
+
+Two specificity conventions you must not remove:
+
+- `.jv-prose.jv-prose <element>` — doubled so these rules beat a vendor editor
+  reset (`.ql-editor p { margin: 0 }`) regardless of import order.
+- `.jv-prose.jv-prose` base — doubled because the editor adds its own class to
+  the _same_ element (`ql-container` ships a 13px `font-size`).
+
+Both are commented in place. Deleting the doubling silently reverts the reader
+to 13px with no paragraph spacing.
+
+---
+
+## 5. Shape, surfaces and borders
+
+- Journiv is not a product where every fact lives in a rounded card. **Cards are
+  for genuinely detached objects** (dialogs, the reader's "write about this"
+  invitation). Lists use rhythm and selection, not boxes.
+- **A row never has both a radius and a divider.** Timeline rows have a radius
+  and no dividers at all.
+- Borders: `--border` for every structural edge — pane, bar, dense-list
+  divider. `--line-strong` for inputs and quote rules, where a border needs to
+  read as heavier than a structural hairline.
+- No blur. No gradient. No glow. No shadow outside overlays.
+
+---
+
+## 6. Interaction states
+
+| State         | Recipe                                                               |
+| ------------- | -------------------------------------------------------------------- |
+| hover         | `--state-hover` background; text lifts to `--foreground`             |
+| pressed       | shadcn `Button`'s own `active:translate-y-px` — see below            |
+| selected      | `--state-selected` background **plus** a 3px `--state-selected-rail` |
+| focus-visible | see below — it is not the same treatment everywhere                  |
+| disabled      | opacity 0.55, `cursor: not-allowed`                                  |
+| loading       | `StatusView` with a spinner, or a shape-matching `Skeleton`          |
+| error         | `StatusView` with `tone="danger"` and a retry action attached        |
+
+**Selection is never communicated by colour alone.** The sidebar and the Timeline
+both pair the tinted background with an accent rail. Both also set
+`aria-current="page"`.
+
+**Pressed is a shadcn behaviour, not a Journiv token.** Every `Button` nudges
+down one pixel on `:active`. Hand-built product rows (nav items, Timeline rows,
+Library rows) have hover and selected states but no separate pressed treatment
+today — do not invent a `--state-pressed`-style token for them without a real
+design reason; there was one and it had no consumer.
+
+**Focus is two treatments, by design, not by drift.** Native and
+product-pattern elements (`base.css`) get a 2px `--focus-ring` outline, 2px
+offset. Every `src/components/ui/*` registry component gets its own upstream
+treatment instead — `outline-none` plus a 3px `focus-visible:ring-ring/50` and
+a border-colour change — because the shadcn ring pattern (`focus-visible:ring`)
+needs the border+ring pairing to read correctly on small controls, and
+rewriting it would violate §18's "keep close to upstream" rule. Both resolve
+from `--ring`, so a personalized accent reaches both; do not mix the two
+treatments on one control, and do not add a third.
+
+**Actions.** Six variants carry meaning; two more are aliases kept for the
+stock vocabulary:
+
+| Variant                  | Use                                                          |
+| ------------------------ | ------------------------------------------------------------- |
+| `primary` (= `default`)  | The one primary action on a surface. Filled, `--primary`.     |
+| `secondary`              | The default for buttons that are not the primary.             |
+| `outline`                | A secondary action that needs a visible boundary (dialogs, toolbars). |
+| `ghost`                  | Tertiary — icon buttons, inline row actions.                  |
+| `danger` (= `destructive`)| A destructive action that is not (yet) the final confirm — tinted, not filled. |
+| `link`                   | Inline text acting as a control.                               |
+
+Exactly one `primary` per surface. `secondary` is the Button's own default
+variant. `ghost` for tertiary. Cancel and Done must never look identical — that
+was the single clearest "unfinished" signal in the previous UI. `IconButton`'s
+own `variant` prop (`ghost` | `secondary`) is a narrower, icon-only vocabulary
+that maps its `secondary` to the Button's `outline` — an icon control almost
+never wants a filled `secondary` background.
+
+---
+
+## 7. Iconography
+
+Lucide only. Sizes: 13 (inline metadata), 15–16 (buttons), 19 (bar controls),
+20–22 (`StatusView`). Default stroke.
+
+Every icon-only control uses `IconButton`, which **requires** a `label` and
+projects a `::after` hit area of at least `--tap-target` (44px) regardless of the
+visual box. A 30px toolbar button still has a 44px touch target. Never shrink the
+hit area to match the icon.
+
+**A journal is identified by its own colour, never by a repeated glyph.** The
+sidebar's Journals group is dots (or a chosen icon in the journal's own hue,
+below), never a book icon repeated down the list — a shared icon would tell
+journals apart from everything else, not from each other, which is not the
+job. Fixed destinations that are not journals (Timeline, Calendar, Media,
+People, Tags, Moods, Activities, Goals) may carry a distinguishing icon each,
+because there the icon's job is exactly to tell different *kinds* of
+destination apart.
+
+> **A journal may carry a chosen icon.** `JournalResponse.icon` holds one key
+> from the curated Lucide set in [`src/lib/journalIcons.ts`](src/lib/journalIcons.ts).
+> When present, `JournalDot` draws that glyph **in the journal's own hue** in
+> place of the dot; it is still the one place colour enters the chrome (§3), and
+> it is still exactly one mark per journal. The picker offers only that set.
+> An unrecognised value — notably the Material Symbols names the Flutter client
+> writes to the same field — falls back to the plain dot on the web. There is no
+> shared icon vocabulary between the clients yet; the colour dot is the common
+> ground.
+
+> **Mood icons are not renderable with Lucide.** `MoodResponse.icon` is a
+> Material Symbols name (`sentiment_very_satisfied`). Render mood as its colour
+> dot plus its name. Do not guess a mapping.
+
+---
+
+## 8. Motion
+
+One duration (`--duration-fast` 110ms) and one easing curve for
+product-pattern colour transitions (hover, selected). Dialog and drawer entry
+animate too, but through the registry's own Tailwind `duration-100` utility,
+not this token — see §18 on not re-skinning `components/ui/*`. Motion is
+allowed for: hover/selected colour transitions, drawer and dialog entry, and a
+loading spinner. Nothing else animates.
+`prefers-reduced-motion` is honoured globally in `base.css` — the only sanctioned
+`!important` in the product.
+
+---
+
+## 9. Responsive behaviour
+
+Two *layout* breakpoints, expressed in CSS, and no more. **Do not introduce JS
+breakpoint state** for layout — the one sanctioned exception is Settings'
+single `matchMedia` read at navigation time (§23), which is not reactive
+breakpoint state.
+
+| Width      | Layout                                                           |
+| ---------- | ---------------------------------------------------------------- |
+| > 1100px   | nav ∥ list ∥ page, all persistent                                |
+| 861–1100px | list ∥ page; nav moves into a drawer, reached from the `PageBar` |
+| ≤ 860px    | one pane per screen; browser history is the navigation           |
+
+**A component may reflow at its own width — a third kind of breakpoint, not a
+layout one.** A settings row switching from stacked to two-column, a stat grid
+dropping from four columns to two, a toolbar wrapping — none of that is "the
+app's layout changing," and none of it needs to line up with 860/1100.
+Current examples: `settings.css` (620px, row layout), `users.css` (620px,
+heading), `tags.css` (520px stat grid, 640px controls wrap), `editor.css`
+(34rem, conflict banner). Prefer a container query for a new one — the
+component already lives inside a pane whose width it does not control — and
+name the breakpoint's job in a comment next to it. What is not allowed is a
+new *page*-shaped breakpoint (a pane restructuring, a pattern moving between
+stacked and side-by-side across a whole screen) at a width that is not 860 or
+1100.
+
+- `.jv-desktop-only` / `.jv-compact-only` are the sanctioned visibility helpers.
+- `PageBar` renders its `leading` slot only below 1100px, so compact layouts
+  always expose navigation and desktop relies on the persistent panes.
+- **Top-level list mode must always expose navigation** — the Timeline's
+  `PageBar` carries the menu button.
+- Detail vs list is decided by **route `staticData`**, never by parsing the
+  pathname. A new detail route only needs `staticData: detailPane`.
+- Every pane has exactly **one scroll owner**. `PageBar` is a flex sibling above
+  it, never a sticky overlay, so content cannot scroll through the actions.
+- Touch targets ≥ 44px. Text inputs ≥ 16px on touch, or iOS zooms the viewport.
+- Safe-area insets are applied to the drawer and to the bottom padding of every
+  scrolling pane.
+
+---
+
+## 10. Moment rendering semantics
+
+**A Moment is a container. An Entry is optional, and so is everything else.** The
+backend treats a Moment as non-empty if it has _any_ of: entry, note, mood,
+prompt, pin, media, location, weather, tags, people.
+
+Classification lives in [`src/lib/moment.ts`](src/lib/moment.ts) and is covered by
+tests. Never re-derive it inline.
+
+| Kind               | Condition                        | Timeline row                                  | Reader                                                 |
+| ------------------ | -------------------------------- | --------------------------------------------- | ------------------------------------------------------ |
+| **titled entry**   | entry with a title               | time · title · excerpt · meta                 | date line, `<h1>` title, meta, prose                   |
+| **untitled entry** | entry, no title                  | time, then the entry text at **body weight**  | **date becomes the `<h1>`**, then prose                |
+| **note-only**      | no entry, has `note`             | time · `Note` chip · note text at body weight | date `<h1>`, note in a quote rule, invitation to write |
+| **media-only**     | no entry/note, `media_count > 0` | time · `N photos` chip · thumbnail            | date `<h1>`, media, invitation to write                |
+| **marker-only**    | only pin/mood/tags/location      | time · `No writing yet` chip · meta           | date `<h1>`, meta, invitation to write                 |
+
+Rules:
+
+- **Never render a placeholder title.** No "Untitled moment". When there is no
+  title, the date is the page heading and the Moment's own content takes the
+  primary slot.
+- **A note is not a title.** It may be the most prominent text in a row, but it
+  is styled as body text, never with `.jv-moment-title` or `.jv-entry-title`.
+- Every kind must reach the editor through the same "write about this moment"
+  path.
+
+---
+
+## 11. Metadata priority by surface
+
+`MomentMeta` takes a `surface` prop and enforces a budget. It is not a single
+overloaded row.
+
+| Surface   | Budget                     | Priority order                      |
+| --------- | -------------------------- | ----------------------------------- |
+| `row`     | 3 (2 below 860px, via CSS) | journal → location → mood → weather |
+| `compact` | 2                          | as above                            |
+| `reader`  | unlimited, one row         | as above                            |
+
+Overflow in list surfaces is **dropped silently** — a "+2" badge is noise in a
+row whose job is to be scannable. The reader shows everything.
+
+People and tags are **not** metadata. They render at the foot of **both the
+reader and the editor** via the shared `MomentChips` — `PersonChip`
+(avatar + name) and `TagChip` (`#word`), deliberately different objects, never
+the same chip. `MomentChips` renders nothing when a Moment has neither, so it is
+dropped in unconditionally.
+
+Before adding a field here, confirm the API actually returns it in that response.
+`location_json` keys are documented on the backend Moment model as
+`{name, street, locality, admin_area, country, latitude, longitude, timezone}`;
+`locationLabel()` reads `name → locality → admin_area → country` and nothing else.
+
+**Editing** all of it — mood, location, weather, people, tags — lives in the
+editor's Details popover (§14), never in the reader. The reader only shows.
+Reader and editor render the same values the same way: `EntryHeader` +
+`MomentMeta` for mood/location/weather, `MomentChips` at the foot for
+people/tags. Restyle one and you restyle both.
+
+---
+
+## 12. Time and grouping
+
+- Every Moment date is rendered **in the timezone the Moment happened in**, not
+  the viewer's. Helpers live in [`src/lib/datetime.ts`](src/lib/datetime.ts).
+- The Timeline groups by `logged_date_tz`, the Moment's own local calendar day. A
+  trip across timezones must not re-shuffle history.
+- "Today" / "Yesterday" are used **only** when `logged_timezone` matches the
+  viewer's timezone. Across timezones those words are ambiguous, so the explicit
+  date is shown. This is deliberate and covered by a test.
+- Times use tabular numerals.
+
+### List pane modes
+
+The middle pane (`Workspace`) has three ways to see the same moments — the
+chronological Timeline, a month Calendar, and a Media grid — chosen by the
+`view` search param (`undefined` | `"calendar"` | `"media"`, validated by the
+router's shared `timelineSearch` schema). All three are moments seen
+differently; the detail pane beside them is untouched by a mode change — a
+moment open in the reader stays open while the left pane changes, exactly like
+Day One. Every list-header carries a `ListViewSwitch`, a three-option
+segmented control that changes only the `view` param and stays on whatever
+route is current, so the selected state is colour **plus** a raised surface
+**plus** `aria-current="page"` (§6). The sidebar's "Views" group (Timeline /
+Calendar / Media) links to the same three modes from the nav.
+
+- **Timeline** (`view` unset) — the default, specified fully in §15.
+- **Calendar** (`CalendarPane`, `?view=calendar&month=YYYY-MM&date=YYYY-MM-DD`)
+  navigates with a month `<select>` + a year `<select>` (`.jv-field` skin,
+  1970 → next year, ascending — the same range as `EntryDateControl`'s
+  caption) flanked by prev/next-month arrows and "Today". The selected month
+  lives in the URL; a `role="status"` sr-only line still announces it. Grid
+  maths is pure and UTC-noon based in
+  [`calendarGrid.ts`](src/features/calendar/calendarGrid.ts). Clicking a day
+  sets `date` in the URL and shows that day's moments below the grid, without
+  leaving the calendar.
+- **Media** (`MediaPane`, `?view=media`) — a grid of every Moment with
+  `media_count > 0`, grouped by month, an infinite query over
+  `GET /media/library`, journal-scoped when the route names a journal. Each
+  tile is a square `object-fit: cover` thumbnail — a navigational affordance
+  to the Moment, not the content itself, so §13's no-crop rule does not apply
+  here (see the reader-media layout note). A signed thumbnail that expires
+  between response and render gets the same first-failure-refetch,
+  second-failure-broken handling as `useMomentMedia`. Loading is a
+  shape-matched skeleton grid; empty and error are `StatusView`.
+
+> **Open hypothesis:** day headers are currently `position: sticky`. Sticky
+> headers inside a nested scroll container behave differently on iOS Safari.
+> Verify on a real phone; if it misbehaves, make them static rather than
+> reaching for JavaScript.
+
+---
+
+## 13. Reader specification
+
+Reference: `docs/design/reference/02-reader-rich-*`, `03-reader-plain-*`,
+`04-reader-note-only-*`.
+
+- `PageBar`: compact-only Back, journal badge, and Edit (or a primary **Write**
+  when the Moment has no entry).
+- One scroll owner: `.jv-reader__scroll`. The bar is above it.
+- Column: `max-width: 47rem`, centred, `--reader-gutter` sides. The column owns
+  the measure, so `.jv-prose { max-width: none }` inside it.
+- `EntryHeader` (shared with the editor) renders: date line (`Monday, 17 August
+2026 · 7:04 AM`), title, then `MomentMeta` at `reader` budget. The date line is
+**display-only here** — the editable `EntryDateControl` is passed only by the
+editor (§14 "Entry date & time").
+- Body: `.jv-prose` via `QuillReader`. Never `dangerouslySetInnerHTML`.
+- Foot: people, then tags, above a `--line-subtle` rule.
+- Malformed stored content falls back to `content_plain_text` inside a bordered
+  notice; it must never crash or render raw HTML.
+
+### Reader media
+
+Media appears in two places, and never in both at once:
+
+- **Inline**, inside the prose, where the writer placed it.
+- **The gallery** (`EntryMedia`), between the entry header and the prose, for
+  media attached to the Moment but not referenced by the text. For Moments with
+  no writing, this places photos above the "write about this moment" invitation.
+
+#### Data contract — verified against the live API, do not re-derive
+
+- `GET /moments/{id}` returns `media[]` as **thumbnails only** —
+  `{id, media_type, signed_thumbnail_url}` — plus `media_count`.
+- The gallery uses a **second query**, `momentMediaQuery` →
+  `GET /moments/{id}/media`, returning `signed_url`, `width`, `height`,
+  `alt_text`, `duration`, `mime_type`, `upload_status`,
+  `signed_url_expires_at`. It is enabled only when `media_count > 0`.
+- **Inline embeds are hydrated by the backend.** The database stores
+  `{ insert: { image: "<media id>" } }`, but the API returns
+  `{ insert: { image: "/api/v1/media/<id>/signed?uid=..&exp=..&sig=.." } }`.
+  The client renders the URL it is given and never resolves ids. A hydrated URL
+  must never be written back to the server in place of the id.
+- `media_count` is **denormalised on the Moment row**. When the media list
+  disagrees with it, the list wins.
+
+#### Layout — a photograph is never cropped where it *is* the content
+
+The rule is about role, not surface: **wherever media is the thing being
+looked at, it is shown whole; wherever a thumbnail is a navigational
+affordance that leads to the uncropped original one click away, a crop is
+fine.** There is no full-image viewer yet, so a cropped preview with no way to
+inspect the original would hide part of a memory. The reader gallery is
+content, so:
+
+- One column, one item per row, at the item's own aspect ratio from
+  `width`/`height` (3:2 when dimensions are missing).
+- `object-fit: contain`, and `max-height: 78svh` so a tall portrait cannot take
+  over the page — it letterboxes rather than cuts.
+- The frame reserves its ratio before the image decodes, so prose never jumps.
+
+The Timeline's 68px row thumbnail and the Media grid's square tile (§15, and
+the list-pane Media mode above) are navigational, not content — both are links
+to the Moment or its uncropped original, so `object-fit: cover` there is
+correct today, lightbox or no lightbox.
+
+A compact cropped **gallery** grid — replacing the reader's one-column list
+above — becomes acceptable **once a full-image viewer exists**, and not
+before: cropping the one place media *is* the content, with no way to see the
+uncropped version, is what this rule forbids. Until then, a Moment with
+several photos pushes the prose a long way down; that is the accepted trade.
+
+#### States
+
+- **`alt_text` is alt text.** It goes in the `alt` attribute. Journiv has no
+  caption field, and nothing is rendered under an image. A test asserts the alt
+  string never appears as visible text.
+- `upload_status` `pending`/`processing` renders a "Processing" frame; `failed`
+  renders "<Photo|Media> unavailable". `processing_error` is never displayed.
+- **A failed media request is never silent.** Known user content must not
+  disappear without a word, so the gallery shows a quiet inline
+  "Media couldn't be loaded · Retry" notice. It is deliberately _not_ a
+  pane-filling `StatusView`: the writing must keep reading.
+- **An empty list with a non-zero `media_count`** renders nothing and shows no
+  error. The request succeeded; the count is the stale value, and there is
+  nothing for the reader to retry.
+- One item failing never removes the others.
+
+#### Signed-URL expiry
+
+Signatures expire, and recovery is explicit — it never relies on the query's
+`staleTime`:
+
+- **Proactively**, `useMomentMedia` compares `signed_url_expires_at` against the
+  clock and calls `refetch()` once per data snapshot to re-sign.
+- **Reactively**, the first image load failure per item forces a refetch; a
+  second is treated as genuinely broken. Never a retry loop, never a broken
+  image left on screen.
+- **Inline** sources live inside the document, so re-signing them means
+  refetching the _entry_, not the media. `QuillReader` listens for image errors
+  in the capture phase and asks the reader to refetch the entry once.
+
+#### Inline rendering rules
+
+- Reader guard is `isReaderDocumentDelta` — Gate-1 text plus `image`, `video`
+  and `audio` embeds. The editor shares it via the `isEditableDocumentDelta`
+  alias, so both surfaces accept exactly the same documents.
+- **Only same-origin relative URLs are rendered.** Fetching a third-party URL
+  found in stored content would tell that host the entry had been opened.
+- `formula`, `divider`, an embed carrying real attributes, or an unsafe source
+  sends the whole document to the plain-text fallback. Falling back visibly
+  always beats dropping content silently.
+- Video and audio use Journiv blots in
+  [`mediaBlots.ts`](src/features/editor/mediaBlots.ts). Quill's built-in `video`
+  format renders an `<iframe>` (for YouTube); Journiv needs a real `<video>`.
+  The blots keep the **standard Delta keys**, so the wire format stays
+  byte-compatible with `flutter_quill`. Never autoplay.
+- The gallery excludes inline media by **URL path** — the signature differs
+  between the copy hydrated into the document and the copy from the media
+  endpoint, while `/api/v1/media/<id>/signed` is stable.
+
+#### Not yet built
+
+A full-size viewer / lightbox (§21).
+
+## 14. Editor specification
+
+Reference: `docs/design/reference/05-editor-*`, `06-editor-new-*`.
+
+The contract is **reading and writing must look the same**. The editor uses the
+same `EntryHeader` and the same `.jv-prose`. If you restyle prose for one, you
+have restyled it for both — that is the point.
+
+- `PageBar`: journal selector (when a choice is required), save status, Cancel
+  (ghost), Done (primary). **One Cancel control at every width** — two controls
+  sharing an accessible name is a trap even when one is `display: none`.
+- Title is a `<textarea>` that grows with its content. An `<input>` cannot wrap
+  and clipped long titles on mobile.
+- New entries show the date they will be logged at, from the browser's timezone.
+  The date/time line is **editable in the editor** — see "Entry date & time"
+  below. The reader's copy of it is display-only.
+- Placeholder is an invitation (`Give this a title (optional)`), never a fake
+  title.
+- Toolbar: 30px visual buttons, 44px hit areas, active state is
+  `--accent-surface` + `--accent` (not an inverted black block).
+- `onPointerDown → preventDefault` on every toolbar button is **load-bearing**:
+  it preserves the editor selection. Do not remove it.
+- Toolbar positioning is `position: sticky` inside the existing single scroll
+  owner. **Keyboard-relative docking is explicitly not a requirement.** Do not
+  reach for `visualViewport` until a reproduced real-device failure demands it.
+
+### Entry date & time
+
+Reference: `journiv-frontend` (Flutter) `entry_form_screen._showDateTimePicker`.
+
+The `EntryHeader` date line ("Monday, 17 August 2026 · 7:04 AM") is an
+`EntryDateControl` in the editor — a button that opens a popover with a shadcn
+`Calendar` and a native time field. The reader passes nothing to
+`EntryHeader.dateControl` and keeps a plain `<p>`; restyling one does not touch
+the other.
+
+- **Caption.** The `Calendar` runs `captionLayout="dropdown"` — month and year
+  are native `<select>`s (rdp's own, styled by `calendar.tsx`), not just
+  prev/next chevrons, so backdating a decades-old entry is one click, not forty.
+  The range is fixed by `startMonth`/`endMonth` (Jan 1970 → December of next
+  year) rather than rdp's default 100-years-ago-to-this-December, which would
+  bar scheduling into next year.
+
+- **Timezone.** A new entry defaults to the browser's IANA zone
+  (`browserTimeZone()` in [`src/lib/datetime.ts`](src/lib/datetime.ts)); the
+  picked wall-clock is converted to UTC in that zone and both `logged_at_utc`
+  and `logged_timezone` are sent. Editing an **existing** Moment **preserves its
+  own `logged_timezone`** and reinterprets the newly picked wall-clock in it —
+  an old Warsaw entry is never silently re-read in today's zone. The effective
+  zone is shown in the popover (`8:00 PM · Europe/Warsaw`) only when it differs
+  from the browser's. There is no arbitrary timezone selector yet (§21).
+- **Conversion.** `zonedWallTimeToUtcIso` / `wallTimePartsInZone` wrap
+  `date-fns-tz`; DST is covered by tests. `react-day-picker`'s `Date` is used
+  for its y/m/d only — its own `toISOString()` is browser-local midnight and is
+  never persisted.
+- **Persistence.** For an existing Moment the change is an immediate
+  `PUT /moments/{id}` that re-sorts the Timeline and, like every other metadata
+  write on an existing Moment (§14 "Dirty tracking"), does **not** mark the form
+  dirty. For a new entry it seeds the draft `logged_at_utc` and the eventual
+  `MomentCreate`; once a draft Moment exists (media / details) that Moment is
+  updated in place too. The picker has **no primary action** — the surface's
+  primary is Done — and commits on discrete actions (a day click, a committed
+  time change), never per keystroke.
+- **Local drafts** carry `loggedAtUtc` / `loggedTimezone` so a reload before the
+  server Moment exists does not reset a backdated new entry to "now".
+
+### Media attachment
+
+Reference: `docs/design/reference/08-editor-*`.
+
+**Server identity first.** Media upload needs a `moment_id`, and
+`EntryDraftCreate` needs one too, so a new Entry has none until we make one.
+[`useEntryDraft`](src/features/editor/useEntryDraft.ts) creates Moment + a
+`is_draft` Entry **on first media attach** — not on form open, so an accidental
+"New entry" leaves no row. Draft Moments are hidden from the Timeline by
+`_apply_draft_filter`. Done finalises with `is_draft: false` in the same call.
+
+**The pipeline:**
+
+```
+capture caret → ensureDraft() → placeholder → upload → durable reference → save
+```
+
+- The caret is captured **before** the picker opens; it does not survive the
+  picker backgrounding the page on mobile. A drop supplies its own index.
+- The placeholder ([`uploadPlaceholder.ts`](src/features/editor/uploadPlaceholder.ts))
+  carries **only an upload id**. Object URL, filename and status live in a side
+  registry, so a `blob:` URL has no path into a document.
+- On success the swap is one `updateContents(retain/delete/insert)`, so undo
+  treats it as a single step.
+- **The race:** a completing upload looks for its placeholder in the _live_
+  document. If it is gone — removed, or undone mid-flight — the media is
+  **deleted**, never reinserted.
+- Object URLs are released when the surface unmounts, not when a placeholder
+  disappears: Quill re-creates the blot from its Delta value on undo.
+- `getContents()` strips placeholders before validating, so a document that is
+  mid-upload still yields a valid saveable Delta.
+- Only the **upload** phase blocks Done. Server-side processing does not — the
+  reference is already durable and the reader renders a processing state.
+
+**Uploads** use [`mediaUpload.ts`](src/features/editor/mediaUpload.ts): an
+isolated `XMLHttpRequest`, because `fetch` cannot report upload progress. The
+generated Fetch client is untouched and there is no Axios. Concurrency is capped
+at 2. Progress shows a percentage **only** when `lengthComputable`; never invent
+one. User abort is a distinct state, not an error.
+
+**The picker filter comes from `GET /media/formats`**, never a hardcoded list, so
+the frontend cannot accept what the server rejects. Wildcards are the fallback
+while it loads.
+
+**Drop and paste** feed the same `attach(files, index)` entry point. Two
+non-obvious safeguards:
+
+- **Quill's `uploader` module is disabled.** It intercepts dropped and pasted
+  image files and inlines them as base64 data URLs — bypassing the media
+  pipeline and persisting a payload no backup could map to a file.
+- **A clipboard matcher strips foreign images.** With `image` in the format
+  allowlist, pasting HTML could otherwise embed
+  `{image: "https://tracker.example.com/x.png"}`. Only same-origin
+  `/api/v1/media/` images survive, normalised to a relative path.
+
+**Removal.** A contextual control appears in the Insert group when the cursor is
+on media, labelled for what it removes — "Remove photo" / "Remove video" /
+"Remove audio", never a bare "Delete".
+
+- Removing media makes the document dirty. The **backend** deletes media a save
+  dropped from the Delta (`delete_orphaned_media_for_delta`), so remove-from-prose
+  and delete-the-file are the same action once saved. Before Done it is undoable.
+- **`clearHistory()` runs after a successful save** — otherwise undo could
+  restore a reference to a file the backend has already deleted.
+- Quill is configured `history: { userOnly: true }`. By default it records
+  `silent` and `api` changes, which let Ctrl+Z revert the initial load and leave
+  the entry empty.
+
+**Cancel.** Uploads in flight are aborted. A draft this session created is
+discarded, but **media the user attached is kept** — the Moment survives as a
+media-only Moment rather than deleting photographs someone just took. The
+confirm says so. Media that existed before this edit is never touched.
+
+### Local drafts, and how they meet the server draft
+
+Two different mechanisms, doing two different jobs. Keep them straight.
+
+|                       | Server draft (`is_draft`)                               | Local draft (IndexedDB)                                 |
+| --------------------- | ------------------------------------------------------- | ------------------------------------------------------- |
+| Made by               | [`useEntryDraft`](src/features/editor/useEntryDraft.ts) | [`useLocalDraft`](src/features/editor/useLocalDraft.ts) |
+| Made when             | first media attach or first metadata write              | 500ms after anything worth keeping changes              |
+| Holds                 | a Moment id that can own media, and an empty Entry row  | the writing itself, as a durable Delta                  |
+| Reaches other devices | yes                                                     | no                                                      |
+| Retired by            | Done (`is_draft: false`) or Cancel                      | a confirmed save, or an explicit discard                |
+
+The server draft is **not** cross-device autosave: its Entry is created with
+`content_delta: null` and is not written again until Done. Nothing but the local
+draft holds unsaved writing, and it is device-local.
+
+**The ownership rule.** `useEntryDraft` cleans up on Cancel, so what it believes
+it owns is load-bearing. A local draft records the Moment it belongs to, and for
+an entry that is already saved that is the reader's _own_ Moment — so
+`initialIdentity` is **refused outright whenever `moment` is set**, and `discard`
+returns early on the same condition. Without that guard, recovering a draft on an
+existing entry and then cancelling deleted a real journal entry.
+
+**Recovery is a continuation, not a fresh session.** A recovered draft's Moment
+is finalised rather than duplicated, and its resolved media ids seed
+`sessionMediaRef` — so Cancel keeps the photographs, exactly as it would have if
+the tab had never reloaded. A reload must not change what Cancel does.
+
+**Verified, not remembered.** `useDraftRecovery` fetches the Moment a draft
+records and hands back `verifiedIdentity`: null when that Moment is definitely
+gone (Done then makes a fresh one instead of failing forever), and carrying the
+Moment's _own_ `entry` id, so a draft Entry deleted underneath the record stops
+being addressed by an update that could only 404. Only a definite 404 clears
+it — see "Errors carry their status".
+
+**A retired record stays retired.** `remove()` latches, because both things that
+call it (a confirmed save, an explicit discard) then leave the editor — and
+leaving is a flush point. A draft that came back from the dead would be offered
+again on the next visit.
+
+### Concurrent edits
+
+Journiv has no autosave: the editor holds a whole entry in memory and writes it
+back on Done. Two devices open on the same entry therefore used to mean the
+second Done replaced everything the first wrote, with nothing on screen to say
+it had happened.
+
+`EntryUpdate.expected_updated_at` (optional) closes that. The editor sends the
+`updated_at` it opened on; the backend refuses with **409** if the entry has
+moved since. Omitting the field keeps last-write-wins, so existing clients —
+the Flutter app among them — are unaffected. It is compared as an instant, not
+a string: a naive column and an offset-bearing payload are the same moment.
+
+Sent only for an entry that already exists. A draft Entry is invisible to every
+other device, so it has no version worth defending, and a spurious refusal there
+would block the first real save.
+
+On 409 the editor shows `SaveConflict` — the writing untouched, one action
+("Save anyway", which resends without the version). No merge, and no diff:
+there is no server-side history to compare against, and inventing one would be
+worse than saying plainly that the two versions cannot be combined. Leaving
+instead is safe: the local copy stays, and the recovery prompt says the entry
+changed elsewhere the next time it opens.
+
+> **Cancel is a discard; navigating away is not.** They must not share a
+> sentence. Leaving keeps the local copy; Cancel removes it _and_ cleans up the
+> draft this session created. "Your writing is kept on this device" on the
+> second one would be a lie told at the moment it matters.
+
+### Errors carry their status
+
+[`ApiError`](src/api/client/errors.ts) wraps every failed request with its HTTP
+status; `configureApiClient` installs the interceptor, which is the last place
+that still holds the `Response`. The generated client throws the parsed body
+alone, and without the status "the Moment is gone" and "the network is gone"
+are the same value.
+
+`isNotFound` is deliberately narrow — a thrown value with **no** status is not
+a 404. Every caller is about to act on the absence of something, and "I could
+not ask" must never be read as "I asked, and it is gone": dropping a draft's
+Moment id offline would orphan a Moment nobody would ever finalise.
+
+> Drafts persist **durable media ids only** — never signed URLs, object URLs, or
+> base64. [`draftCanonical.ts`](src/features/editor/draftCanonical.ts) owns that
+> translation in both directions and is the only file that knows media signing
+> exists. A document holding durable content a draft cannot represent produces
+> **no record at all** rather than a lossy one.
+
+> **Never call `crypto.randomUUID` directly.** It is undefined outside a secure
+> context, and a self-hosted Journiv reached over plain HTTP on a LAN is not one.
+> Attaching a photo threw there and did nothing at all. Use
+> [`uuid()`](src/lib/uuid.ts). The same caution applies to any other
+> secure-context-gated API.
+
+**Toolbar growth.** Insert actions live in a `role="group"` inside
+`role="toolbar"`. Metadata editing joins _that_ group, never the formatting
+controls — but five separate buttons (mood, location, weather, people, tags)
+would crowd the bar, so they collapse into **one "Moment details" control**
+(`MomentDetailsPopover`, a `SlidersHorizontal` `IconButton`) that opens a
+popover. The popover is a base-ui `Popover`, an overlay with its own scroll
+container, so the "one scroll owner per pane" rule does not apply to it.
+
+### Metadata editing
+
+Reference: the reader specification (§11, §13) — the popover writes what the
+reader shows, and nothing else.
+
+**Server identity first, exactly like media.** Every write needs a `moment_id`.
+A new entry has none until real intent, so `ensureMomentId` runs the same
+lazy-draft path as the first media attach (`useEntryDraft.ensure`): the draft
+Moment is created on the first metadata write, not on popover open. A brand-new
+entry the user only _looked_ at leaves no row. `onSaved(id)` refreshes the
+editor's live Moment (a query on the draft id; an existing Moment is already
+refetched by the parent), so the header `MomentMeta` and foot `MomentChips`
+update the instant a write lands.
+
+**Mood.** `MoodResponse.icon` is a Material Symbols name and is **not** Lucide
+(§7). Mood is rendered as its colour dot (`moodColor(color_value)`, a Flutter
+ARGB int) plus its name, in the popover and in `MomentMeta`. `primary_mood_id`
+is set with `PUT /moments/{id}` — accepted on update even when the mood is not
+yet in the Moment's mood set (it is **rejected** on create; see
+`scripts/seed_dev_data.py`). Because the popover always goes through the draft
+or existing Moment, it always takes the update path. "None" clears it.
+
+**Location** geocodes free text via `POST /location/search` and stores the
+chosen result's `location_json` (the documented keys only) plus `latitude` /
+`longitude`. **"Use current location"** ([`geolocation.ts`](src/lib/geolocation.ts))
+reads the device position, reverse-geocodes it (`POST /location/reverse`, falling
+back to a `"lat, lon"` label), saves the place, and then fills weather for it in
+the same action — the user can still override any of it with the manual
+controls. The browser Geolocation API is secure-context-only, so on a plain-HTTP
+LAN it fails rather than prompting; that is tolerated **only** because the
+failure is always shown (`geolocationErrorMessage`, never a raw error) and the
+manual search is always present — the same "no silent failure" bar as the rest
+of §14. **Weather** needs coordinates: `POST /weather/fetch` with the entry's
+own timestamp and timezone, then a free-text `weather_summary` in the seed-data
+shape (`formatWeatherSummary` → `"Clear 14°C"`), with `weather_json` kept
+alongside. The service can be off — `WeatherServiceDisabledResponse` is shown as
+a plain notice, nothing is saved. A manual summary field is always available.
+
+**People** is `PUT /moments/{id}/people` with the full `person_ids` set every
+time (not a delta). **Tags** are `POST /moments/{id}/tags` by name (comma or
+Enter commits) and `DELETE /moments/{id}/tags/{tag_id}` to remove; `GET
+/tags/search` feeds inline suggestions. Both pickers filter client-side.
+
+**Every failure reaches the screen.** Each section owns a `role="alert"` with a
+human message; searches show their own inline error and empty states; mood and
+people show `Skeleton` while loading and a `StatusView` on error or when the
+account has none. The popover has **no primary action** — the surface's one
+primary is the editor's Done.
+
+**Dirty tracking.** A metadata write on an _existing_ Moment is persisted
+immediately and does not mark the form dirty. A write on a _new_ entry marks it
+dirty so the unsaved-changes guard protects the freshly created draft; Cancel
+then discards that draft the same way it always has.
+
+### Editor independence
+
+`.jv-prose` styles **semantic elements only** and never mentions Quill.
+[`quill-adapter.css`](src/features/editor/quill-adapter.css) and
+[`mediaBlots.ts`](src/features/editor/mediaBlots.ts) are the only files that may
+reference Quill. If Journiv replaces its editor, those are what get rewritten.
+
+> **`EDITOR_FORMATS` must admit every kind the guard admits.** They are two
+> separate lists; when they disagreed, opening a real entry threw
+> `[Parchment] Unable to create video blot` and killed the route. It now derives
+> from `INLINE_MEDIA_KINDS`, and a test mounts a document of each kind.
+
+---
+
+## 15. Timeline specification
+
+Reference: `docs/design/reference/01-timeline-*`, `07-empty-search-*`.
+
+- Header names the real scope — the journal's title with its colour dot, or
+  "All journals" — never a generic "Timeline". Below 1100px the `PageBar` carries
+  the scope and the large heading is hidden to avoid repeating it.
+- Sticky day headers group the list (see the hypothesis in §12).
+- Row: time · optional kind chip · optional pin, then title (or the Moment's own
+  text at body weight), a **two-line** excerpt, then `MomentMeta`.
+- Excerpts are `.jv-clamp-2`. Never `white-space: nowrap` — a three-line-tall row
+  showing one clipped line is wasted space.
+- Media: a 68px (80px on mobile) rounded thumbnail with a `+N` badge.
+- No dividers. Selection is `--state-selected` plus the accent rail.
+
+---
+
+## 16. Empty, loading and error states
+
+One component: `StatusView` (icon, title, optional description, optional action).
+
+- Empty and error states get an action wherever one exists ("Clear search",
+  "Write your first entry", "Try again").
+- Loading uses either a `StatusView` with a spinner (whole pane) or a `Skeleton`
+  that **mirrors the final layout** (list rows, reader header + body).
+- A bare sentence floating in a pane is not an acceptable state.
+- Never show a raw server message or stack text. Preserve request IDs where the
+  API provides them.
+
+---
+
+## 17. Accessibility contract
+
+- Touch targets ≥ 44px, enforced by `IconButton`'s hit area.
+- A visible focus treatment on every control (two sanctioned variants — §6);
+  never remove an outline or ring without replacing it.
+- Body text meets AA comfortably in both themes; check any new pair.
+- Selection is never colour-only.
+- One `<h1>` per screen. When there is no title, the date is the `<h1>`.
+- Every icon-only control has a label. Every form control has a `<label>`.
+- Formatting buttons expose `aria-pressed`.
+- Errors use `role="alert"`; loading regions use `role="status"`.
+- Reduced motion is honoured globally.
+
+Automated checks do not replace a keyboard pass and a VoiceOver pass.
+
+---
+
+## 18. Where things live
+
+```
+src/styles/tokens.css        stock base-vega tokens (:root + .dark) + Journiv's few
+src/styles/index.css          imports, @custom-variant dark, @theme inline map
+src/styles/base.css          reset, focus, typographic roles, visibility helpers
+src/styles/prose.css         long-form typography — editor-independent
+src/styles/fonts.css          --font-sans / --font-reader / --font-mono stacks
+src/styles/util.css           .jv-field, .jv-dialog__actions, pane-status, spinner
+src/components/ui/            shadcn base-vega primitives: button, input, dialog,
+                              popover, dropdown-menu, select, combobox, calendar,
+                              tooltip … + Journiv wrappers icon-button, search-input
+src/components/journiv/       cross-feature product patterns: PageBar, EntryHeader,
+                              JournalBadge, MomentMeta, PersonChip, StatusView,
+                              LibraryRow, EntityGlyph, ListViewSwitch, journiv.css
+src/api/                      generated OpenAPI client (`generated/`, gitignored),
+                              the hand-written wrapper (`client/`), auth session
+                              storage (`auth/`), React Query keys/options (`query/`)
+src/app/                      router (`app/router/`), query client, theme.ts
+                              (the light/dark/system tri-state — distinct from
+                              `features/theme/`, the personalization layer)
+src/features/theme/           personalization: UserTheme model, applyUserTheme,
+                              parseThemeCss, exportThemeCss, fonts, usePersonalization
+src/features/library/         People / Tags / Moods / Activities / Goals (§24)
+src/features/media/           the Media grid list-pane mode
+src/lib/                      moment semantics, datetime, journal lookup + order,
+                              journal colours + icons, `utils.ts` (`cn`), `cx.ts`
+src/features/<feature>/       feature UI + its own <feature>.css
+src/features/editor/quill-adapter.css   the only file that knows about Quill
+src/test/                     vitest setup only — not a feature directory
+```
+
+**Placement rule:** a component goes in `components/journiv/` only when **two or
+more features** use it. Otherwise it is feature-local.
+
+**Two class-name joiners, on purpose.** `cn` (`src/lib/utils.ts`, wraps
+`clsx` + `tailwind-merge`) is for `components/ui/*` — it resolves conflicting
+Tailwind classes so a passed `className` can override the component's own.
+`cx` (`src/lib/cx.ts`, a plain falsy-filtering join) is for everything else —
+Journiv product code does not fight Tailwind class precedence, so it does not
+need `tailwind-merge`'s cost. Reach for `cn` only inside `components/ui/`;
+reach for `cx` everywhere in `components/journiv/` and `features/`.
+
+**shadcn-first for generic primitives.** Every generic UI primitive — button,
+input, dialog, popover, dropdown-menu, select, combobox, tabs, tooltip,
+accordion, calendar, skeleton … — comes from the configured **base-vega**
+registry (`components.json`) into the flat `src/components/ui/`, kept close to
+upstream. Reconcile only: `cn` from `src/lib/utils.ts`, `lucide-react` in place of
+base-vega's `IconPlaceholder`, and any concrete UX fix (documented in the file).
+Do **not** rewrite a registry component's Tailwind classes to re-skin it — the
+`.jv-shadcn` bridge is gone; components read the stock `--color-*` / `--radius-*`
+map in `index.css`, which resolves to Journiv's tokens. Hand-build only Journiv
+**product** components (`components/journiv/`, feature dirs) or behaviour the
+registry lacks (`IconButton`'s 44px hit area, `SearchInput`, `StatusView`,
+`EntryDateControl`). A custom generic primitive needs a one-line reason in the
+file. Later stock-evaluation candidates: `EntryHeader`, `MomentMeta`, `PageBar`,
+`MomentListItem`, the People group section.
+
+**Base UI directly** is allowed only for a product shell that no registry
+component fits — today just `SettingsModal` (full-screen routed modal) and
+`AppShell`'s nav drawer. Everything else composes `src/components/ui/`.
+
+**CSS rule:** styling lives in scoped stylesheets next to the feature that owns
+it, driven by tokens. Tailwind utilities are fine for one-off layout. Do not
+mechanically convert working scoped CSS into utilities, and do not add a utility
+that duplicates a design decision.
+
+---
+
+## 19. Reference screenshots
+
+`docs/design/reference/` holds desktop (1440×900) and mobile (390×844) captures
+in light and dark for: Timeline, a rich reader, a plain reader, a note-only
+reader, the editor, a new entry, and an empty search.
+
+Regenerate them after any visual change:
+
+```bash
+JOURNIV_EMAIL=... JOURNIV_PASSWORD=... \
+  node scripts/capture-design-reference.mjs --base http://127.0.0.1:5199
+```
+
+Credentials come from the environment. **Never commit an account into this repo.**
+
+> **Migrating to Playwright.** `scripts/capture-design-reference.mjs` is not
+> being developed further — its determinism problems (a live-database
+> heuristic picks the scenes, fixed sleeps instead of real waits, no frozen
+> clock, no personalization reset) and its lack of any actual diffing make it
+> a screenshotter, not a regression guard. When Playwright lands, visual
+> regression moves there in full: deterministic fixture data, viewport/theme
+> coverage, a frozen clock, a personalization reset, and the screenshot
+> comparison itself (`expect(page).toHaveScreenshot()`), with Playwright's own
+> committed snapshots becoming the single reference set this section points
+> at. Once that coverage exists, delete the custom script and this section's
+> `node scripts/capture-design-reference.mjs` instructions along with it. Until
+> then, the script and the manual regenerate-and-look step above are what
+> exists — do not invest further in the script itself.
+
+**What stays a static check regardless of Playwright** (§ preamble, and
+`scripts/check-design-system.mjs`): a *documented* token fact — a literal
+value in this file's own prose, like the radius scale — is validated by
+parsing `tokens.css`, not by rendering a page. Playwright separately verifies
+the *runtime* result of those tokens — rendered contrast, computed styles,
+whether a token actually reached the pixel — which a source-level parse cannot
+see (a page-specific override could still make the rendered value wrong even
+when the source values match). The two are complementary, not redundant: keep
+both once Playwright exists.
+
+---
+
+## 20. Checklist before marking any UI task done
+
+- [ ] No raw colour, font-size, radius or spacing literal — tokens and roles only
+- [ ] Light **and** dark checked
+- [ ] 1440 / 1024 / 390 checked
+- [ ] Loading, empty and error states exist and use `StatusView`/`Skeleton`
+- [ ] Exactly one primary action on the surface
+- [ ] Selection/active state uses colour **and** a rail, plus `aria-current`
+- [ ] Icon-only controls have labels and 44px hit areas
+- [ ] Keyboard reachable, focus visible
+- [ ] Only data the API actually returns is displayed
+- [ ] No secure-context-only API (`crypto.randomUUID`, …) — self-hosting is often
+      plain HTTP over a LAN
+- [ ] No user action can fail silently; every failure reaches the screen
+- [ ] One scroll owner per pane; no sticky element overlapping content
+- [ ] `npm run verify` passes (format, lint, design guard, types, tests, build,
+      OpenAPI drift) — one command, run it before reporting anything done
+- [ ] Reference screenshots regenerated if the visuals changed
+
+---
+
+## 21. Open questions
+
+1. **Sticky day headers** on iOS Safari (§12) — needs a real device.
+2. **The reader `PageBar` title is empty** for Moments with no journal
+   (note-only, media-only). Acceptable today; revisit if it looks bare.
+3. **Editor toolbar overflow** still scrolls horizontally below ~700px. The
+   intended fix is an overflow "More" popover, not a smaller hit area.
+4. **Mood colours are not a valence scale** in the default data (Awesome is blue,
+   Meh is deep orange). Use `category`/`score` for meaning; use `color_value` only
+   as identity.
+5. **No full-size media viewer.** Reader images are not clickable. Until one
+   exists, the reader gallery never crops (§13), which makes photo-heavy
+   Moments tall. A lightbox is a deliberate follow-up, not an oversight.
+6. **RELEASE BLOCKER — inline video degrades documents in Flutter.** Verified by
+   `journiv-frontend/test/unit/features/entries/journiv_delta_compatibility_test.dart`:
+   `flutter_quill` treats a video embed as a block embed and emits an extra line
+   terminator on every `Document.fromJson` to `toDelta()` cycle. It never
+   converges — one newline, then two, then three. Image and audio embeds are
+   stable and idempotent from the first pass.
+
+   Consequence: every time a Flutter client opens and saves an entry containing
+   an inline video, the document gains a blank line, permanently.
+
+   This is a pre-existing defect — Flutter authors these embeds itself — and the
+   product decision is to ship inline video from the web anyway, with a targeted
+   normalisation fix in the Flutter client (collapse a video embed followed by
+   two or more newlines down to one, on load) landing BEFORE the new frontend
+   reaches users. Until that fix ships this is a release blocker, not a
+   known-issue footnote.
+
+   The Dart test pins the divergence with an inverted assertion, so the day
+   `flutter_quill` is fixed it fails loudly and this entry can be retired.
+
+7. **Editor media attachment has no real-device coverage.** The pipeline is
+   built and unit-tested, but the picker round trip, caret survival, keyboard
+   behaviour and slow-network upload have only been exercised in desktop Chrome.
+   Drop-path base64 suppression in particular is browser-verified only — jsdom
+   lacks `caretRangeFromPoint`, so no test covers it.
+8. **Absolute media URLs in legacy content fall back to plain text.** An
+   imported entry pointing at a third-party host is not fetched. If real
+   imports rely on this, decide on an explicit allowlist rather than loosening
+   the rule.
+9. **No alt-text editing.** `alt_text` is settable only as an upload form field;
+   `/media/{id}` exposes `delete` alone. Existing alt text is respected and
+   rendered, but it cannot be changed after upload. Needs a small backend
+   endpoint (`PATCH /media/{media_id}`) before an affordance is worth building.
+10. **Conflicts are refused, never merged.** A 409 tells the writer the entry
+    moved and offers to overwrite; there is no way to see what the other version
+    said, or to combine them. That is a deliberate floor, not a finished
+    feature — the backend keeps no history to diff against. If entry history
+    ever lands, this is the first thing that should use it.
+11. **The draft Moment itself has no concurrency protection.** `expected_updated_at`
+    is sent only for an entry that already exists. Two tabs recovering the _same_
+    local draft would still race on finalising its draft Moment; the loser now
+    gets a fresh Moment rather than a dead end (§14), but the two halves of that
+    writing end up in two entries. Recovering the same draft twice at once is not
+    a flow the UI offers, so this is recorded rather than solved.
+12. **No arbitrary timezone selector for a logged date.** `EntryDateControl`
+    (§14) records a new entry in the browser's zone and keeps an existing
+    Moment's own zone; it cannot record "8 PM in Tokyo" while the writer is in
+    Berlin. The backend accepts any `logged_timezone`, so this is a UI
+    follow-up if real travel/backfill use cases justify the extra control.
+13. **Personalization is device-local.** The `UserTheme` (§25) lives in
+    localStorage. A `theme` field on `GET/PUT /users/me/settings` — same JSON
+    shape — would sync it across devices; the frontend needs no change for it.
+14. **Accent picker sets `--primary` only.** `--primary-foreground` keeps the
+    Journiv near-white, which suits saturated hues but not a pale custom accent.
+    For per-mode / full control the user imports a theme. A contrast auto-pick
+    is a possible refinement.
+15. **Admin user pagination exposes no total or continuation token.** `GET
+/admin/users` accepts `limit` / `offset` and returns a bare array. Settings →
+    Users therefore walks pages until a short response and only then offers
+    local search and ten-row presentation paging. A server total or cursor
+    would let very large self-hosted instances render progressively.
+
+---
+
+## 22. Journal management
+
+Reference: `docs/design/reference/11-journals-*`.
+
+Two concerns, kept apart:
+
+- **Browsing by journal** stays in the shell. The sidebar lists active journals
+  in the canonical order — favourites sort to the top, so favouriting a journal
+  re-orders the rail rather than hiding the others — each a colour dot / glyph
+  plus title linking to the scoped Timeline. The list is capped (`SIDEBAR_MAX`);
+  one **"All journals"** row always follows, opening the management screen. The
+  rail never grows unbounded and never lists archived journals.
+- **Managing journals** — create, rename, description, colour, icon, favourite,
+  reorder, archive, delete — all lives on `/journals`, a list-pane route (no
+  `staticData`, so it composes as a list, not a detail). It is reached from the
+  sidebar and is where a future Settings → Manage section will link.
+
+### The screen
+
+- `PageBar` (compact only) carries the menu button and the pane name. The
+  desktop heading is `.jv-display` "Journals". **One primary action: New
+  journal.**
+- One scroll owner (`.jv-journals__scroll`).
+- **Active** section first: a divided list (rhythm, not cards — §5), roomier
+  than a Timeline row. Each row is the journal's dot/glyph, title, optional
+  description, and a metadata line showing `entry_count`, `total_words` and
+  `last_entry_at` (see §21.2 — shown despite the known drift). Trailing: a
+  favourite star, and a `⋯` menu (Rename · Edit appearance · Move up / Move
+  down · Archive · Delete…). The row body links to the scoped Timeline.
+- **Archived** section: a `<details>` disclosure, collapsed, labelled with its
+  count. Rows there swap the star for **Unarchive** and drop the reorder items.
+  This is the only route to an archived journal.
+- Loading is shape-matched `Skeleton` rows; error and empty are `StatusView`
+  (empty offers the same one primary, New journal).
+
+### Ordering
+
+`is_favorite DESC, position ASC NULLS LAST, created_at DESC` — the backend's own
+order, implemented once in [`src/lib/journalOrder.ts`](src/lib/journalOrder.ts)
+and shared by the sidebar, this screen and the editor's default journal.
+"Move up / down" swaps a journal with its neighbour **within its own
+favourite/non-favourite group** (the two the backend positions independently)
+and persists the whole group via `PUT /journals/reorder`. There is no
+drag-and-drop yet and no "default journal" flag: favouriting and ordering are
+how the top journal — the one a new entry is filed in when the route names none
+— is chosen.
+
+### Create / edit
+
+A `Dialog` ([`src/components/ui/dialog.tsx`](src/components/ui/dialog.tsx), the
+shared modal now used here and by the editor's link dialog). Title (required, validated in-form — no native
+`required` bubble), description, a colour radio group of the 22 `JournalColor`
+presets rendered as `JournalDot` swatches (the only sanctioned swatch — §3), and
+an icon radio grid from the curated Lucide set, each option tinted with the
+currently chosen colour so the result is previewed. One primary: Create / Save.
+Every failure lands in a `role="alert"` with a human sentence.
+
+### Delete
+
+`DELETE /journals/{id}` cascade-deletes every entry's narrative in the journal
+(the parent Moments survive as quick logs). The dialog states exactly that,
+offers **Archive instead** first, and keeps the destructive button disabled
+until the journal's title is typed back. A regression test proves the guard.
+
+---
+
+## 23. Settings
+
+Reference: `docs/design/reference/12-settings-profile-*`,
+`13-settings-security-*`.
+
+Settings is a **secondary, contextual activity**. The user is reading or writing;
+opening Settings should feel like adjusting Journiv's controls without leaving
+the journal, and closing it should put them back exactly where they were. It is
+never a permanent third pane.
+
+### Routing is real; the modal is a presentation
+
+`/settings` → `/settings/profile` · `/settings/security`. These are ordinary
+routes carrying `staticData.settings`. `AppShell` reads that the same
+declarative way it reads `pane: "detail"` and mounts `SettingsModal` over the
+running app — the route tree is the source of truth, never component state. A
+direct hit on `/settings/security` loads Journiv and opens the modal on
+Security. Adding `/settings/tags` later is: register the route with
+`staticData: { settings: "tags" }`, add an entry to `SETTINGS_NAV`, build the
+page. Nothing about the modal, the responsive behaviour, the active state or the
+close behaviour changes.
+
+### Responsive shape — one Dialog, CSS switches the layout
+
+| Width    | Shape                                                                                                                         |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| > 1100px | centred modal, `min(1050px, …)` × `min(780px, …)`, ~220px section nav ∥ content. Matches the persistent-pane breakpoint (§9). |
+| ≤ 1100px | full-screen routed flow. `/settings` is the section list; `/settings/profile` is that page with a `‹ Settings` back control.  |
+
+The one JS breakpoint read allowed here is a single `window.matchMedia` check
+when `/settings` loads, deciding redirect-to-Profile (desktop) vs show-the-list
+(compact). It is a one-shot read at navigation time, not reactive breakpoint
+state. Everything else is CSS.
+
+### Background context and closing
+
+Opening from within the app stashes the origin href in history `state`
+(`settingsFrom`). Closing — X, Escape, backdrop — navigates back to it
+(`router.history.replace`), or to `/timeline` when Settings was deep-linked with
+no prior in-app route. Successful saves never close Settings. Section switches
+and every dismissal run through one `useBlocker` guard: if a page has unsaved
+edits, a `window.confirm("Discard your unsaved changes?")` — the same prompt the
+editor uses — gates the navigation. Password fields are ephemeral: never written
+to any draft or storage.
+
+### Visual treatment — paper, not panel
+
+The modal has overlay elevation because it is a true overlay (§5). Inside: a
+quiet top bar (title + one close control), a section nav with **restrained**
+group labels (sentence case, muted — real hierarchy, not a SaaS eyebrow), and a
+content pane whose form width tops out around 24–46rem rather than stretching.
+Settings are laid out as **section title → setting / description / control**, not
+a bordered card per row. Selected nav item: tint **plus** a rail plus
+`aria-current` (§6). No nested large modals — Profile fields and the password
+form edit in place; only small confirmations (discard) may stack.
+
+### Functional now
+
+- **Profile** — `GET/PUT /users/me` for the display name; `GET/PUT
+/users/me/settings` for the timezone (a native `<select>` over
+  `Intl.supportedValuesOf('timeZone')`, canonical IANA values stored). Email is
+  read-only (no update path). Avatar is read-only initials/URL — there is no
+  user avatar-upload endpoint. Initialises from the shared current-user /
+  user-settings queries; a successful save invalidates them so the sidebar
+  updates without reload.
+- **Security** — capability-aware from `UserResponse.is_oidc_user` and
+  `GET /instance/config`. Password accounts get a change-password form (`PUT
+/users/me` with `current_password` + `new_password`; client mirrors the
+  backend rule of ≥8 chars with a letter and a digit). OIDC accounts get a short
+  provider notice, no form. A commented "danger zone" marks where account
+  deletion will live; it is not built.
+- **Appearance** — `/settings/appearance` uses `GET/PUT /users/me/settings` for
+  the account theme default, time format and first day of the week. The existing
+  sidebar control remains the explicit per-device override; it is not silently
+  moved or replaced. The page submits the three settings together, invalidates
+  `queryKeys.userSettings`, and participates in the shared discard guard.
+- **Integrations** — `/settings/integrations` is capability-gated by
+  `GET /instance/config`. An Immich form appears only when `immich_base_url` is
+  present, reads `GET /integrations/immich/status`, connects or updates through
+  the generated endpoints, and confirms disconnect. API keys remain ephemeral
+  and participate in the shared dirty guard; status cache is invalidated after
+  every successful write.
+- **Data & backup** — `/settings/data/import` and `/settings/data/export` use the
+  general background-job APIs. Both require an explicit start action, poll only
+  while a job is pending/running, render progress and a human failure state,
+  and never auto-download. Import uses the source types and ZIP contract from
+  OpenAPI (Markdown is omitted because the endpoint documents it as coming
+  soon); Export exposes the returned download URL only after completion.
+- **Support** — `/settings/support/help` contains the project and issue links.
+  `/settings/support/about` combines `GET /instance/version/info`, public
+  instance config and license info, omitting unavailable optional fields.
+- **Administration → Users** — `/settings/admin/users` is registered like every
+  other routed Settings page, but its **navigation group is conditional on the
+  shared current-user query returning `role: "admin"`**. A non-admin direct hit
+  is replaced with `/settings/profile` before the admin list query mounts. The
+  page walks `GET /admin/users` to completion through its offset contract (a
+  fixed page ceiling guards against a broken short-page response), then searches
+  and pages the complete collection locally. Edits send only changed fields, so
+  an untouched value never routes through a server protection. `POST
+  /admin/users` creates local password accounts and applies the same password
+  policy as signup; `PATCH /admin/users/{user_id}` edits name, email, role and
+  active status (plus password for local accounts); `DELETE
+  /admin/users/{user_id}` is protected by an exact-email confirmation that names
+  the full cascade. The server refuses to delete, demote or deactivate the last
+  admin who can still sign in; the row menu also **hides Deactivate and Delete
+  on the signed-in admin's own row** and disables them while the account is the
+  sole active admin. A refused write shows the server's own `detail` verbatim.
+  Every successful write invalidates `queryKeys.adminUsers`; writes affecting the
+  signed-in account also invalidate `queryKeys.me`, and self-deactivation /
+  self-deletion clears the session and hard-navigates to `/login`. OIDC password
+  reset is deliberately absent pending the backend contract decision in §22.
+  Responsive visual references: `docs/design/reference/12-settings-users-*`.
+
+### Deferred (do not stub pages)
+
+Version-check administration and license registration/reset remain deferred.
+Their endpoints exist, but no surface is designed. Account deletion remains
+explicitly out of scope. Dead links are not rendered.
+
+---
+
+## 24. Library
+
+People, Tags, Moods, Activities and Goals are journal content, not application
+preferences. They live as first-class children beneath a quiet **Library**
+label in the primary navigation and never mount the Settings modal. Their
+existing `/settings/journaling/*` URLs remain stable for now; the route contract,
+not the legacy prefix, determines the surface.
+
+Library is a content-management workspace, not an admin panel, CRM or database
+view. It spans the shell's two content columns, has one scroll owner and keeps a
+readable maximum measure. At compact widths the standard `PageBar` exposes the
+navigation drawer. Rows use whitespace and one hairline rule, or an airy
+`LibraryRow` grid — never nested tables. Exactly one visually dominant action
+belongs to a Library surface.
+
+**List → detail is a push, not a third pane.** Opening an item swaps the
+workspace for a detail *page* on the same span-2 route area (the marketplace
+pattern), with a breadcrumb bar as the title and the way back. Two shared
+shells carry this: `LibraryWorkspace` (the compact `PageBar`, the header with
+the one primary, the scroll owner) and `LibraryDetailView` (the breadcrumb bar
++ actions, its own scroll owner). Tags is the reference implementation; People,
+Moods, Activities and Goals adopt `LibraryDetailView` as their `$id` routes
+land. Neither route carries `staticData: detailPane` — there is no side-by-side
+detail here, so the shell's `.is-detail` machinery is not involved.
+
+**The scoped Timeline stays three-pane.** "View moments" on any Library item
+opens `/timeline` filtered to that entity — the ordinary nav ∥ list ∥ reader
+Timeline — so a tag's or person's moments are browsable beside the reader. That
+is deliberately *not* the `LibraryDetailView`.
+
+### People
+
+`/settings/journaling/people` is functional. **Add person** is the one primary
+action; **Manage groups** is secondary. The header and its primary sit above the
+scroll owner (as on the Journals surface), so "Add person" is always reachable.
+Search is local over the complete active People response and group names. The
+page combines `GET /people` (full person metadata) with `GET /people-groups`
+(ordered group membership):
+
+- A group is a **directory section**, not the absence of one: a header of
+  `chevron · EntityGlyph colour dot · sentence-case name · hairline rule ·
+  server count · ⋯` (the same dot + rule + count device as §22), then an airy
+  responsive grid of people (`repeat(auto-fill, minmax(15rem, 1fr))`, one
+  column below the two-pane breakpoint). No boxes, no rail — whitespace and the
+  one rule carry the grouping (§5). Named groups are open by default; the chevron
+  collapses a section; the count is the **server** figure (`people.length`) and
+  does not change when search narrows the grid.
+- Group overflow actions are Add person to group, Rename group (opens the
+  groups manager on that group), Manage people and Delete group. Deleting a
+  group never deletes its people.
+- **Manage groups** is one `Dialog` with three in-place views — the group list
+  (each row: glyph, name, count, edit, delete, plus New group), an appearance
+  form (name + colour swatches from `ENTITY_COLOR_PRESETS` + icon grid from the
+  curated Lucide set; writes `PersonGroupCreate/Update` including `color_value`
+  via `argbFromHex` and `icon`), and a delete confirmation. Views swap, never
+  stack (§22). Membership is **not** edited here.
+- A person is a rich row (the shared `LibraryRow`): avatar or initials, display
+  name, then `nickname · N moments` — the moment count is shown only when the
+  API returns `memory_count`. One overflow menu: Edit, Manage groups, Upload /
+  Remove image, Merge duplicate, Archive. Actions use only the existing edit,
+  group membership, profile image, merge and archive endpoints.
+- Membership is many-to-many (`PersonCreate/Update.group_ids` and the
+  `person_group_link` model), so every person-facing control says **Manage
+  groups**, never “Change group”. Group membership writes preserve memberships
+  in other groups.
+- People without membership are collected in a separate **“Without a group”**
+  section — same header, muted name, no dot and no `⋯`, rendered only when
+  non-empty. It is **collapsed by default when real groups exist** (so it reads
+  as a fallback bucket, not the page) and **open when there are no groups** (so a
+  first-time Library is not a wall of collapsed headers). A person in multiple
+  groups appears under each of them — the honest cost of a flat directory over a
+  tree.
+- `LibraryRow` and `EntityGlyph` live in `components/journiv`; the `⋯` menu is
+  the stock `DropdownMenu` primitive (`src/components/ui/dropdown-menu.tsx`).
+  Activities, Goals and Moods reuse all three, plus the now-generic
+  `GroupsManagerDialog` (`LibraryGroup` shape + `itemNoun` / `itemCount` props —
+  People keeps the defaults). The People collection's own section rendering
+  stays People-local so a future `/library/people/$personId` route can replace
+  the dialogs without rewriting it.
+
+### Activities
+
+`/settings/journaling/activities` is functional and follows the People directory
+rather than the older card/reorder UI. **Add activity** is the one primary
+action and **Manage groups** is secondary. The page walks every page of
+`GET /activities` (200 at a time) and combines the complete active collection
+with ordered `GET /activity-groups/` results. Search is local over activity and
+group names; named groups are open by default, and active activities with no
+`group_id` use the same muted, collapsed-by-default **Without a group** fallback
+as People.
+
+- Activity rows reuse `LibraryRow`, `EntityGlyph` and the shared overflow menu.
+  They render only `ActivityResponse.name`, `icon` and validated `color` (a hex
+  string, passed to `EntityGlyph`'s `color` prop); the list response has no
+  usage count. Create/edit uses `POST /activities` and
+  `PUT /activities/{activity_id}` for name, one optional group, colour and icon.
+  Delete is confirmed and calls `DELETE /activities/{activity_id}`; the backend
+  soft-deletes the definition, so existing moment links remain.
+- Group headers and the in-place `GroupsManagerDialog` reuse the People visual
+  contract. Group appearance writes `ActivityGroupCreate/Update` through
+  `POST /activity-groups/` and `PUT /activity-groups/{group_id}`. Deleting via
+  `DELETE /activity-groups/{group_id}` moves its activities to **Without a
+  group**; it never deletes them. Activity membership is one-to-zero-or-one via
+  `ActivityCreate/Update.group_id`, so moving an activity is part of Edit rather
+  than a many-to-many membership dialog.
+- Every successful activity or group write invalidates both `activities` and
+  `activity-groups`; a failed write stays in its dialog, retains all entered
+  values, and shows a human failure sentence. The generated reorder endpoints
+  remain supported by the API but are not exposed by this People-style
+  directory iteration.
+
+### Goals
+
+`/settings/journaling/goals` is functional and follows the People / Activities
+directory contract. **Add goal** is the one primary action and **Manage groups**
+is secondary. The page combines active `GET /goals` results with ordered
+`GET /goal-categories` groups and active `GET /activities` definitions used to
+name and select a goal's optional linked activity. Search is local over goal and
+group names; named groups are open by default, and goals without `category_id`
+use the muted, collapsed-by-default **Without a group** fallback.
+
+- Goal rows reuse `LibraryRow`, `EntityGlyph` and the shared overflow menu. They
+  show the API's cadence, direction, current-period completed / target counts,
+  linked activity name when resolvable, and paused state. Create/edit uses
+  `POST /goals` and `PUT /goals/{goal_id}` for every supported definition field:
+  title, optional category and activity, achieve/avoid direction, daily/weekly/
+  monthly cadence, integer target ≥ 1, optional reminder time, paused state,
+  colour and icon. The wider goal form uses a stock `sm:max-w-2xl` on
+  `DialogContent`, not a bespoke width class. Delete is explicitly permanent,
+  confirmed, and calls `DELETE /goals/{goal_id}`; its copy names the loss of
+  completion history.
+- **History** is exposed: a goal's ⋯ menu opens `GoalHistoryDialog`, a
+  read-only view of `GET /goals/{id}/logs` — one evaluated period per row,
+  newest first, a status mark, the cadence-shaped period label, and the
+  count / target plus whether the period was logged automatically or by hand.
+  No primary action; the surface's one primary stays "Add goal" on the page
+  behind it, matching the Details-popover precedent in §14.
+- Goal categories use the same in-place `GroupsManagerDialog` and appearance
+  form as People / Activities. Writes use `POST /goal-categories`,
+  `PUT /goal-categories/{category_id}` and
+  `DELETE /goal-categories/{category_id}`. Because the backend relationship is
+  `ON DELETE SET NULL`, deleting a group moves its goals to **Without a group**
+  and never deletes them. Counts are derived from the complete active Goals
+  response because category responses do not embed members.
+- Every successful goal or category write invalidates both `goals` and
+  `goal-categories`; a failed write remains in its dialog, retains all entered
+  values, and shows a human failure sentence. The generated archive/unarchive,
+  completion-toggle and reorder endpoints remain supported by the API but are
+  not exposed by this People-style definition-management iteration.
+
+### Moods
+
+`/settings/journaling/moods` is a first-class Library workspace backed by
+`GET /moods` and `GET /moods/groups`. New accounts arrive with the
+backend-seeded **Daily Moods** group and five active moods; the page renders
+that server data directly and does not invent a special built-in badge because
+neither mood nor group responses expose their internal `stable_key`. Mood rows
+use the shared `LibraryRow` and colour-only `EntityGlyph` (the API's icon is a
+Material Symbols name and is not renderable by the Lucide frontend; §7), and
+show the derived category plus score out of five. Search covers mood, category
+and group names; moods absent from every many-to-many group appear under
+**Without a group**.
+
+- Create/edit uses `POST /moods` and `PUT /moods/{mood_id}` for name, score
+  (required integer 1–5; the backend derives positive / neutral / negative) and
+  optional ARGB colour. The unsupported icon picker is deliberately absent, while
+  edits preserve existing Material Symbols icon values by omitting that field.
+  `DELETE /moods/{mood_id}` is a confirmed soft delete: the mood leaves active
+  lists while existing moment references remain.
+- Mood-group appearance CRUD reuses `GroupsManagerDialog` and calls
+  `POST /moods/groups`, `PUT /moods/groups/{group_id}` and
+  `DELETE /moods/groups/{group_id}`. Group deletion removes only memberships;
+  moods remain in the Library. Every successful mood or group write invalidates
+  both `moods` and `mood-groups`; failed saves retain entered values and show a
+  human sentence. Mood/group reorder, membership assignment, statistics and
+  streak endpoints remain backend-supported but are not exposed in this
+  People-style definition-management iteration.
+
+### Tags
+
+`/library/tags` is functional. It is the reference implementation of the
+Library push pattern above: `TagsPage` is a `LibraryWorkspace`, and opening a
+tag pushes to `TagDetailPage` (a `LibraryDetailView`) on `/library/tags/$tagId`.
+Tags have no groups, colour or icon, so the mark is a plain `#` and the
+People/Moods section machinery does not apply. The legacy
+`/settings/journaling/tags` URL redirects here.
+
+- **Workspace.** One primary: **New tag**; a secondary **Clean up N unused**
+  `ghost` button appears while `usage_count === 0` tags exist
+  (`DELETE /tags/unused`, confirmed). Local search over `GET /tags/`; a sort
+  `<select>` (Most used — the default and the backend's own order — / A–Z /
+  Recently added). A slim **insights strip** always shows four counts derived
+  client-side from the tag list (total, in use, unused, avg per tag); it needs
+  no licence. Then an airy `LibraryRow` grid (`.jv-lib-section__grid`, one
+  column below the two-pane breakpoint) — `rowLink` makes the whole card open
+  the detail; `#name`, `N moments · added …`, and a `⋯` menu (View moments →
+  Timeline tag-scope · Merge into… · Delete…). Loading / empty / error via
+  `Skeleton` / `StatusView`.
+- **Merge** opens a `Dialog` with a filter field and a radio list of the other
+  tags; the confirm sentence names the resulting tag and that the source is
+  deleted. `POST /tags/{source}/merge/{target}`; a 400 (case-only collision) is
+  shown as a human sentence.
+- **Detail.** Breadcrumb `Tags / #name`; **Rename** (the surface's one primary)
+  and the `⋯` menu sit at the bar's end. Body: the `N moments · added …` line,
+  a **Usage** section, and a **Recent moments** preview (`GET /tags/{id}/moments`,
+  first few, linking into the reader when the moment has an entry, else inert; a
+  **View all** link always goes to the Timeline tag-scope). Merge and Delete
+  both leave for `/library/tags` on success.
+- **Tag analytics is Journiv Plus (Supporter tier or higher).** The gate is
+  `GET /instance/config` → `plus` (`{ available, tier, upgrade_url }`), read via
+  `usePlusCapability()` — never by probing the analytics endpoint and reading
+  its 403/503. Three outcomes: `isSupporter` renders the analytics
+  (`GET /tags/{id}/analytics?days=…` — trend chip, peak month, growth, a
+  sparkline of `usage_over_time`); `available && !isSupporter` shows an upsell
+  `StatusView` linking `upgrade_url`; `!available` shows a quieter "not included
+  in this build" with no call to action. The analytics query still treats a
+  late 403/503 defensively as the same locked state, so an expiring licence
+  never reaches the screen as a raw error.
+- The aggregate `GET /tags/analytics` visuals (distribution buckets +
+  `usage_over_time` across all tags) render in the workspace strip for a
+  Supporter licence; the four free counts stay for everyone.
+
+Chart marks (`StatTiles`, `DistributionBars`, `Sparkline` in
+[`tagCharts.tsx`](src/features/library/tagCharts.tsx)) are the first data
+visualisations in the app — deliberately minimal, one series in `--chart-1`,
+tracks in `--border`, every label a typographic role. Feature-local until a
+second surface needs them (§18).
+
+---
+
+## 25. Personalization
+
+A viewer can retint and re-font Journiv for their device. It works precisely
+*because* the app is on stock shadcn tokens — nothing is hard-coded, so a
+retheme reaches every surface including the reader and editor.
+
+### The layer
+
+[`src/features/theme/`](src/features/theme/) owns it.
+
+- **`UserTheme`** (`types.ts`) — `{ version, light, dark, systemFont?,
+  editorFont?, editorFontScale? }`. `light` / `dark` are `Partial<Record<ColorVar,
+  string>>`; `ColorVar` is the stock shadcn colour / shadow set —
+  **font variables are deliberately not in it, and neither is `radius`.** Shape
+  is not personalizable (§3); only colour, fonts and text size are. This shape
+  is exactly what a
+  future `PUT /users/me/settings { theme }` will carry; backend sync needs no
+  redesign. Today it is **localStorage only** (`journiv.userTheme`).
+- **`applyUserTheme`** renders the structured map to a single
+  `<style id="journiv-user-theme">` in `<head>` — `:root { … } .dark { … }` plus
+  `--font-sans` / `--font-reader` / `--prose-font-scale`. Called from `main.tsx`
+  after `applyTheme` (no flash) and on every save / reset. We always serialise
+  from the parsed map; a pasted string is never written to the DOM.
+- **`parseThemeCss`** ingests a tweakcn / shadcn "Tailwind v4" export. A CSS
+  declaration scanner — never a DOM or `<style>` probe. **Lenient about
+  structure** (unknown selectors, `@theme`, `@layer`, `@custom-variant` are
+  ignored, not rejected); **strict about names and values**: a declaration is
+  kept only if the name is an allowlisted `ColorVar` and the value passes a
+  function-name grammar (`oklch/oklab/rgb/hsl/color-mix/calc/var` …). `url(`,
+  `image-set(`, `element(`, `expression(`, `@import`, `javascript:`, unbalanced
+  parens → dropped with a note. `--font-*` → dropped with a note. Succeeds
+  whenever ≥ 1 colour var survives. Covered by real tweakcn fixtures in
+  `__fixtures__/`.
+- **`exportThemeCss`** is the inverse, for copy / share. Fonts are a comment,
+  not `--font-*`.
+
+### Controls (Settings → Appearance → "Personalize")
+
+Accent colour (preset swatches + any CSS colour → `--primary`, light and dark);
+**system font** and **editor font** as *independent* pickers over the bundled
+set (`fonts.ts` — DM Sans always, others lazy); **text size** as a prose-only
+scale (`--prose-font-scale`, consumed by `prose.css` — **the root font-size is
+never scaled**, that would resize Tailwind's whole rem system); import / export
+/ reset. Every setter previews live and persists immediately. There is
+deliberately no corner-radius control (§3).
+
+### Rules
+
+- Fonts come only from the pickers. An imported `--font-sans` is ignored.
+- No remote fonts — a self-hosted Journiv makes no external requests (§13).
+- Derived Journiv roles (`--accent-surface`, `--state-*`, …) are `color-mix` of
+  stock tokens, so a user theme flows through them without being listed.
+- Backend cross-device sync is a **follow-up**; the `UserTheme` JSON is the
+  contract it will reuse.
+
+---
+
+## 26. Authentication
+
+Reference: none yet — add `docs/design/reference/26-login-*` when the capture
+script covers it (§19).
+
+- One route, `/login`, outside the shell entirely — no nav, no `PageBar`, no
+  Settings. It is the one screen in the product that is not one of the three
+  panes.
+- `.jv-auth` centres a single card on `--sidebar` (the app-shell ground, not
+  the reading `--background`) — the only place the ground itself is the whole
+  page. The card is `--card`, `--radius-lg`, `max-width: 22rem`.
+- **The login card is the second sanctioned use of `--shadow-overlay`** (§5
+  says "no shadow outside overlays" — this is the exception, not a violation).
+  A lone card on an otherwise bare screen reads as the one focal object the
+  same way a dialog does; nowhere else outside `components/ui/*` overlays
+  earns this.
+- Brand mark, `.jv-display` heading ("Welcome back"), a one-line lede, then the
+  form: email, password, a single `role="alert"` error line, one primary
+  submit. Exactly one primary action, per §6.
+- **Errors are deliberately generic.** "Sign in failed. Check your email and
+  password." never distinguishes a wrong email from a wrong password — do not
+  make this more specific even if the backend response would allow it.
+- `returnTo` is carried in the `/login` route's search params and is where a
+  successful sign-in navigates — so a session expiring mid-read returns the
+  reader to the same Moment, not to the Timeline.
+- No OIDC branch is built here yet. When one lands, it joins this section, not
+  a new one — the login screen has exactly one spec regardless of how many
+  ways there are to arrive at "signed in".

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,9 @@
     "lint:design": "node scripts/check-design-system.mjs",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "test": "vitest run",
+    "test": "node scripts/check-design-system.mjs && vitest run",
     "test:watch": "vitest",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build && npm run api:check",
+    "verify": "npm run format:check && npm run lint && npm run lint:design && npm run typecheck && npm test && npm run build && npm run api:check",
     "api:pull": "node scripts/pull-openapi.mjs",
     "api:generate": "openapi-ts",
     "api:check": "node scripts/check-generated.mjs"

--- a/frontend/scripts/capture-design-reference.mjs
+++ b/frontend/scripts/capture-design-reference.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Capture the design reference screenshots used by DESIGN.md.
+ *
+ * Dependency-free: drives headless Chrome over the DevTools Protocol using
+ * Node's built-in WebSocket. Regenerate the references whenever a redesign
+ * lands so the documentation cannot drift from the product.
+ *
+ *   JOURNIV_EMAIL=... JOURNIV_PASSWORD=... \
+ *     node scripts/capture-design-reference.mjs --base http://127.0.0.1:5199
+ *
+ * Credentials are read from the environment only. Never hard-code an account
+ * in this file: it is committed.
+ */
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
+import path from "node:path";
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 2) {
+  args.set(process.argv[i].replace(/^--/, ""), process.argv[i + 1]);
+}
+const BASE = args.get("base") ?? "http://127.0.0.1:5199";
+const OUT = path.resolve(args.get("out") ?? "docs/design/reference");
+const CHROME =
+  args.get("chrome") ??
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const EMAIL = process.env.JOURNIV_EMAIL;
+const PASSWORD = process.env.JOURNIV_PASSWORD;
+
+if (!EMAIL || !PASSWORD) {
+  console.error(
+    "Set JOURNIV_EMAIL and JOURNIV_PASSWORD for a disposable local account.",
+  );
+  process.exit(1);
+}
+
+/** Scenarios are named after what they demonstrate, not after test data. */
+const VIEWPORTS = [
+  { name: "desktop", width: 1440, height: 900, scale: 1 },
+  { name: "mobile", width: 390, height: 844, scale: 1 },
+];
+const THEMES = ["light", "dark"];
+
+const PORT = 9333;
+const chrome = spawn(CHROME, [
+  "--headless=new",
+  `--remote-debugging-port=${PORT}`,
+  "--no-first-run",
+  "--no-default-browser-check",
+  "--user-data-dir=/tmp/journiv-design-capture",
+  "--hide-scrollbars",
+  "--force-device-scale-factor=1",
+  "about:blank",
+]);
+chrome.stderr.on("data", () => {});
+
+async function cdpTarget() {
+  for (let i = 0; i < 40; i += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${PORT}/json/list`);
+      const targets = await response.json();
+      const page = targets.find((t) => t.type === "page");
+      if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl;
+    } catch {
+      /* chrome not up yet */
+    }
+    await delay(250);
+  }
+  throw new Error("Chrome DevTools endpoint never became available");
+}
+
+function connect(url) {
+  const socket = new WebSocket(url);
+  const pending = new Map();
+  let id = 0;
+  const ready = new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true });
+    socket.addEventListener("error", reject, { once: true });
+  });
+  socket.addEventListener("message", (event) => {
+    const message = JSON.parse(event.data);
+    const entry = pending.get(message.id);
+    if (!entry) return;
+    pending.delete(message.id);
+    if (message.error) entry.reject(new Error(JSON.stringify(message.error)));
+    else entry.resolve(message.result);
+  });
+  return {
+    ready,
+    close: () => socket.close(),
+    send(method, params = {}) {
+      id += 1;
+      const messageId = id;
+      return new Promise((resolve, reject) => {
+        pending.set(messageId, { resolve, reject });
+        socket.send(JSON.stringify({ id: messageId, method, params }));
+      });
+    },
+  };
+}
+
+async function main() {
+  const cdp = connect(await cdpTarget());
+  await cdp.ready;
+  await cdp.send("Page.enable");
+  await cdp.send("Runtime.enable");
+
+  const evaluate = async (expression) => {
+    const result = await cdp.send("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    if (result.exceptionDetails) {
+      throw new Error(
+        result.exceptionDetails.exception?.description ?? "eval failed",
+      );
+    }
+    return result.result.value;
+  };
+
+  const goto = async (url) => {
+    await cdp.send("Page.navigate", { url });
+    await delay(900);
+  };
+
+  await goto(`${BASE}/login`);
+
+  // Authenticate through the API and seed the session the app expects, so the
+  // capture never types credentials into the UI.
+  const signedIn = await evaluate(`(async () => {
+    const response = await fetch("/api/v1/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: ${JSON.stringify(EMAIL)}, password: ${JSON.stringify(PASSWORD)} }),
+    });
+    if (!response.ok) return "login failed: " + response.status;
+    const tokens = await response.json();
+    sessionStorage.setItem("journiv.prototype.session.v1", JSON.stringify({
+      version: 1,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+    }));
+    return "ok";
+  })()`);
+  if (signedIn !== "ok") throw new Error(String(signedIn));
+
+  const moments = await evaluate(`(async () => {
+    const token = JSON.parse(sessionStorage.getItem("journiv.prototype.session.v1")).accessToken;
+    const auth = { Authorization: "Bearer " + token };
+    const response = await fetch("/api/v1/moments?limit=50&include_empty=true", { headers: auth });
+    const items = (await response.json()).items;
+    const pick = (predicate) => items.find(predicate);
+
+    // Inline media has to be found by inspecting entry content: the Moment list
+    // does not carry content_delta.
+    let inline = null;
+    const candidates = items.filter((m) => m.entry && m.media_count > 0).slice(0, 8);
+    for (const moment of candidates) {
+      const entry = await fetch("/api/v1/entries/" + moment.entry.id, { headers: auth });
+      if (!entry.ok) continue;
+      const ops = (await entry.json())?.content_delta?.ops ?? [];
+      if (ops.some((op) => op && typeof op.insert === "object")) {
+        inline = moment.id;
+        break;
+      }
+    }
+
+    return {
+      rich: pick((m) => m.entry && m.media_count === 1 && m.tags?.length && m.id !== inline)?.id ?? null,
+      plain: pick((m) => m.entry && !m.media_count && !m.tags?.length)?.id ?? null,
+      noteOnly: pick((m) => !m.entry && m.note)?.id ?? null,
+      mediaOnly: pick((m) => !m.entry && !m.note && m.media_count > 0)?.id ?? null,
+      mediaGallery: pick((m) => m.entry && m.media_count > 1 && m.id !== inline)?.id ?? null,
+      inline,
+    };
+  })()`);
+
+  // Named after the canonical Moment scenarios in DESIGN.md §10, so the
+  // reference set always covers both sparse and rich Moments.
+  const scenes = [
+    { name: "01-timeline", url: `${BASE}/timeline` },
+    moments.rich && {
+      name: "02-reader-rich",
+      url: `${BASE}/timeline/${moments.rich}`,
+    },
+    moments.plain && {
+      name: "03-reader-plain",
+      url: `${BASE}/timeline/${moments.plain}`,
+    },
+    moments.noteOnly && {
+      name: "04-reader-note-only",
+      url: `${BASE}/timeline/${moments.noteOnly}`,
+    },
+    moments.mediaOnly && {
+      name: "05-reader-media-only",
+      url: `${BASE}/timeline/${moments.mediaOnly}`,
+    },
+    moments.mediaGallery && {
+      name: "06-reader-media-gallery",
+      url: `${BASE}/timeline/${moments.mediaGallery}`,
+    },
+    moments.inline && {
+      name: "07-reader-inline-media",
+      url: `${BASE}/timeline/${moments.inline}`,
+    },
+    moments.rich && {
+      name: "08-editor",
+      url: `${BASE}/timeline/${moments.rich}/edit`,
+    },
+    { name: "09-editor-new", url: `${BASE}/timeline/new` },
+    { name: "10-empty-search", url: `${BASE}/timeline?q=zzzznothingmatches` },
+    // Settings overlay (DESIGN.md §23): the desktop capture shows the two-column
+    // modal, the mobile capture the full-screen routed page.
+    { name: "12-settings-profile", url: `${BASE}/settings/profile` },
+    { name: "13-settings-security", url: `${BASE}/settings/security` },
+  ].filter(Boolean);
+
+  await mkdir(OUT, { recursive: true });
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      await cdp.send("Emulation.setDeviceMetricsOverride", {
+        width: viewport.width,
+        height: viewport.height,
+        deviceScaleFactor: viewport.scale,
+        mobile: viewport.name === "mobile",
+      });
+      await cdp.send("Emulation.setEmulatedMedia", {
+        features: [{ name: "prefers-color-scheme", value: theme }],
+      });
+      await evaluate(
+        `localStorage.setItem("journiv.theme", ${JSON.stringify(theme)})`,
+      );
+
+      for (const scene of scenes) {
+        await goto(scene.url);
+        await delay(1500); // let queries settle and images decode
+        const shot = await cdp.send("Page.captureScreenshot", {
+          format: "png",
+          captureBeyondViewport: false,
+        });
+        const file = path.join(
+          OUT,
+          `${scene.name}-${viewport.name}-${theme}.png`,
+        );
+        await writeFile(file, Buffer.from(shot.data, "base64"));
+        console.log("captured", path.relative(process.cwd(), file));
+      }
+    }
+  }
+
+  cdp.close();
+  chrome.kill();
+}
+
+main().catch((error) => {
+  console.error(error);
+  chrome.kill();
+  process.exit(1);
+});

--- a/frontend/scripts/check-design-system.mjs
+++ b/frontend/scripts/check-design-system.mjs
@@ -3,6 +3,11 @@
  * Mechanical enforcement of the DESIGN.md rules that are easiest to break and
  * hardest to spot in review.
  *
+ * This is a STATIC, source-level guard. It parses .css/.ts/.tsx files and
+ * DESIGN.md's own prose — it never launches a browser. Rendered/runtime
+ * properties (contrast as actually painted, computed styles, visual
+ * regressions) are Playwright's job, not this script's — see DESIGN.md §19.
+ *
  * Run via `npm run lint:design`, `npm test` or `npm run verify`.
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -15,6 +20,65 @@ const VALUE_LAYER = [
   "src/styles/prose.css",
   "src/styles/fonts.css",
   "src/styles/util.css",
+];
+
+/** The one sanctioned data-palette exception (DESIGN.md §3) — literal hex
+ *  arrays that are content a user picks, not a piece of Journiv's theme. */
+const DATA_PALETTE_FILES = ["src/lib/journalColors.ts"];
+
+/** Registry components kept close to upstream (DESIGN.md §18) are exempt from
+ *  the arbitrary-Tailwind-value check — re-skinning them to avoid a bracketed
+ *  value would violate the "don't rewrite a registry component" rule. */
+const REGISTRY_DIR = "src/components/ui/";
+
+/** CSS custom properties that are legitimately never `--name: value;`
+ *  declared in any stylesheet: set inline from API data by JS (DESIGN.md §3),
+ *  or owned by a vendor (base-ui) whose CSS we don't author. */
+const RUNTIME_OR_VENDOR_VARS = new Set([
+  "--journal-accent",
+  "--mood-accent",
+  "--entity-accent",
+]);
+
+/** `--name` prefixes that exist only to bridge tokens into Tailwind's
+ *  `@theme inline` utility generator (src/styles/index.css) — consumed by
+ *  Tailwind's compiler via class names (`bg-primary`, `rounded-md`, …), never
+ *  by a textual `var(--color-primary)` in our own code. A dead-token check
+ *  that doesn't know this would flag all of them. */
+const THEME_BRIDGE_PREFIX = /^--(color|radius|font)-/;
+
+/** The two layout breakpoints (DESIGN.md §9) plus every current
+ *  component-level breakpoint, named there. A new *page*-shaped breakpoint
+ *  must be one of the two layout widths; a new *component* breakpoint must be
+ *  added here and named in DESIGN.md §9 — this check is a "confirm and
+ *  document" gate, not a ban. */
+const ALLOWED_BREAKPOINTS = new Set([
+  "860px",
+  "1100px",
+  "1101px", // paired with 1100px's max-width to avoid a 1-pixel overlap
+  "620px", // settings.css row layout, users.css heading
+  "520px", // tags.css stat grid
+  "640px", // tags.css controls wrap
+  "768px", // util.css .jv-field font-size
+  "34rem", // editor.css conflict banner wrap
+]);
+
+/** Token facts documented as a literal value in DESIGN.md prose, cross-checked
+ *  against their `tokens.css` definition so the two cannot silently diverge
+ *  (this is exactly the class of bug — a documented radius scale nobody
+ *  updated after the tokens changed — that motivated this check). Each entry:
+ *  the CSS custom property name, and how it appears in DESIGN.md prose
+ *  (```--name` <value>`` or ``--name`` <value>``, both used depending on
+ *  section). */
+const TOKEN_FACTS = [
+  "radius-xs",
+  "radius-sm",
+  "radius-md",
+  "radius-lg",
+  "bar-height",
+  "reader-measure",
+  "tap-target",
+  "duration-fast",
 ];
 
 function walk(dir, extensions) {
@@ -52,6 +116,9 @@ const featureCss = cssFiles.filter((file) => !VALUE_LAYER.includes(file));
 const sourceFiles = walk("src", [".tsx", ".ts"]).filter(
   (file) => !/\.test\.tsx?$/.test(file),
 );
+const productFiles = sourceFiles.filter(
+  (file) => !file.startsWith(REGISTRY_DIR),
+);
 
 // A broken walk would make every check pass vacuously.
 if (cssFiles.length < 5 || featureCss.length < 3 || sourceFiles.length < 20) {
@@ -63,7 +130,7 @@ if (cssFiles.length < 5 || featureCss.length < 3 || sourceFiles.length < 20) {
   process.exit(2);
 }
 
-const checks = [
+const lineChecks = [
   {
     name: "raw colour outside the token layer",
     files: featureCss,
@@ -104,10 +171,30 @@ const checks = [
       `Journiv is commonly reached over plain HTTP on a LAN — attaching a photo\n` +
       `threw there and did nothing. Use uuid() from src/lib/uuid.ts.`,
   },
+  {
+    name: "raw colour in a Tailwind arbitrary-value utility",
+    files: productFiles.filter((file) => !DATA_PALETTE_FILES.includes(file)),
+    pattern:
+      /\b(?:bg|text|border|ring|fill|stroke|from|via|to|shadow|outline|decoration|accent|caret|divide)-\[#[0-9a-fA-F]{3,8}\]/,
+    fix:
+      `A bracketed Tailwind colour utility (e.g. bg-[#405DE6]) bypasses every\n` +
+      `token. Use the semantic Tailwind class (bg-primary, text-muted-foreground,\n` +
+      `…) that already resolves through index.css's --color-* map (DESIGN.md §3).`,
+  },
+  {
+    name: "arbitrary spacing or font-size Tailwind value",
+    files: productFiles,
+    pattern:
+      /\b(?:m|p)[trblxy]?-\[[0-9.]+(?:px|rem|em)\]|\bgap(?:-x|-y)?-\[[0-9.]+(?:px|rem|em)\]|\btext-\[[0-9.]+(?:px|rem|em)\]/,
+    fix:
+      `DESIGN.md §3: "Do not write mt-[13px]." Use the spacing scale\n` +
+      `(--space-1…--space-16 / gap-1, gap-2, …) or a typographic role class from\n` +
+      `src/styles/base.css instead of a bracketed pixel/rem value.`,
+  },
 ];
 
 let failed = 0;
-for (const check of checks) {
+for (const check of lineChecks) {
   const violations = scan(check.files, check.pattern);
   if (!violations.length) continue;
   failed += violations.length;
@@ -117,6 +204,225 @@ for (const check of checks) {
   }
   console.error(`\n  ${check.fix.split("\n").join("\n  ")}\n`);
 }
+
+// ---------------------------------------------------------------------------
+// Structural checks: these need more than "does this line match a pattern",
+// so they are hand-written rather than run through `lineChecks`/`scan`.
+// ---------------------------------------------------------------------------
+
+function report(name, violations, fix) {
+  if (!violations.length) return 0;
+  console.error(`\n✗ ${name}\n`);
+  for (const line of violations) console.error(`    ${line}`);
+  console.error(`\n  ${fix.split("\n").join("\n  ")}\n`);
+  return violations.length;
+}
+
+/** Every `var(--x)` used in a stylesheet must resolve to a real `--x: …;`
+ *  declaration somewhere, or be one of the sanctioned runtime/vendor names.
+ *  This is the check that would have caught `var(--line)` resolving to
+ *  nothing in a real border-bottom rule — a bug the design guard did not
+ *  previously catch because nothing verified property NAMES, only literal
+ *  colour/size VALUES. */
+function checkUndefinedCustomProperties() {
+  const defined = new Set();
+  for (const file of cssFiles) {
+    for (const m of withoutComments(readFileSync(file, "utf8")).matchAll(
+      /^\s*(--[a-zA-Z0-9-]+)\s*:/gm,
+    )) {
+      defined.add(m[1]);
+    }
+  }
+  const violations = [];
+  for (const file of cssFiles) {
+    withoutComments(readFileSync(file, "utf8"))
+      .split("\n")
+      .forEach((text, index) => {
+        for (const m of text.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)/g)) {
+          const name = m[1];
+          if (!defined.has(name) && !RUNTIME_OR_VENDOR_VARS.has(name)) {
+            violations.push(
+              `${file}:${index + 1}  var(${name}) — never declared`,
+            );
+          }
+        }
+      });
+  }
+  return report(
+    "undefined CSS custom property",
+    violations,
+    `This property is not declared \`--name: value;\` in any stylesheet, and\n` +
+      `is not one of the sanctioned runtime/vendor names\n` +
+      `(${[...RUNTIME_OR_VENDOR_VARS].join(", ")}). A typo here silently\n` +
+      `resolves to nothing — the browser drops the whole declaration — so it\n` +
+      `never throws and rarely gets noticed in review. Fix the name, or add it\n` +
+      `to tokens.css and document it in DESIGN.md §3.`,
+  );
+}
+
+/** A token declared in tokens.css that nothing consumes is either dead code
+ *  or a promise DESIGN.md makes that the product doesn't keep. Either way it
+ *  should be resolved, not left to rot — this is exactly how `--state-pressed`
+ *  and `--duration-base` were found. */
+function checkDeadTokens() {
+  const defined = new Map(); // name -> file:line
+  for (const file of cssFiles) {
+    withoutComments(readFileSync(file, "utf8"))
+      .split("\n")
+      .forEach((text, index) => {
+        const m = text.match(/^\s*(--[a-zA-Z0-9-]+)\s*:/);
+        if (m) defined.set(m[1], `${file}:${index + 1}`);
+      });
+  }
+  const used = new Set();
+  for (const file of cssFiles) {
+    for (const m of readFileSync(file, "utf8").matchAll(
+      /var\(\s*(--[a-zA-Z0-9-]+)/g,
+    )) {
+      used.add(m[1]);
+    }
+  }
+  const violations = [];
+  for (const [name, where] of defined) {
+    if (!used.has(name) && !THEME_BRIDGE_PREFIX.test(name)) {
+      violations.push(`${where}  ${name} — no var(${name}) anywhere`);
+    }
+  }
+  return report(
+    "dead token",
+    violations,
+    `Defined in tokens.css but nothing reads it. Either give it a real\n` +
+      `consumer, or remove it and its mention in DESIGN.md — a token with no\n` +
+      `consumer is a claim the design system isn't keeping.`,
+  );
+}
+
+/** Every `[text](src/...)` link in DESIGN.md must resolve to a real file or
+ *  directory. A stale link (a rename the doc missed) sends the next agent
+ *  looking for a file that isn't there. */
+function checkDesignMdLinks() {
+  const designMd = readFileSync("DESIGN.md", "utf8");
+  const violations = [];
+  const seen = new Set();
+  for (const m of designMd.matchAll(/\]\((src\/[^)]+)\)/g)) {
+    const target = m[1];
+    if (seen.has(target)) continue;
+    seen.add(target);
+    try {
+      statSync(target);
+    } catch {
+      violations.push(`DESIGN.md links to ${target} — does not exist`);
+    }
+  }
+  return report(
+    "broken DESIGN.md link",
+    violations,
+    `Fix the path, or the file this linked to before continuing — a broken\n` +
+      `link sends the next reader (human or agent) looking for something that\n` +
+      `moved or was renamed.`,
+  );
+}
+
+/** A page-shaped breakpoint at a width nobody has named is exactly how "one
+ *  breakpoint system" quietly became seven. This does not forbid a new
+ *  component breakpoint — it forces it to be named in ALLOWED_BREAKPOINTS
+ *  (and, by the same change, in DESIGN.md §9) rather than added silently. */
+function checkBreakpoints() {
+  const violations = [];
+  for (const file of cssFiles) {
+    withoutComments(readFileSync(file, "utf8"))
+      .split("\n")
+      .forEach((text, index) => {
+        if (!/@media/.test(text)) return;
+        for (const m of text.matchAll(/([0-9.]+(?:px|rem))/g)) {
+          if (!ALLOWED_BREAKPOINTS.has(m[1])) {
+            violations.push(
+              `${file}:${index + 1}  ${text.trim()} — ${m[1]} is not an allowed breakpoint`,
+            );
+          }
+        }
+      });
+  }
+  return report(
+    "unlisted breakpoint",
+    violations,
+    `DESIGN.md §9 names exactly two layout breakpoints (860px, 1100px/1101px)\n` +
+      `plus a fixed list of component-level ones. A new *page*-shaped\n` +
+      `breakpoint (a pane restructuring) must be one of the two layout widths.\n` +
+      `A new *component* breakpoint (one control reflowing at its own width) is\n` +
+      `fine — add it to ALLOWED_BREAKPOINTS in this script and name it in\n` +
+      `DESIGN.md §9's component-breakpoint list.`,
+  );
+}
+
+/** Cross-checks a handful of literal values DESIGN.md documents in prose
+ *  (the radius scale, layout constants) against their tokens.css definition,
+ *  so a token change and its documentation cannot silently drift apart — the
+ *  exact failure mode that let the radius scale in DESIGN.md describe values
+ *  the app hadn't rendered in months. This validates literal VALUES; rendered
+ *  contrast and other computed/cascaded properties are Playwright's job. */
+function checkTokenFacts() {
+  const tokensCss = readFileSync("src/styles/tokens.css", "utf8");
+  const designMd = readFileSync("DESIGN.md", "utf8");
+  const violations = [];
+
+  for (const name of TOKEN_FACTS) {
+    const defMatch = tokensCss.match(
+      new RegExp(`--${name}:\\s*([0-9.]+[a-zA-Z]+)`),
+    );
+    const docMatch = designMd.match(
+      new RegExp(`\`--${name}\`\\s+([0-9.]+[a-zA-Z]+)`),
+    );
+    if (!defMatch) {
+      violations.push(
+        `--${name} is a documented token fact but is not declared in tokens.css`,
+      );
+      continue;
+    }
+    if (!docMatch) {
+      violations.push(
+        `--${name} is ${defMatch[1]} in tokens.css but DESIGN.md never states its value`,
+      );
+      continue;
+    }
+    if (defMatch[1] !== docMatch[1]) {
+      violations.push(
+        `--${name} is ${defMatch[1]} in tokens.css but DESIGN.md says ${docMatch[1]}`,
+      );
+    }
+  }
+
+  // The spacing scale is documented as one ordered sequence, not per-token —
+  // "4 / 8 / 12 / 16 / 24 / 32 / 48 / 64 as --space-1 … --space-16" — so it is
+  // checked positionally against tokens.css's own declaration order.
+  const spaceValues = [
+    ...tokensCss.matchAll(/--space-\d+:\s*([0-9.]+px)/g),
+  ].map((m) => m[1]);
+  const docSpacing = designMd.match(/^Spacing:\s*([0-9\s/]+)\s*as `--space-1/m);
+  if (docSpacing) {
+    const documented = docSpacing[1].split("/").map((n) => `${n.trim()}px`);
+    if (JSON.stringify(documented) !== JSON.stringify(spaceValues)) {
+      violations.push(
+        `Spacing scale in tokens.css (${spaceValues.join(", ")}) does not match ` +
+          `DESIGN.md's documented sequence (${documented.join(", ")})`,
+      );
+    }
+  }
+
+  return report(
+    "token fact drifted from DESIGN.md",
+    violations,
+    `A value in tokens.css no longer matches what DESIGN.md's prose states.\n` +
+      `Update whichever one is wrong — usually the doc, since tokens.css is the\n` +
+      `thing that actually renders — in the same change.`,
+  );
+}
+
+failed += checkUndefinedCustomProperties();
+failed += checkDeadTokens();
+failed += checkDesignMdLinks();
+failed += checkBreakpoints();
+failed += checkTokenFacts();
 
 if (failed) {
   console.error(

--- a/frontend/src/components/journiv/StatusView.tsx
+++ b/frontend/src/components/journiv/StatusView.tsx
@@ -37,7 +37,7 @@ export function StatusView({
       {icon && (
         <span
           className={cn(
-            "mb-1 inline-flex size-11 items-center justify-center rounded-xl",
+            "mb-1 inline-flex size-11 items-center justify-center rounded-lg",
             tone === "danger"
               ? "bg-destructive/10 text-destructive"
               : "bg-muted text-muted-foreground",
@@ -47,9 +47,7 @@ export function StatusView({
           {icon}
         </span>
       )}
-      <p className="text-[0.9375rem] font-semibold text-balance text-foreground">
-        {title}
-      </p>
+      <p className="jv-section-title text-balance text-foreground">{title}</p>
       {description && (
         <p className="text-sm leading-normal text-pretty text-muted-foreground">
           {description}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -81,7 +81,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-lg bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/frontend/src/components/ui/input-group.tsx
+++ b/frontend/src/components/ui/input-group.tsx
@@ -20,7 +20,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const inputGroupAddonVariants = cva(
-  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-xs [&>svg:not([class*='size-'])]:size-4",
   {
     variants: {
       align: {
@@ -67,10 +67,9 @@ const inputGroupButtonVariants = cva(
   {
     variants: {
       size: {
-        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        xs: "h-6 gap-1 rounded-xs px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
         sm: "",
-        "icon-xs":
-          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        "icon-xs": "size-6 rounded-xs p-0 has-[>svg]:p-0",
         "icon-sm": "size-8 p-0 has-[>svg]:p-0",
       },
     },

--- a/frontend/src/features/library/library.css
+++ b/frontend/src/features/library/library.css
@@ -82,7 +82,7 @@
   gap: var(--space-3);
   min-height: var(--bar-height);
   padding: var(--space-2) var(--space-4);
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--border);
 }
 
 .jv-library__crumb {

--- a/frontend/src/features/settings/appearance/PersonalizeSection.tsx
+++ b/frontend/src/features/settings/appearance/PersonalizeSection.tsx
@@ -20,13 +20,6 @@ const ACCENT_PRESETS = [
   { label: "Slate", value: "oklch(0.45 0.03 260)" },
 ];
 
-const RADIUS_STEPS = [
-  { label: "Square", value: "0rem" },
-  { label: "Slight", value: "0.375rem" },
-  { label: "Default", value: "0.625rem" },
-  { label: "Round", value: "1rem" },
-];
-
 const SIZE_STEPS = [0.92, 0.96, 1, 1.08, 1.18];
 
 export function PersonalizeSection() {
@@ -42,7 +35,6 @@ export function PersonalizeSection() {
   }, [p.theme.light.primary]);
 
   const currentScale = p.theme.editorFontScale ?? 1;
-  const currentRadius = p.theme.light.radius ?? "0.625rem";
 
   const applyImport = () => {
     setImportError(null);
@@ -151,22 +143,6 @@ export function PersonalizeSection() {
               onClick={() => p.setEditorFontScale(scale)}
             >
               {Math.round(scale * 100)}%
-            </button>
-          ))}
-        </div>
-      </SettingsRow>
-
-      <SettingsRow label="Corner radius">
-        <div className="jv-personalize__steps">
-          {RADIUS_STEPS.map((step) => (
-            <button
-              key={step.value}
-              type="button"
-              className="jv-personalize__step"
-              aria-pressed={currentRadius === step.value}
-              onClick={() => p.setRadius(step.value)}
-            >
-              {step.label}
             </button>
           ))}
         </div>

--- a/frontend/src/features/theme/theme.test.ts
+++ b/frontend/src/features/theme/theme.test.ts
@@ -102,7 +102,7 @@ describe("parseThemeCss — leniency and safety", () => {
 describe("applyUserTheme", () => {
   const theme: UserTheme = {
     version: 1,
-    light: { primary: "oklch(0.5 0.2 20)", radius: "0.75rem" },
+    light: { primary: "oklch(0.5 0.2 20)", border: "oklch(0.9 0 0)" },
     dark: { primary: "oklch(0.7 0.2 20)" },
     systemFont: "lora",
     editorFont: "dm-sans",
@@ -116,7 +116,7 @@ describe("applyUserTheme", () => {
     const css = el?.textContent ?? "";
     expect(css).toContain(":root {");
     expect(css).toContain("--primary: oklch(0.5 0.2 20);");
-    expect(css).toContain("--radius: 0.75rem;");
+    expect(css).toContain("--border: oklch(0.9 0 0);");
     expect(css).toContain(".dark {");
     expect(css).toContain("--prose-font-scale: 1.1;");
     expect(css).toMatch(/--font-sans: "Lora Variable"/);

--- a/frontend/src/features/theme/types.ts
+++ b/frontend/src/features/theme/types.ts
@@ -9,9 +9,11 @@
  * redesign.
  */
 
-/** The stock shadcn colour / radius / shadow variables a user (or an imported
- *  tweakcn theme) may set. Font variables are deliberately NOT here — fonts come
- *  only from the bundled-font pickers. */
+/** The stock shadcn colour / shadow variables a user (or an imported tweakcn
+ *  theme) may set. Font variables are deliberately NOT here — fonts come only
+ *  from the bundled-font pickers. `radius` is deliberately NOT here either —
+ *  there is no corner-radius personalization control; the shape scale in
+ *  tokens.css is four literal values (DESIGN.md §3), not user-configurable. */
 export const COLOR_VARS = [
   "background",
   "foreground",
@@ -32,7 +34,6 @@ export const COLOR_VARS = [
   "border",
   "input",
   "ring",
-  "radius",
   "sidebar",
   "sidebar-foreground",
   "sidebar-primary",

--- a/frontend/src/features/theme/usePersonalization.ts
+++ b/frontend/src/features/theme/usePersonalization.ts
@@ -28,13 +28,6 @@ export function usePersonalization() {
     [theme, commit],
   );
 
-  const setRadius = useCallback(
-    (value: string) => {
-      commit({ ...theme, light: { ...theme.light, radius: value } });
-    },
-    [theme, commit],
-  );
-
   const setSystemFont = useCallback(
     (value: BundledFont) => commit({ ...theme, systemFont: value }),
     [theme, commit],
@@ -71,7 +64,6 @@ export function usePersonalization() {
   return {
     theme,
     setAccent,
-    setRadius,
     setSystemFont,
     setEditorFont,
     setEditorFontScale,

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -57,13 +57,14 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 
-  /* Radius scale. `--radius-xs` is a Journiv extra; the rest are what the
-     base-vega components reference. */
-  --radius-xs: calc(var(--radius) - 4px);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  /* Radius scale: literal tokens from tokens.css (DESIGN.md §3), aliased here
+     so Tailwind's `rounded-*` utilities resolve to them. Never calc(). There
+     is no `--radius-xl` step — a component that needs the largest radius
+     uses `rounded-lg`. */
+  --radius-xs: var(--radius-xs);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
 }
 
 @layer base {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -24,7 +24,10 @@
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  /* Darkened from stock base-vega's oklch(0.556 0 0), which measured 4.53:1 on
+     --sidebar — clears AA (4.5:1) but with almost no margin. This lands ~5.2:1
+     on --sidebar / ~5.4:1 on --background. See §3 "Measured contrast". */
+  --muted-foreground: oklch(0.52 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
@@ -45,7 +48,13 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 
-  --radius: 0.625rem;
+  /* ---- shape scale (DESIGN.md §3) ------------------------------------ */
+  /* Four literal steps, never calc(). Not user-configurable — there is no
+     corner-radius personalization control. */
+  --radius-xs: 6px; /* chips, inputs, toolbar buttons */
+  --radius-sm: 10px; /* buttons, list rows */
+  --radius-md: 14px; /* cards, popovers, media */
+  --radius-lg: 20px; /* sheets, drawers, dialogs */
 
   /* ---- Journiv brand — the one identity colour --------------------- */
   /* Hue 269, the same blue the Flutter client ships (#405DE6). A user theme
@@ -58,14 +67,11 @@
   /* Product CSS (reader, editor, timeline, shell) needs a few roles the stock
      shadcn set does not name. They are DERIVED from the themeable tokens
      above, so an imported user theme flows through them automatically. */
-  --accent-hover: color-mix(in oklab, var(--primary) 88%, var(--foreground));
-  --accent-pressed: color-mix(in oklab, var(--primary) 78%, var(--foreground));
   --accent-surface: color-mix(in oklab, var(--primary) 12%, var(--background));
   --accent-border: color-mix(in oklab, var(--primary) 40%, var(--border));
   --focus-ring: var(--ring);
   --line-strong: color-mix(in oklab, var(--border), var(--foreground) 22%);
   --state-hover: color-mix(in oklab, transparent, var(--foreground) 6%);
-  --state-pressed: color-mix(in oklab, transparent, var(--foreground) 11%);
   --state-selected: var(--accent-surface);
   --state-selected-rail: var(--primary);
   --danger-surface: color-mix(
@@ -114,7 +120,6 @@
   /* ---- motion --------------------------------------------------------- */
   --ease: cubic-bezier(0.2, 0, 0.15, 1);
   --duration-fast: 110ms;
-  --duration-base: 180ms;
 }
 
 .dark {

--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""
+Seed a Journiv development instance with realistic journal content.
+
+This exists so that UI work — the Timeline, the reader, the editor, media — can
+be exercised against content that looks like a real journal rather than lorem
+ipsum. It is idempotent: run it as often as you like.
+
+    JOURNIV_SEED_PASSWORD='choose-a-local-password' \
+      python scripts/seed_dev_data.py --api-url http://127.0.0.1:8000/api/v1
+
+Credentials are never hard-coded here. Supply the password through
+JOURNIV_SEED_PASSWORD or --password; the account is created on first run.
+
+Media is generated locally: photographs with Pillow, and a short video and
+audio clip with ffmpeg. Both are optional — the script degrades with a warning
+if either tool is unavailable, and everything else still seeds.
+
+DO NOT run this against a database holding real journal entries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+DEFAULT_API_URL = "http://127.0.0.1:8000/api/v1"
+DEFAULT_EMAIL = "dev@example.com"
+TIMEZONE = "America/Los_Angeles"
+
+
+# --------------------------------------------------------------------------
+# transport
+# --------------------------------------------------------------------------
+
+
+class Api:
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token: str | None = None
+
+    def request(self, method: str, path: str, payload: Any = None) -> Any:
+        body = None if payload is None else json.dumps(payload).encode()
+        headers = {"Content-Type": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(
+            f"{self.base_url}{path}", body, headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                if response.status == 204:
+                    return None
+                return json.load(response)
+        except urllib.error.HTTPError as error:
+            # Surface the API's own message; a bare "HTTP 400" is useless when
+            # this script is used to debug a contract change.
+            detail = error.read().decode(errors="replace")[:600]
+            error.seed_detail = detail  # type: ignore[attr-defined]
+            print(f"  ! {method} {path} -> {error.code}: {detail}", file=sys.stderr)
+            raise
+
+    def upload(self, path: str, file_path: Path, fields: dict[str, str]) -> Any:
+        """Minimal multipart/form-data upload, so there is no requests dependency."""
+        boundary = f"----journiv{uuid.uuid4().hex}"
+        parts: list[bytes] = []
+        for name, value in fields.items():
+            parts.append(
+                f"--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"\r\n\r\n{value}\r\n".encode()
+            )
+        parts.append(
+            f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{file_path.name}\"\r\n"
+            f"Content-Type: application/octet-stream\r\n\r\n".encode()
+        )
+        parts.append(file_path.read_bytes())
+        parts.append(f"\r\n--{boundary}--\r\n".encode())
+
+        headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(
+            f"{self.base_url}{path}", b"".join(parts), headers, method="POST"
+        )
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return json.load(response)
+
+    def sign_in(self, email: str, password: str) -> bool:
+        """Returns True when a new account was created."""
+        created = False
+        try:
+            self.request("POST", "/auth/login", {"email": email, "password": password})
+        except urllib.error.HTTPError as error:
+            if error.code != 401:
+                raise
+            self.request(
+                "POST",
+                "/auth/register",
+                {"email": email, "password": password, "name": "Journiv Dev"},
+            )
+            created = True
+        tokens = self.request(
+            "POST", "/auth/login", {"email": email, "password": password}
+        )
+        self.token = tokens["access_token"]
+        return created
+
+
+# --------------------------------------------------------------------------
+# generated media
+# --------------------------------------------------------------------------
+
+PALETTES = {
+    "lake": [(58, 78, 96), (128, 156, 168), (214, 196, 158), (36, 48, 62)],
+    "kyoto": [(196, 72, 54), (228, 112, 76), (120, 64, 58), (238, 196, 150)],
+    "beach": [(226, 214, 190), (146, 180, 190), (96, 132, 150), (240, 236, 224)],
+    "trail": [(84, 104, 66), (140, 158, 104), (58, 72, 50), (198, 204, 170)],
+    "city": [(58, 68, 88), (120, 138, 150), (210, 180, 150), (36, 42, 56)],
+    "tiles": [(70, 120, 150), (230, 232, 228), (180, 200, 214), (120, 160, 180)],
+}
+
+
+def make_photos(out_dir: Path) -> dict[str, Path]:
+    try:
+        from PIL import Image, ImageDraw, ImageFilter
+    except ImportError:
+        print("  ! Pillow not available — skipping photo generation", file=sys.stderr)
+        return {}
+
+    import random
+
+    photos: dict[str, Path] = {}
+    for name, colours in PALETTES.items():
+        target = out_dir / f"{name}.jpg"
+        width, height = 1600, 1067
+        # Portrait for one of them, so layout work sees a tall photograph.
+        if name == "tiles":
+            width, height = 1067, 1600
+        image = Image.new("RGB", (width, height), colours[0])
+        draw = ImageDraw.Draw(image)
+        random.seed(name)
+        for _ in range(90):
+            colour = random.choice(colours)
+            x, y = random.randint(-200, width), random.randint(-200, height)
+            draw.ellipse(
+                [x, y, x + random.randint(120, 900), y + random.randint(90, 700)],
+                fill=tuple(
+                    min(255, max(0, value + random.randint(-28, 28))) for value in colour
+                ),
+            )
+        image = image.filter(ImageFilter.GaussianBlur(38))
+        image.save(target, quality=88)
+        photos[name] = target
+    return photos
+
+
+def make_video(out_dir: Path) -> Path | None:
+    if not shutil.which("ffmpeg"):
+        print("  ! ffmpeg not available — skipping video", file=sys.stderr)
+        return None
+    target = out_dir / "sunset.mp4"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-f", "lavfi", "-i", "gradients=size=960x540:duration=4:speed=0.06",
+            "-t", "4", "-pix_fmt", "yuv420p", "-movflags", "+faststart",
+            str(target),
+        ],
+        check=True,
+    )
+    return target
+
+
+def make_audio(out_dir: Path) -> Path | None:
+    if not shutil.which("ffmpeg"):
+        return None
+    target = out_dir / "water.m4a"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-f", "lavfi", "-i", "anoisesrc=d=6:c=pink:a=0.06",
+            "-c:a", "aac", "-b:a", "96k",
+            str(target),
+        ],
+        check=True,
+    )
+    return target
+
+
+# --------------------------------------------------------------------------
+# content
+# --------------------------------------------------------------------------
+
+
+def paragraph(text: str) -> list[dict]:
+    return [{"insert": text}, {"insert": "\n"}]
+
+
+def line(text: str, **attributes: Any) -> list[dict]:
+    return [{"insert": text}, {"insert": "\n", "attributes": attributes}]
+
+
+def runs(*pieces: tuple[str, dict | None]) -> list[dict]:
+    ops: list[dict] = []
+    for text, attributes in pieces:
+        ops.append({"insert": text, **({"attributes": attributes} if attributes else {})})
+    ops.append({"insert": "\n"})
+    return ops
+
+
+def document(*groups: list[dict]) -> dict:
+    ops: list[dict] = []
+    for group in groups:
+        ops.extend(group)
+    return {"ops": ops}
+
+
+NOTE_ONLY_TEXT = (
+    "Saw a heron on the way to the store. Want to write about this properly later."
+)
+
+
+def _first_text(delta: dict) -> str:
+    for op in delta.get("ops", []):
+        insert = op.get("insert")
+        if isinstance(insert, str) and insert.strip():
+            return insert.strip()[:60]
+    return ""
+
+
+def _spec_signature(spec: dict) -> str:
+    return spec["title"] or _first_text(spec["content"])
+
+
+def _signatures(moments: list[dict]) -> set[str]:
+    """Titles plus first-paragraph prefixes, so untitled Moments dedupe too."""
+    found: set[str] = set()
+    for moment in moments:
+        entry = moment.get("entry") or {}
+        if entry.get("title"):
+            found.add(entry["title"])
+        text = (entry.get("content_plain_text") or "").strip()
+        if text:
+            found.add(text[:60])
+    return found
+
+
+def when(days_ago: int, hour: int, minute: int) -> str:
+    moment = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days_ago)
+    return moment.replace(hour=hour, minute=minute, second=0, microsecond=0).isoformat()
+
+
+JOURNALS = [
+    ("Personal", "#6366F1", "Everyday life, thinking out loud."),
+    ("Travel", "#14B8A6", "Trips, trains and long walks."),
+    ("Family", "#F43F5E", "The people who make the noise."),
+    ("Running", "#84CC16", "Training log and race notes."),
+    ("Work notes", "#64748B", "Standups, decisions, retros."),
+]
+
+PEOPLE = [("Maya", None), ("Charles", "Dad"), ("Sarah Chen", None), ("Tom Whitfield", None)]
+
+
+def moment_specs() -> list[dict]:
+    return [
+        dict(
+            days=1, hour=21, minute=40, journal="Personal", title="The long way home",
+            tags=["evening", "walking"], people=[], mood="Meh", photo="city",
+            weather="Clear 14°C", location="Bernal Heights, San Francisco",
+            lat=37.7396, lon=-122.4156, pinned=True,
+            content=document(
+                paragraph("I took the long way home tonight, up and over the hill instead of straight down Mission. There was no reason for it. The bus was right there. I just wanted the extra twenty minutes."),
+                paragraph("From the top you can see the whole grid lit up, and the fog coming in over Twin Peaks like something being poured. I sat on the bench near the radio tower until my hands got cold."),
+                line("What I keep coming back to", header=2),
+                paragraph("There is a version of this year where I did everything right and still felt like this. I am trying to make peace with that being possible."),
+                line("The city looked completely indifferent to me, and somehow that was the comforting part.", blockquote=True),
+                line("Three things I noticed", header=3),
+                line("The eucalyptus smell after rain", list="bullet"),
+                line("Someone practicing trumpet, badly, with total commitment", list="bullet"),
+                line("A dog wearing a raincoat, deeply unimpressed", list="bullet"),
+                paragraph("I got home at nine, ate cereal standing up, and felt fine. Not good exactly. Fine. I will take fine."),
+            ),
+        ),
+        dict(
+            days=2, hour=7, minute=15, journal="Running", title="Six miles, easy",
+            tags=["training", "morning"], people=[], mood=None, photo="trail",
+            weather="Fog 11°C", location="Golden Gate Park",
+            content=document(
+                paragraph("Six easy miles around the park loop. Legs felt heavy for the first two and then remembered what they were for."),
+                line("Splits", header=3),
+                *[line(f"Mile {index} — {pace}", list="ordered") for index, pace in
+                  enumerate(["9:12", "8:58", "8:41", "8:39", "8:34", "8:20"], start=1)],
+                runs(("Negative split without trying. ", None), ("That has not happened since March.", {"bold": True})),
+            ),
+        ),
+        dict(
+            days=4, hour=19, minute=5, journal="Family",
+            title="Dad on the phone for fifty minutes",
+            tags=["family", "phone"], people=["Charles"], mood="Good",
+            content=document(
+                paragraph("Dad called and talked for fifty minutes about a fence. Not his fence. The neighbour's fence. The neighbour is apparently building it four inches onto the property line and Dad has measured it twice."),
+                paragraph("Halfway through I realised I was not really listening to the fence. I was listening to him being completely absorbed in something, which he has not been in a while."),
+                runs(("He said, ", None), ("\"I am not going to say anything, I just want it on the record.\"", {"italic": True}), (" On the record with whom, Dad? Me. I am the record.", None)),
+            ),
+        ),
+        dict(
+            days=6, hour=14, minute=30, journal="Work notes", title=None,
+            tags=["retro"], people=["Sarah Chen", "Tom Whitfield"], mood=None,
+            content=document(
+                paragraph("Retro ran long again. The migration is the elephant nobody wants to name, so we spent thirty minutes on ticket hygiene instead."),
+                line("Sarah made the actual point: we are optimising the process around a decision we have not made.", blockquote=True),
+                paragraph("Writing it here so I remember to say it out loud on Thursday."),
+            ),
+        ),
+        dict(
+            days=9, hour=11, minute=0, journal="Travel", title="Kyoto, day three",
+            tags=["kyoto", "japan", "trains"], people=["Maya"], mood="Awesome",
+            photo="kyoto", weather="Rain 18°C", location="Fushimi Inari, Kyoto",
+            lat=34.9671, lon=135.7727, pinned=True,
+            content=document(
+                paragraph("Rain the whole day, which turned out to be the best thing that could have happened. We went up Fushimi Inari at seven in the morning and for the first forty minutes we had the gates almost entirely to ourselves."),
+                paragraph("Maya counted torii out loud until she lost track somewhere past two hundred, and then we just walked. The rain on the vermilion made the whole tunnel feel like it was breathing."),
+                line("Notes for next time", header=2),
+                line("Go early. Seven is not early enough. Six is early enough.", list="bullet"),
+                line("The upper shrine is worth the climb; most people turn back at the halfway viewpoint.", list="bullet"),
+                line("There is a tiny place near the base that does grilled sparrow. Maya was horrified. I was curious. We got udon.", list="bullet"),
+                paragraph("We came down at eleven soaked through and sat in a coffee place for two hours drying out, watching the tour groups arrive in waves."),
+                runs(("Best day of the trip so far and it was the one we did not plan.", {"bold": True})),
+            ),
+        ),
+        dict(
+            days=15, hour=22, minute=10, journal="Personal", title="Insomnia, again",
+            tags=["sleep"], people=[], mood="Bad",
+            content=document(
+                paragraph("Third night this week. I know the drill by now: do not look at the clock, do not do the maths on how many hours are left, do not start planning tomorrow."),
+                paragraph("I did all three."),
+            ),
+        ),
+        dict(
+            days=23, hour=9, minute=30, journal="Running",
+            title="Half marathon — 1:52:11", tags=["race", "training"],
+            people=["Sarah Chen"], mood="Awesome", photo="lake",
+            weather="Cool 9°C", location="Lake Merced", lat=37.7180, lon=-122.4939,
+            pinned=True,
+            content=document(
+                paragraph("Went out too fast, obviously. Everyone does. The first three miles felt free and the last three felt like a negotiation with someone who does not like me."),
+                line("1:52:11.", header=1),
+                paragraph("Four minutes off the target and I do not care even slightly. Two years ago I could not run the length of the block without stopping to pretend I was checking my phone."),
+                line("Sarah waited at the finish with a coffee and did not say anything about the time, which was the correct call.", blockquote=True),
+                line("What worked", header=3),
+                line("The long slow runs. Boring, unglamorous, entirely the reason.", list="bullet"),
+                line("New shoes, broken in properly instead of the week before.", list="bullet"),
+            ),
+        ),
+        dict(
+            days=38, hour=20, minute=0, journal="Personal", title="Nothing much",
+            tags=[], people=[], mood=None, weather="Clear 17°C",
+            content=document(paragraph("Quiet day. Made soup. Read forty pages. That is the whole entry and it is allowed to be.")),
+        ),
+        dict(
+            days=74, hour=18, minute=20, journal="Family",
+            title="Sunday, the whole day", tags=["family", "sunday"],
+            people=["Maya", "Charles", "Sarah Chen"], mood="Good", photo="beach",
+            weather="Warm 22°C", location="Ocean Beach", lat=37.7594, lon=-122.5107,
+            content=document(
+                paragraph("Everyone at the beach. Dad wore actual shoes onto sand and refused to acknowledge this was a mistake at any point during the four hours."),
+                paragraph("Maya spent ninety minutes building something she described as 'a house for a crab, but the crab is optional'. No crab was ever located."),
+                line("Dad, watching her rebuild the same wall for the fourth time: \"She gets that from you.\"", blockquote=True),
+            ),
+        ),
+    ]
+
+
+# --------------------------------------------------------------------------
+# seeding
+# --------------------------------------------------------------------------
+
+
+def wait_for_processing(api: Api, moment_id: str, expected: int, timeout: float = 45.0) -> None:
+    """Media processing is asynchronous; give the worker a chance to finish."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        items = api.request("GET", f"/moments/{moment_id}/media")
+        statuses = [item.get("upload_status") for item in items]
+        if len(items) >= expected and all(s in ("completed", "failed") for s in statuses):
+            return
+        time.sleep(1.0)
+    print(f"  ! media for {moment_id[:8]} still processing after {timeout:.0f}s", file=sys.stderr)
+
+
+def seed(api: Api, media_dir: Path) -> None:
+    print("Generating media…")
+    photos = make_photos(media_dir)
+    video = make_video(media_dir)
+    audio = make_audio(media_dir)
+
+    print("Journals…")
+    journals = {j["title"]: j for j in api.request("GET", "/journals/")}
+    for title, colour, description in JOURNALS:
+        if title not in journals:
+            journals[title] = api.request(
+                "POST", "/journals/",
+                {"title": title, "color": colour, "description": description},
+            )
+    print(f"  {len(journals)} journals")
+
+    print("People…")
+    people = {p["name"]: p for p in api.request("GET", "/people/")}
+    for name, nickname in PEOPLE:
+        if name not in people:
+            people[name] = api.request("POST", "/people/", {"name": name, "nickname": nickname})
+
+    moods = {m["name"]: m["id"] for m in api.request("GET", "/moods/")}
+
+    existing = api.request("GET", "/moments?limit=200&include_empty=true")["items"]
+    seen = _signatures(existing)
+
+    print("Moments…")
+    created = 0
+    for spec in moment_specs():
+        # Content-derived signature, so untitled Moments dedupe too. Timestamps
+        # are relative to "now" and therefore cannot be used as a key.
+        if _spec_signature(spec) in seen:
+            continue
+        body: dict[str, Any] = {
+            "logged_at_utc": when(spec["days"], spec["hour"], spec["minute"]),
+            "logged_timezone": TIMEZONE,
+            "is_pinned": spec.get("pinned", False),
+            "entry": {
+                "title": spec["title"],
+                "journal_id": journals[spec["journal"]]["id"],
+                "content_delta": spec["content"],
+            },
+        }
+        if spec.get("weather"):
+            body["weather_summary"] = spec["weather"]
+        if spec.get("location"):
+            body["location_json"] = {"name": spec["location"]}
+        if spec.get("lat"):
+            body["latitude"] = spec["lat"]
+            body["longitude"] = spec["lon"]
+        moment = api.request("POST", "/moments", body)
+
+        # `primary_mood_id` is rejected on create unless it is already part of
+        # the moment's mood set, but it is accepted on update.
+        if spec.get("mood") and spec["mood"] in moods:
+            api.request(
+                "PUT", f"/moments/{moment['id']}",
+                {"primary_mood_id": moods[spec["mood"]]},
+            )
+        if spec["tags"]:
+            api.request("POST", f"/moments/{moment['id']}/tags", spec["tags"])
+        if spec["people"]:
+            api.request(
+                "PUT", f"/moments/{moment['id']}/people",
+                {"person_ids": [people[name]["id"] for name in spec["people"]]},
+            )
+        if spec.get("photo") and spec["photo"] in photos:
+            api.upload(
+                "/media/upload", photos[spec["photo"]],
+                {"moment_id": moment["id"], "alt_text": spec.get("location") or spec["title"] or ""},
+            )
+            wait_for_processing(api, moment["id"], 1)
+        created += 1
+    print(f"  {created} moments created")
+
+    # --- sparse Moment scenarios from DESIGN.md §10 ----------------------
+    print("Sparse Moments…")
+    current = api.request("GET", "/moments?limit=200&include_empty=true")["items"]
+    notes = {(m.get("note") or "").strip() for m in current}
+    if NOTE_ONLY_TEXT not in notes:
+        api.request("POST", "/moments", {
+            "logged_at_utc": when(3, 15, 0), "logged_timezone": TIMEZONE,
+            "note": NOTE_ONLY_TEXT,
+        })
+        print("  note-only moment")
+
+    media_only_exists = any(
+        not m.get("entry") and not (m.get("note") or "").strip() and (m.get("media_count") or 0) > 0
+        for m in current
+    )
+    if not media_only_exists and photos:
+        moment = api.request("POST", "/moments", {
+            "logged_at_utc": when(21, 10, 30), "logged_timezone": TIMEZONE,
+            "location_json": {"name": "Ferry Building, San Francisco"},
+        })
+        for name in ("beach", "tiles"):
+            if name in photos:
+                api.upload("/media/upload", photos[name],
+                           {"moment_id": moment["id"], "alt_text": "Saturday at the water"})
+        wait_for_processing(api, moment["id"], 2)
+        print("  media-only moment")
+
+    # --- inline media -----------------------------------------------------
+    print("Inline media…")
+    if "The tiles, close up" not in _signatures(current) and photos.get("tiles"):
+        moment = api.request("POST", "/moments", {
+            "logged_at_utc": when(46, 16, 40), "logged_timezone": TIMEZONE,
+            "location_json": {"name": "Alfama, Lisbon"}, "weather_summary": "Sunny 24°C",
+            "entry": {
+                "title": "The tiles, close up",
+                "journal_id": journals["Travel"]["id"],
+                "content_delta": document(paragraph("Placeholder while the media uploads.")),
+            },
+        })
+        uploads = []
+        uploaded = api.upload("/media/upload", photos["tiles"],
+                              {"moment_id": moment["id"], "alt_text": "A tiled doorway in Alfama"})
+        uploads.append(("image", uploaded["id"]))
+        if video:
+            uploaded = api.upload("/media/upload", video,
+                                  {"moment_id": moment["id"], "alt_text": "Light moving on the tiles"})
+            uploads.append(("video", uploaded["id"]))
+        wait_for_processing(api, moment["id"], len(uploads))
+
+        ops: list[dict] = []
+        ops += paragraph("Spent the afternoon photographing doorways. Every third building has tile work that would be behind glass anywhere else, and here it is holding up a laundry line.")
+        for kind, media_id in uploads:
+            # Persisted form is a bare media id. The backend hydrates it to a
+            # signed URL on read and normalizes it back on write.
+            ops.append({"insert": {kind: media_id}})
+            ops.append({"insert": "\n"})
+        ops += runs(("This one had a ", None), ("cracked", {"italic": True}),
+                    (" corner that someone had repaired with a slightly wrong blue. I liked it more for that.", None))
+        api.request("PUT", f"/moments/{moment['id']}",
+                    {"entry_update": {"content_delta": {"ops": ops}}})
+        print(f"  inline entry with {len(uploads)} media item(s)")
+
+    if audio:
+        print("  (audio clip generated at %s for manual attachment tests)" % audio.name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--api-url", default=DEFAULT_API_URL)
+    parser.add_argument("--email", default=DEFAULT_EMAIL)
+    parser.add_argument("--password", default=os.environ.get("JOURNIV_SEED_PASSWORD"))
+    parser.add_argument("--media-dir", default=None,
+                        help="Where to write generated media (default: a temp dir)")
+    args = parser.parse_args()
+
+    if not args.password:
+        raise SystemExit(
+            "A password is required. Set JOURNIV_SEED_PASSWORD or pass --password.\n"
+            "Credentials are deliberately not stored in this file."
+        )
+
+    api = Api(args.api_url)
+    try:
+        created = api.sign_in(args.email, args.password)
+    except urllib.error.HTTPError as error:
+        raise SystemExit(
+            f"Sign-in failed with HTTP {error.code}. If the account exists with a "
+            "different password, pass --email to use a new one."
+        ) from None
+    except urllib.error.URLError as error:
+        raise SystemExit(f"Cannot reach {args.api_url}: {error.reason}") from None
+
+    print(f"Account {args.email}: {'created' if created else 'existing'}")
+
+    media_dir = Path(args.media_dir) if args.media_dir else Path(tempfile.mkdtemp(prefix="journiv-seed-"))
+    media_dir.mkdir(parents=True, exist_ok=True)
+    seed(api, media_dir)
+    print(f"\nDone. Sign in as {args.email}.")
+    print(f"Generated media kept in {media_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_phase_c_remediation.py
+++ b/scripts/seed_phase_c_remediation.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Seed the reusable Phase C browser-test account through the public API."""
+
+import argparse
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+DEFAULT_API_URL = "http://127.0.0.1:8011/api/v1"
+DEFAULT_EMAIL = "phase-c-remediation@example.com"
+DEFAULT_PASSWORD = "PhaseC-Remediation-2026!"
+
+
+def api_request(
+    api_url: str,
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    token: str | None = None,
+) -> Any:
+    body = None if payload is None else json.dumps(payload).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        f"{api_url.rstrip('/')}{path}", body, headers, method=method
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return json.load(response)
+
+
+def login(api_url: str, email: str, password: str) -> str:
+    response = api_request(
+        api_url,
+        "POST",
+        "/auth/login",
+        {"email": email, "password": password},
+    )
+    return str(response["access_token"])
+
+
+def ensure_account(api_url: str, email: str, password: str) -> tuple[str, bool]:
+    try:
+        return login(api_url, email, password), False
+    except urllib.error.HTTPError as error:
+        if error.code != 401:
+            raise
+
+    try:
+        api_request(
+            api_url,
+            "POST",
+            "/auth/register",
+            {"email": email, "password": password, "name": "Phase C Remediation"},
+        )
+    except urllib.error.HTTPError as error:
+        if error.code == 400:
+            raise SystemExit(
+                "The account already exists but the configured password was rejected. "
+                "Use the database that was originally seeded or choose another --email."
+            ) from error
+        raise
+    return login(api_url, email, password), True
+
+
+def ensure_journal(
+    api_url: str,
+    token: str,
+    journals: list[dict[str, Any]],
+    title: str,
+) -> tuple[dict[str, Any], bool]:
+    existing = next((journal for journal in journals if journal["title"] == title), None)
+    if existing:
+        return existing, False
+    journal = api_request(api_url, "POST", "/journals/", {"title": title}, token)
+    journals.append(journal)
+    return journal, True
+
+
+def fixture_entries() -> list[tuple[str, dict[str, Any]]]:
+    return [
+        (
+            "Gate 1 valid document",
+            {
+                "ops": [
+                    {"insert": "Gate 1 heading"},
+                    {"insert": "\n", "attributes": {"header": 1}},
+                    {"insert": "Editable bold text", "attributes": {"bold": True}},
+                    {"insert": "\n"},
+                    {"insert": "A quotation"},
+                    {"insert": "\n", "attributes": {"blockquote": True}},
+                ]
+            },
+        ),
+        (
+            "Unsupported image embed",
+            {
+                "ops": [
+                    {"insert": "Plain text before image.\n"},
+                    {"insert": {"image": "legacy-image-id"}},
+                    {"insert": "\n"},
+                ]
+            },
+        ),
+        (
+            "Unsupported colored text",
+            {
+                "ops": [
+                    {
+                        "insert": "Legacy colored text",
+                        "attributes": {"color": "#ff0000"},
+                    },
+                    {"insert": "\n"},
+                ]
+            },
+        ),
+    ]
+
+
+def seed(api_url: str, email: str, password: str, timezone: str) -> None:
+    token, account_created = ensure_account(api_url, email, password)
+    journals = api_request(api_url, "GET", "/journals/", token=token)
+    source, source_created = ensure_journal(
+        api_url, token, journals, "Phase C Source"
+    )
+    _, destination_created = ensure_journal(
+        api_url, token, journals, "Phase C Destination"
+    )
+
+    query = urllib.parse.urlencode({"limit": 200, "include_empty": "true"})
+    moments = api_request(api_url, "GET", f"/moments?{query}", token=token)["items"]
+    existing_titles = {
+        moment["entry"]["title"]
+        for moment in moments
+        if moment.get("entry") and moment["entry"].get("title")
+    }
+
+    created_entries: list[str] = []
+    for title, delta in fixture_entries():
+        if title in existing_titles:
+            continue
+        api_request(
+            api_url,
+            "POST",
+            "/moments",
+            {
+                "logged_timezone": timezone,
+                "entry": {
+                    "title": title,
+                    "journal_id": source["id"],
+                    "content_delta": delta,
+                },
+            },
+            token,
+        )
+        created_entries.append(title)
+
+    print(f"Account: {'created' if account_created else 'already present'}")
+    print(
+        "Journals: "
+        f"Phase C Source ({'created' if source_created else 'present'}), "
+        f"Phase C Destination ({'created' if destination_created else 'present'})"
+    )
+    print(
+        "Entries: "
+        + (", ".join(created_entries) if created_entries else "all already present")
+    )
+    print(f"Login verified for {email}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-url", default=DEFAULT_API_URL)
+    parser.add_argument("--email", default=DEFAULT_EMAIL)
+    parser.add_argument("--password", default=DEFAULT_PASSWORD)
+    parser.add_argument("--timezone", default="America/Los_Angeles")
+    args = parser.parse_args()
+    try:
+        seed(args.api_url, args.email, args.password, args.timezone)
+    except urllib.error.HTTPError as error:
+        raise SystemExit(
+            f"Journiv API request failed with HTTP {error.code}. "
+            "Check the backend terminal for details."
+        ) from None
+    except urllib.error.URLError as error:
+        raise SystemExit(
+            f"Cannot connect to the Journiv API at {args.api_url}. "
+            "Start the backend on port 8011 first, then rerun this command. "
+            f"Connection error: {error.reason}"
+        ) from None
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Describe the final Base Vega token system, typography, surfaces, interaction states, responsive pane model, Moment semantics, reader and editor behavior, media, local drafts, metadata, Journals, Settings, Library entities, Tags, personalization, accessibility, and visual review checklist.

Add the deterministic browser capture helper used to refresh desktop and mobile light and dark references as implementation evolves.

chore(dev): add comprehensive frontend seed data

Add a development seeder that creates representative Journals, Moments, Entries, metadata, media states, People, Moods, Activities, Goals, and Tags for exercising the React frontend's list, reader, editor, calendar, media, and Library surfaces.

test(dev): add Quill compatibility seed cases

Add a focused remediation seeder for the canonical Phase C Delta fixtures and editor edge cases. It creates disposable entries that make cross-runtime formatting, malformed content, empty documents, and compatibility checks reproducible during manual validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated corner-radius styling across dialogs, inputs, status views, and library elements for a more consistent appearance.
  - Improved light-mode muted text contrast for better readability.
  - Refined theme and color token behavior for more predictable visual results.

- **Personalization**
  - Removed the corner-radius setting from Appearance preferences; accent colors, fonts, text sizing, and theme import/export remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->