### PR TITLE
feat: add support for delete entry in frontend v2

### DIFF
--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -524,6 +524,27 @@ Reference: `docs/design/reference/02-reader-rich-*`, `03-reader-plain-*`,
 - Malformed stored content falls back to `content_plain_text` inside a bordered
   notice; it must never crash or render raw HTML.
 
+### Delete entry
+
+The reader `PageBar` shows one ghost trash `IconButton` immediately before Edit
+when the Moment has an Entry. It is the same direct action at every width; there
+is no compact overflow menu, Timeline-row action or swipe gesture. Confirmation
+uses the existing centred shadcn `Dialog` at every width, with a danger final
+action, a disabled pending state and an inline human error that leaves the
+dialog open.
+
+`DELETE /entries/{entry_id}` permanently removes the Entry's writing, **not the
+Moment**. Photos, moods, tags, people, location and other Moment context remain,
+so a successful delete refetches the Moment in place and the reader becomes the
+corresponding quick log. The backend prunes a Moment that has no meaningful
+context left; a 404 from that refetch returns to the same list mode, search and
+entity scope. The mutation invalidates every Moment list, Calendar, Media
+library, journal count and tag preview affected by the change.
+
+There is no Undo: the endpoint is a hard delete and the API exposes no restore
+contract. Recreating cached writing would produce a different Entry identity
+and is not presented as recovery.
+
 ### Reader media
 
 Media appears in two places, and never in both at once:

--- a/frontend/e2e/editor/drafts.spec.ts
+++ b/frontend/e2e/editor/drafts.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "../fixtures/test";
+
+test.describe("local editor drafts", () => {
+  test("an unsaved draft is recovered after an accidental reload", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const title = data.label("Recovered draft");
+    const body = data.label("Writing that survived the reload");
+
+    await page.goto(`/journals/${journal.id}/new`);
+    await page.getByLabel("Entry title").fill(title);
+    const editor = page.getByRole("textbox", { name: "Entry body" });
+    await editor.click();
+    await page.keyboard.type(body);
+
+    await expect(
+      page
+        .getByRole("status")
+        .filter({ hasText: "Saved locally · not in your journal yet" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL((url) =>
+      Boolean(url.searchParams.get("draft")),
+    );
+
+    page.once("dialog", (dialog) => void dialog.accept());
+    await page.reload();
+
+    await expect(
+      page.getByText("You have writing that was never saved", { exact: true }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Recover" }).click();
+
+    await expect(page.getByLabel("Entry title")).toHaveValue(title);
+    await expect(
+      page.getByRole("textbox", { name: "Entry body" }),
+    ).toContainText(body);
+  });
+});

--- a/frontend/e2e/editor/entry.spec.ts
+++ b/frontend/e2e/editor/entry.spec.ts
@@ -1,0 +1,357 @@
+import { freezeClock } from "../fixtures/determinism";
+import { expect, test } from "../fixtures/test";
+import { VIEWPORTS } from "../viewports";
+
+test.describe("entry journeys", () => {
+  test("writing a new entry and saving it shows it on the timeline", {
+    tag: "@smoke",
+  }, async ({ page, data }) => {
+    const journal = await data.journal();
+    const title = data.label("New entry");
+    const body = data.label("A newly saved memory");
+
+    await page.goto(`/journals/${journal.id}/new`);
+    await page.getByLabel("Entry title").fill(title);
+    const editor = page.getByRole("textbox", { name: "Entry body" });
+    await editor.click();
+    await page.keyboard.type(body);
+
+    const created = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/api/v1/moments",
+    );
+    await page.getByRole("button", { name: "Done" }).click();
+    await created;
+
+    await expect(page.getByRole("heading", { name: title })).toBeVisible();
+    await expect(
+      page.getByLabel("Entry content").getByText(body, { exact: true }),
+    ).toBeVisible();
+
+    await page.goto("/timeline");
+    const timeline = page.getByRole("region", { name: "Timeline" });
+    await expect(timeline.getByRole("link", { name: title })).toBeVisible();
+
+    await page.reload();
+    await expect(timeline.getByRole("link", { name: title })).toBeVisible();
+  });
+
+  test("editing an existing entry persists across a reload", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const moment = await data.moment({
+      journalId: journal.id,
+      title: data.label("Original entry"),
+      body: data.label("Original body"),
+    });
+    const editedTitle = data.label("Edited entry");
+    const editedBody = data.label("Edited body");
+
+    await page.goto(`/timeline/${moment.id}`);
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    await page.getByLabel("Entry title").fill(editedTitle);
+    const editor = page.getByRole("textbox", { name: "Entry body" });
+    await editor.click();
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.type(editedBody);
+
+    const updated = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        new URL(response.url()).pathname === `/api/v1/moments/${moment.id}`,
+    );
+    await page.getByRole("button", { name: "Done" }).click();
+    await updated;
+
+    await expect(
+      page.getByRole("heading", { name: editedTitle }),
+    ).toBeVisible();
+    await expect(
+      page.getByLabel("Entry content").getByText(editedBody, { exact: true }),
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(
+      page.getByRole("heading", { name: editedTitle }),
+    ).toBeVisible();
+    await expect(
+      page.getByLabel("Entry content").getByText(editedBody, { exact: true }),
+    ).toBeVisible();
+  });
+
+  test("deleting an entry removes an entry-only moment from the timeline", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const title = data.label("Deleted entry");
+    const moment = await data.moment({ journalId: journal.id, title });
+
+    await page.goto(`/timeline/${moment.id}`);
+    await page.getByRole("button", { name: "Delete entry" }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: `Delete “${title}”?` }),
+    ).toBeVisible();
+
+    const deleted = page.waitForResponse(
+      (response) =>
+        response.request().method() === "DELETE" &&
+        new URL(response.url()).pathname ===
+          `/api/v1/entries/${moment.entry?.id}`,
+    );
+    await dialog.getByRole("button", { name: "Delete entry" }).click();
+    await deleted;
+
+    await expect(page).toHaveURL((url) => url.pathname === "/timeline");
+    const timeline = page.getByRole("region", { name: "Timeline" });
+    await expect(timeline.getByRole("link", { name: title })).toHaveCount(0);
+    await page.reload();
+    await expect(timeline.getByRole("link", { name: title })).toHaveCount(0);
+  });
+
+  test("deleting writing preserves the Moment and its logged details", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const title = data.label("Entry with details");
+    const tag = data.label("kept tag");
+    const moment = await data.moment({ journalId: journal.id, title });
+    await data.tags(moment.id, [tag]);
+
+    await page.goto(`/timeline/${moment.id}`);
+    await page.getByRole("button", { name: "Delete entry" }).click();
+    const deleted = page.waitForResponse(
+      (response) =>
+        response.request().method() === "DELETE" &&
+        new URL(response.url()).pathname ===
+          `/api/v1/entries/${moment.entry?.id}`,
+    );
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Delete entry" })
+      .click();
+    await deleted;
+
+    await expect(page).toHaveURL(
+      (url) => url.pathname === `/timeline/${moment.id}`,
+    );
+    await expect(
+      page.getByRole("button", { name: "Write", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("region", { name: "Tags" }).getByText(tag),
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(
+      page.getByRole("button", { name: "Write", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("region", { name: "Tags" }).getByText(tag),
+    ).toBeVisible();
+  });
+
+  test("changing an entry date moves it to yesterday's timeline group", async ({
+    page,
+    data,
+  }) => {
+    await freezeClock(page);
+    const journal = await data.journal();
+    const title = data.label("Moved date entry");
+    const moment = await data.moment({ journalId: journal.id, title });
+
+    await page.goto(`/timeline/${moment.id}/edit`);
+    await page
+      .getByRole("button", { name: "Change entry date and time" })
+      .click();
+
+    const calendar = page.getByRole("grid");
+    const yesterday = calendar.getByRole("button").filter({ hasText: /^16$/ });
+    const changed = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        new URL(response.url()).pathname === `/api/v1/moments/${moment.id}`,
+    );
+    await yesterday.click();
+    await changed;
+
+    await page.goto("/timeline");
+    const timeline = page.getByRole("region", { name: "Timeline" });
+    await expect(
+      timeline.getByRole("heading", { name: "Yesterday" }),
+    ).toBeVisible();
+    await expect(timeline.getByRole("link", { name: title })).toBeVisible();
+  });
+
+  test("moving an entry to another journal shows it in the new journal", async ({
+    page,
+    data,
+  }) => {
+    const source = await data.journal({ title: data.label("Source journal") });
+    const destination = await data.journal({
+      title: data.label("Destination journal"),
+    });
+    const title = data.label("Moved journal entry");
+    const moment = await data.moment({ journalId: source.id, title });
+
+    await page.goto(`/timeline/${moment.id}/edit`);
+    await page
+      .getByRole("combobox", { name: "Journal", exact: true })
+      .selectOption({ label: destination.title });
+
+    const moved = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        new URL(response.url()).pathname === `/api/v1/moments/${moment.id}`,
+    );
+    await page.getByRole("button", { name: "Done" }).click();
+    await moved;
+
+    await page.goto(`/journals/${destination.id}`);
+    const destinationTimeline = page.getByRole("region", { name: "Timeline" });
+    await expect(
+      destinationTimeline.getByRole("heading", { name: destination.title }),
+    ).toBeVisible();
+    await expect(
+      destinationTimeline.getByRole("link", { name: title }),
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(
+      destinationTimeline.getByRole("link", { name: title }),
+    ).toBeVisible();
+
+    await page.goto(`/journals/${source.id}`);
+    await expect(
+      page
+        .getByRole("region", { name: "Timeline" })
+        .getByRole("link", { name: title }),
+    ).toHaveCount(0);
+  });
+
+  test("formatting round-trips through save and reload", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const title = data.label("Formatted entry");
+    const boldText = data.label("Bold memory");
+    const italicText = data.label("Italic memory");
+    const firstItem = data.label("First list item");
+    const secondItem = data.label("Second list item");
+
+    await page.goto(`/journals/${journal.id}/new`);
+    await page.getByLabel("Entry title").fill(title);
+    const editor = page.getByRole("textbox", { name: "Entry body" });
+    await editor.click();
+
+    await page.getByRole("button", { name: "Bold" }).click();
+    await page.keyboard.type(boldText);
+    await page.getByRole("button", { name: "Bold" }).click();
+    await page.keyboard.press("Enter");
+
+    await page.getByRole("button", { name: "Italic" }).click();
+    await page.keyboard.type(italicText);
+    await page.getByRole("button", { name: "Italic" }).click();
+    await page.keyboard.press("Enter");
+
+    await page.getByRole("button", { name: "Bullet list" }).click();
+    await page.keyboard.type(firstItem);
+    await page.keyboard.press("Enter");
+    await page.keyboard.type(secondItem);
+
+    await expect(
+      page
+        .getByRole("status")
+        .filter({ hasText: "Saved locally · not in your journal yet" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL((url) =>
+      Boolean(url.searchParams.get("draft")),
+    );
+    await page.getByRole("button", { name: "Done" }).click();
+    await expect(page).toHaveURL(
+      (url) =>
+        url.pathname.startsWith(`/journals/${journal.id}/`) &&
+        !url.pathname.endsWith("/new"),
+    );
+
+    const reader = page.getByLabel("Entry content");
+    await expect(reader.getByRole("strong")).toHaveText(boldText);
+    await expect(reader.getByRole("emphasis")).toHaveText(italicText);
+    const list = reader.getByRole("list");
+    await expect(
+      list.getByRole("listitem").filter({ hasText: firstItem }),
+    ).toBeVisible();
+    await expect(
+      list.getByRole("listitem").filter({ hasText: secondItem }),
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(
+      page.getByLabel("Entry content").getByRole("strong"),
+    ).toHaveText(boldText);
+    await expect(
+      page.getByLabel("Entry content").getByRole("emphasis"),
+    ).toHaveText(italicText);
+    await expect(
+      page
+        .getByLabel("Entry content")
+        .getByRole("list")
+        .getByRole("listitem")
+        .filter({ hasText: firstItem }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("mobile editor", () => {
+  test.use({ viewport: VIEWPORTS.mobile });
+
+  test("the toolbar is reachable and text entry works at mobile width", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const title = data.label("Mobile entry");
+    const body = data.label("Written on mobile");
+
+    await page.goto(`/journals/${journal.id}/new`);
+    await page.getByLabel("Entry title").fill(title);
+
+    const toolbar = page.getByRole("toolbar", { name: "Editor actions" });
+    await expect(toolbar).toBeVisible();
+    const bold = toolbar.getByRole("button", { name: "Bold" });
+    await expect(bold).toBeVisible();
+
+    const editor = page.getByRole("textbox", { name: "Entry body" });
+    await editor.click();
+    await bold.click();
+    await expect(bold).toHaveAttribute("aria-pressed", "true");
+    await page.keyboard.type(body);
+
+    await expect(editor).toContainText(body);
+    await expect(
+      page
+        .getByRole("status")
+        .filter({ hasText: "Saved locally · not in your journal yet" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL((url) =>
+      Boolean(url.searchParams.get("draft")),
+    );
+
+    await page.getByRole("button", { name: "Done" }).click();
+    await expect(page).toHaveURL(
+      (url) =>
+        url.pathname.startsWith(`/journals/${journal.id}/`) &&
+        !url.pathname.endsWith("/new"),
+    );
+    await expect(
+      page.getByLabel("Entry content").getByRole("strong"),
+    ).toHaveText(body);
+  });
+});

--- a/frontend/src/api/query/keys.ts
+++ b/frontend/src/api/query/keys.ts
@@ -107,4 +107,6 @@ export const queryKeys = {
   momentMedia: (id: string) => ["moment", id, "media"] as const,
   entry: (id: string) => ["entry", id] as const,
   allMoments: ["moments"] as const,
+  allMomentCalendars: ["moment-calendar"] as const,
+  allMediaLibraries: ["media-library"] as const,
 };

--- a/frontend/src/app/router/routes.test.tsx
+++ b/frontend/src/app/router/routes.test.tsx
@@ -1,12 +1,13 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { createMemoryHistory, RouterProvider } from "@tanstack/react-router";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createAppRouter } from ".";
 import { sessionStore } from "../../api/auth/session";
 import { api } from "../../api/client/api";
+import { ApiError } from "../../api/client/errors";
 import type {
   EntryResponse,
   InstanceConfigResponse,
@@ -27,6 +28,8 @@ vi.mock("../../api/client/api", () => ({
     momentCalendar: vi.fn(),
     mediaLibrary: vi.fn(),
     entry: vi.fn(),
+    deleteEntry: vi.fn(),
+    tags: vi.fn(),
     createMoment: vi.fn(),
     updateMoment: vi.fn(),
     login: vi.fn(),
@@ -132,6 +135,8 @@ beforeEach(() => {
   ]);
   vi.mocked(api.mediaLibrary).mockResolvedValue({ items: [] });
   vi.mocked(api.entry).mockResolvedValue(entry);
+  vi.mocked(api.deleteEntry).mockResolvedValue(undefined);
+  vi.mocked(api.tags).mockResolvedValue([]);
   vi.mocked(api.createMoment).mockResolvedValue({
     ...moment,
     id: "moment-new",
@@ -189,6 +194,91 @@ describe("Phase B routes", () => {
       expect(view.router.state.location.pathname).toBe("/timeline");
       expect(view.router.state.location.search.q).toBe("rain");
     });
+  });
+
+  it("cancels entry deletion, then returns to the same scoped list when the Moment is pruned", async () => {
+    vi.mocked(api.moment)
+      .mockResolvedValueOnce(moment)
+      .mockRejectedValueOnce(new ApiError("Moment not found", { status: 404 }));
+    const view = await renderRoute("/timeline/moment-1?q=rain&tag=tag-1");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Delete entry" }),
+    );
+    let dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByRole("heading", {
+        name: "Delete “A rainy morning”?",
+      }),
+    ).toBeTruthy();
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Cancel" }),
+    );
+    expect(api.deleteEntry).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Delete entry" }),
+    );
+    dialog = screen.getByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete entry" }),
+    );
+
+    await waitFor(() =>
+      expect(api.deleteEntry).toHaveBeenCalledWith("entry-1"),
+    );
+    await waitFor(() => {
+      expect(view.router.state.location.pathname).toBe("/timeline");
+      expect(view.router.state.location.search.q).toBe("rain");
+      expect(view.router.state.location.search.tag).toBe("tag-1");
+    });
+  });
+
+  it("keeps a surviving Moment open as a quick log after deleting its writing", async () => {
+    const quickLog: MomentResponse = {
+      ...moment,
+      entry: null,
+      is_pinned: true,
+    };
+    vi.mocked(api.moment)
+      .mockResolvedValueOnce(moment)
+      .mockResolvedValueOnce(quickLog);
+    const view = await renderRoute("/timeline/moment-1?q=rain");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Delete entry" }),
+    );
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Delete entry",
+      }),
+    );
+
+    expect(await screen.findByRole("button", { name: "Write" })).toBeTruthy();
+    expect(view.router.state.location.pathname).toBe("/timeline/moment-1");
+    expect(screen.queryByRole("button", { name: "Delete entry" })).toBeNull();
+    expect(api.moment).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the confirmation open and shows a human error when deletion fails", async () => {
+    vi.mocked(api.deleteEntry).mockRejectedValueOnce(new Error("offline"));
+    const view = await renderRoute("/timeline/moment-1");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Delete entry" }),
+    );
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete entry" }),
+    );
+
+    expect(
+      await within(dialog).findByText(
+        "The entry couldn’t be deleted. Check your connection and try again.",
+      ),
+    ).toBeTruthy();
+    expect(view.router.state.location.pathname).toBe("/timeline/moment-1");
+    expect(screen.getByRole("dialog")).toBeTruthy();
   });
 
   it("debounces search into the URL and query policy", async () => {

--- a/frontend/src/features/reader/DeleteEntryDialog.tsx
+++ b/frontend/src/features/reader/DeleteEntryDialog.tsx
@@ -1,0 +1,82 @@
+import { Trash2, TriangleAlert } from "lucide-react";
+import { useState } from "react";
+import { Alert, AlertDescription } from "../../components/ui/alert";
+import { Button } from "../../components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../../components/ui/dialog";
+import { IconButton } from "../../components/ui/icon-button";
+import { Spinner } from "../../components/ui/spinner";
+
+export function DeleteEntryDialog({
+  entryTitle,
+  deleting,
+  failed,
+  onConfirm,
+  onReset,
+}: {
+  entryTitle?: string | null;
+  deleting: boolean;
+  failed: boolean;
+  onConfirm: () => void;
+  onReset: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (deleting) return;
+        if (nextOpen) onReset();
+        setOpen(nextOpen);
+      }}
+    >
+      <DialogTrigger render={<IconButton label="Delete entry" />}>
+        <Trash2 aria-hidden="true" />
+      </DialogTrigger>
+      <DialogContent showCloseButton={!deleting}>
+        <DialogHeader>
+          <DialogTitle>
+            {entryTitle ? `Delete “${entryTitle}”?` : "Delete entry?"}
+          </DialogTitle>
+          <DialogDescription>
+            The writing in this entry will be permanently removed. Photos,
+            moods, tags, people and other logged details will stay with this
+            moment. If no other details remain, the moment will be removed from
+            the Timeline. This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        {failed && (
+          <Alert variant="destructive">
+            <TriangleAlert aria-hidden="true" />
+            <AlertDescription>
+              The entry couldn’t be deleted. Check your connection and try
+              again.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter>
+          <DialogClose render={<Button variant="ghost" disabled={deleting} />}>
+            Cancel
+          </DialogClose>
+          <Button variant="danger" disabled={deleting} onClick={onConfirm}>
+            {deleting && (
+              <Spinner data-icon="inline-start" aria-hidden="true" />
+            )}
+            {deleting ? "Deleting…" : "Delete entry"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/reader/ReaderPage.tsx
+++ b/frontend/src/features/reader/ReaderPage.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import {
   ArrowLeft,
@@ -7,7 +7,9 @@ import {
   Pencil,
   TriangleAlert,
 } from "lucide-react";
+import { api } from "../../api/client/api";
 import { entryQuery, momentQuery } from "../../api/query/options";
+import { queryKeys } from "../../api/query/keys";
 import { EntryHeader } from "../../components/journiv/EntryHeader";
 import { JournalBadge } from "../../components/journiv/JournalBadge";
 import { MomentChips } from "../../components/journiv/MomentChips";
@@ -20,6 +22,8 @@ import { useJournalLookup } from "../../lib/useJournalLookup";
 import { momentKind, momentKindLabel, momentTitle } from "../../lib/moment";
 import { EMPTY_DELTA } from "../editor/deltaProfile";
 import { planReaderContent, QuillReader } from "../editor/QuillReader";
+import { scopeSearchFrom } from "../timeline/momentScope";
+import { DeleteEntryDialog } from "./DeleteEntryDialog";
 import { EntryMedia } from "./EntryMedia";
 import { useMomentMedia } from "./useMomentMedia";
 import "./reader.css";
@@ -29,21 +33,27 @@ export function ReaderPage() {
     momentId: string;
     journalId?: string;
   };
-  const {
-    q = "",
-    view,
-    month,
-    date,
-  } = useSearch({ strict: false }) as {
+  const search = useSearch({ strict: false }) as {
     q?: string;
     view?: "calendar" | "media";
     month?: string;
     date?: string;
+    person?: string;
+    tag?: string;
+    activity?: string;
+    mood?: string;
+    goal?: string;
   };
+  const { q = "", view, month, date } = search;
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   // Carry the list-pane mode back so Back returns to the calendar or grid the
   // reader was opened from, not the plain list.
-  const listSearch = { q, ...(view ? { view, month, date } : {}) };
+  const listSearch = {
+    q,
+    ...(view ? { view, month, date } : {}),
+    ...scopeSearchFrom(search),
+  };
   const journals = useJournalLookup();
   const moment = useQuery(momentQuery(momentId));
   const entry = useQuery({
@@ -80,6 +90,43 @@ export function ReaderPage() {
       });
     }
   };
+  const remove = useMutation({
+    mutationFn: async (entryId: string) => {
+      await api.deleteEntry(entryId);
+
+      queryClient.removeQueries({ queryKey: queryKeys.entry(entryId) });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.allMoments }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.allMomentCalendars,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.allMediaLibraries,
+        }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.journals }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.tags }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.moment(momentId),
+          refetchType: "none",
+        }),
+      ]);
+
+      try {
+        await queryClient.fetchQuery({
+          ...momentQuery(momentId),
+          retry: false,
+          staleTime: 0,
+        });
+        return true;
+      } catch {
+        queryClient.removeQueries({ queryKey: queryKeys.moment(momentId) });
+        return false;
+      }
+    },
+    onSuccess: (momentSurvived) => {
+      if (!momentSurvived) goBack();
+    },
+  });
 
   if (moment.isLoading) return <ReaderSkeleton />;
   if (moment.isError || !moment.data) {
@@ -107,6 +154,7 @@ export function ReaderPage() {
   }
 
   const data = moment.data;
+  const entryId = data.entry?.id;
   const kind = momentKind(data);
   const title = momentTitle(data);
   const journal = journals.get(data.entry?.journal_id ?? journalId);
@@ -127,19 +175,33 @@ export function ReaderPage() {
         }
         title={<JournalBadge journal={journal} />}
         actions={
-          <Button variant={hasWriting ? "secondary" : "primary"} onClick={edit}>
-            {hasWriting ? (
-              <>
-                <Pencil aria-hidden="true" size={15} />
-                Edit
-              </>
-            ) : (
-              <>
-                <NotebookPen aria-hidden="true" size={15} />
-                Write
-              </>
+          <>
+            {entryId && (
+              <DeleteEntryDialog
+                entryTitle={title}
+                deleting={remove.isPending}
+                failed={remove.isError}
+                onConfirm={() => remove.mutate(entryId)}
+                onReset={remove.reset}
+              />
             )}
-          </Button>
+            <Button
+              variant={hasWriting ? "secondary" : "primary"}
+              onClick={edit}
+            >
+              {hasWriting ? (
+                <>
+                  <Pencil aria-hidden="true" size={15} />
+                  Edit
+                </>
+              ) : (
+                <>
+                  <NotebookPen aria-hidden="true" size={15} />
+                  Write
+                </>
+              )}
+            </Button>
+          </>
         }
       />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to permanently delete writing directly from the reader.
  - Confirmation is required, with a clear destructive action and progress state.
  - If other Moment details remain, they are preserved as a quick log; otherwise, the Moment is removed.
- **Bug Fixes**
  - Updated lists, calendars, media, journal counts, and tag previews after deletion.
  - Preserved search, filters, and entity scope when returning to the list.
  - Deletion errors now remain visible in the confirmation dialog for retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->