### PR TITLE
chore(tests): add more e2e tests for timeline, search, setting, tags etc

### DIFF
--- a/frontend/e2e/library/entities.spec.ts
+++ b/frontend/e2e/library/entities.spec.ts
@@ -1,0 +1,135 @@
+import { toggleGoalCompletionApiV1GoalsGoalIdTogglePost } from "@/api/generated";
+import { expect, test } from "../fixtures/test";
+
+test.describe("library entity journeys", () => {
+  test("recording a starter mood on a moment shows it in the reader", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const moment = await data.moment({
+      journalId: journal.id,
+      title: data.label("Mood entry"),
+    });
+
+    await page.goto(`/timeline/${moment.id}/edit`);
+    await page.getByRole("button", { name: "Moment details" }).click();
+
+    const saved = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        new URL(response.url()).pathname === `/api/v1/moments/${moment.id}`,
+    );
+    await page.getByRole("button", { name: "Good", exact: true }).click();
+    await saved;
+
+    await page.goto(`/timeline/${moment.id}`);
+    const reader = page.getByRole("article");
+    await expect(reader.getByText("Good", { exact: true })).toBeVisible();
+
+    await page.reload();
+    await expect(reader.getByText("Good", { exact: true })).toBeVisible();
+  });
+
+  test("creating a person and attaching them to a moment shows them in the reader", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const moment = await data.moment({
+      journalId: journal.id,
+      title: data.label("People entry"),
+    });
+    const person = data.label("River Song");
+
+    await page.goto("/settings/journaling/people");
+    const people = page.getByRole("main", { name: "People" });
+    await people.getByRole("button", { name: "Add person" }).first().click();
+
+    const dialog = page.getByRole("dialog", { name: "Add person" });
+    await dialog.getByLabel("Name", { exact: true }).fill(person);
+    await dialog.getByRole("button", { name: "Add person" }).click();
+
+    await expect(people.getByText(person, { exact: true })).toBeVisible();
+    await page.reload();
+    await expect(people.getByText(person, { exact: true })).toBeVisible();
+
+    await page.goto(`/timeline/${moment.id}/edit`);
+    await page.getByRole("button", { name: "Moment details" }).click();
+
+    const attached = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        new URL(response.url()).pathname ===
+          `/api/v1/moments/${moment.id}/people`,
+    );
+    await page.getByRole("checkbox", { name: person, exact: true }).click();
+    await attached;
+
+    await page.goto(`/timeline/${moment.id}`);
+    const readerPeople = page.getByRole("region", { name: "People" });
+    await expect(
+      readerPeople.getByRole("link", { name: person, exact: true }),
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(
+      readerPeople.getByRole("link", { name: person, exact: true }),
+    ).toBeVisible();
+  });
+
+  test("creating a goal shows it in the list and completion updates its progress", async ({
+    page,
+    data,
+    api,
+  }) => {
+    const title = data.label("Monthly reflection goal");
+
+    await page.goto("/settings/journaling/goals");
+    const goals = page.getByRole("main", { name: "Goals" });
+    await goals.getByRole("button", { name: "Add goal" }).first().click();
+
+    const dialog = page.getByRole("dialog", { name: "Add goal" });
+    await dialog.getByLabel("Goal title").fill(title);
+    await dialog.getByLabel("Frequency").selectOption("monthly");
+
+    const createdResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/api/v1/goals",
+    );
+    await dialog.getByRole("button", { name: "Add goal" }).click();
+    const created = (await (await createdResponse).json()) as { id?: string };
+    if (!created.id) throw new Error("POST /api/v1/goals returned no goal id");
+
+    const search = goals.getByLabel("Search goals");
+    await search.fill(title);
+    await expect(goals.getByText(title, { exact: true })).toBeVisible();
+    await expect(
+      goals.getByText("Monthly · Achieve · 0/1 this period", { exact: true }),
+    ).toBeVisible();
+
+    await page.reload();
+    await goals.getByLabel("Search goals").fill(title);
+    await expect(goals.getByText(title, { exact: true })).toBeVisible();
+
+    const toggled = await toggleGoalCompletionApiV1GoalsGoalIdTogglePost({
+      client: api,
+      path: { goal_id: created.id },
+      body: {
+        logged_date: new Date().toISOString().slice(0, 10),
+        status: "success",
+      },
+    });
+    if (toggled.error !== undefined)
+      throw new Error(
+        `POST /api/v1/goals/${created.id}/toggle returned HTTP ${toggled.response?.status ?? "unknown"}`,
+      );
+
+    await page.reload();
+    await goals.getByLabel("Search goals").fill(title);
+    await expect(
+      goals.getByText("Monthly · Achieve · 1/1 this period", { exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/library/tags.spec.ts
+++ b/frontend/e2e/library/tags.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "../fixtures/test";
+
+test.describe("tag journeys", () => {
+  test("creating a tag and attaching it to a moment shows it in the reader", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const moment = await data.moment({
+      journalId: journal.id,
+      title: data.label("Tagged entry"),
+    });
+    const tag = data.label("created tag").toLowerCase();
+
+    await page.goto("/library/tags");
+    const tags = page.getByRole("main", { name: "Tags" });
+    await tags.getByRole("button", { name: "New tag" }).first().click();
+
+    const dialog = page.getByRole("dialog", { name: "New tag" });
+    await dialog.getByLabel("Tag name").fill(tag);
+    await dialog.getByRole("button", { name: "Add tag" }).click();
+
+    await expect(tags.getByText(tag, { exact: true })).toBeVisible();
+
+    await data.tags(moment.id, [tag]);
+    await page.goto(`/timeline/${moment.id}`);
+
+    const readerTags = page.getByRole("region", { name: "Tags" });
+    await expect(readerTags.getByRole("link", { name: tag })).toBeVisible();
+
+    await page.reload();
+    await expect(readerTags.getByRole("link", { name: tag })).toBeVisible();
+  });
+
+  test("renaming a tag updates the library and the moment carrying it", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const moment = await data.moment({
+      journalId: journal.id,
+      title: data.label("Renamed tag entry"),
+    });
+    const original = data.label("original tag").toLowerCase();
+    const renamed = data.label("renamed tag").toLowerCase();
+    await data.tags(moment.id, [original]);
+
+    await page.goto("/library/tags");
+    const tags = page.getByRole("main", { name: "Tags" });
+    await tags.getByRole("link").filter({ hasText: original }).first().click();
+
+    await page.getByRole("button", { name: "Rename" }).click();
+    const dialog = page.getByRole("dialog", {
+      name: `Rename #${original}`,
+    });
+    await dialog.getByLabel("Tag name").fill(renamed);
+    await dialog.getByRole("button", { name: "Save" }).click();
+
+    const detail = page.getByRole("main", { name: "Tags" });
+    await expect(
+      detail.getByText(`#${renamed}`, { exact: true }),
+    ).toBeVisible();
+
+    await detail.getByRole("link", { name: "Tags", exact: true }).click();
+    await expect(tags.getByText(renamed, { exact: true })).toBeVisible();
+    await expect(tags.getByText(original, { exact: true })).toHaveCount(0);
+
+    await page.goto(`/timeline/${moment.id}`);
+    const readerTags = page.getByRole("region", { name: "Tags" });
+    await expect(readerTags.getByRole("link", { name: renamed })).toBeVisible();
+    await expect(readerTags.getByRole("link", { name: original })).toHaveCount(
+      0,
+    );
+
+    await page.reload();
+    await expect(readerTags.getByRole("link", { name: renamed })).toBeVisible();
+  });
+
+  test("a tag detail page lists the moments carrying it", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const firstTitle = data.label("First tagged entry");
+    const secondTitle = data.label("Second tagged entry");
+    const first = await data.moment({
+      journalId: journal.id,
+      title: firstTitle,
+    });
+    const second = await data.moment({
+      journalId: journal.id,
+      title: secondTitle,
+    });
+    const tag = data.label("shared tag").toLowerCase();
+    await data.tags(first.id, [tag]);
+    await data.tags(second.id, [tag]);
+
+    await page.goto("/library/tags");
+    await page
+      .getByRole("main", { name: "Tags" })
+      .getByRole("link")
+      .filter({ hasText: tag })
+      .first()
+      .click();
+
+    const recent = page.getByRole("region", { name: "Recent moments" });
+    await expect(
+      recent.getByRole("link").filter({ hasText: firstTitle }),
+    ).toBeVisible();
+    await expect(
+      recent.getByRole("link").filter({ hasText: secondTitle }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/settings/settings.spec.ts
+++ b/frontend/e2e/settings/settings.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "../fixtures/test";
+
+test.describe("settings", () => {
+  test("settings opens as an overlay over the workspace and closes back to it", async ({
+    page,
+  }) => {
+    await page.goto("/timeline");
+
+    const timeline = page.getByRole("region", { name: "Timeline" });
+    await expect(timeline).toBeVisible();
+
+    await page.getByRole("button", { name: "Settings" }).click();
+
+    await expect(page).toHaveURL((url) => url.pathname === "/settings/profile");
+    await expect(page.getByRole("dialog", { name: "Settings" })).toBeVisible();
+    await expect(timeline).toBeVisible();
+
+    await page.getByRole("button", { name: "Close settings" }).click();
+
+    await expect(page).toHaveURL((url) => url.pathname === "/timeline");
+    await expect(page.getByRole("dialog", { name: "Settings" })).toHaveCount(0);
+    await expect(timeline).toBeVisible();
+  });
+
+  test("changing the display name persists across a reload", async ({
+    page,
+    data,
+  }) => {
+    const displayName = data.label("Updated display name");
+
+    await page.goto("/settings/profile");
+    const name = page.getByLabel("Display name");
+    await name.fill(displayName);
+    const saved = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        new URL(response.url()).pathname === "/api/v1/users/me",
+    );
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await saved;
+
+    await expect(name).toHaveValue(displayName);
+
+    await page.reload();
+
+    await expect(page.getByLabel("Display name")).toHaveValue(displayName);
+  });
+
+  test("switching the theme to dark applies it and survives a reload", async ({
+    page,
+  }) => {
+    await page.goto("/timeline");
+
+    const darkTheme = page.getByRole("button", { name: "Dark theme" });
+    await darkTheme.click();
+
+    await expect(darkTheme).toHaveAttribute("aria-pressed", "true");
+
+    await page.reload();
+
+    await expect(
+      page.getByRole("button", { name: "Dark theme" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("changing the password rejects the old password and restores the worker credential", async ({
+    page,
+    journivUser,
+  }) => {
+    const changedPassword = "E2e-Changed-Password-1";
+    let passwordChanged = false;
+    const changePassword = async (
+      currentPassword: string,
+      newPassword: string,
+    ) => {
+      await page.getByLabel("Current password").fill(currentPassword);
+      await page.getByLabel("New password", { exact: true }).fill(newPassword);
+      await page.getByLabel("Confirm new password").fill(newPassword);
+      await page.getByRole("button", { name: "Change password" }).click();
+      await expect(
+        page.getByText("Your password has been changed."),
+      ).toBeVisible();
+    };
+
+    try {
+      await page.goto("/settings/security");
+      await changePassword(journivUser.password, changedPassword);
+      passwordChanged = true;
+
+      await page.goto("/login");
+      await page.getByLabel("Email").fill(journivUser.email);
+      await page.getByLabel("Password").fill(journivUser.password);
+      await page.getByRole("button", { name: "Sign in" }).click();
+
+      await expect(page.getByRole("alert")).toHaveText(
+        "Sign in failed. Check your email and password.",
+      );
+
+      await page.getByLabel("Password").fill(changedPassword);
+      await page.getByRole("button", { name: "Sign in" }).click();
+      await expect(page).toHaveURL((url) => url.pathname === "/timeline");
+
+      await page.goto("/settings/security");
+      await changePassword(changedPassword, journivUser.password);
+      passwordChanged = false;
+    } finally {
+      if (passwordChanged) {
+        await page.goto("/login");
+        await page.getByLabel("Email").fill(journivUser.email);
+        await page.getByLabel("Password").fill(changedPassword);
+        await page.getByRole("button", { name: "Sign in" }).click();
+        await expect(page).toHaveURL((url) => url.pathname === "/timeline");
+
+        await page.goto("/settings/security");
+        await changePassword(changedPassword, journivUser.password);
+      }
+    }
+  });
+});

--- a/frontend/e2e/timeline/search.spec.ts
+++ b/frontend/e2e/timeline/search.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "../fixtures/test";
+
+test.describe("timeline search", () => {
+  test("searching narrows the timeline to matching entries", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const matchingTitle = data.label("Orchid sunrise");
+    const otherTitle = data.label("Harbor fog");
+    await data.moment({ journalId: journal.id, title: matchingTitle });
+    await data.moment({ journalId: journal.id, title: otherTitle });
+
+    await page.goto("/timeline");
+    const timeline = page.getByRole("region", { name: "Timeline" });
+    await expect(
+      timeline.getByRole("link", { name: matchingTitle }),
+    ).toBeVisible();
+    await expect(
+      timeline.getByRole("link", { name: otherTitle }),
+    ).toBeVisible();
+
+    await timeline.getByLabel("Search all moments").fill("Orchid");
+    await expect(page).toHaveURL(
+      (url) =>
+        url.pathname === "/timeline" && url.searchParams.get("q") === "Orchid",
+    );
+    await expect(
+      timeline.getByRole("link", { name: matchingTitle }),
+    ).toBeVisible();
+    await expect(timeline.getByRole("link", { name: otherTitle })).toHaveCount(
+      0,
+    );
+  });
+
+  test("an unmatched query shows the search empty state and clearing restores entries", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const firstTitle = data.label("Amber trail");
+    const secondTitle = data.label("Cobalt lake");
+    await data.moment({ journalId: journal.id, title: firstTitle });
+    await data.moment({ journalId: journal.id, title: secondTitle });
+
+    await page.goto("/timeline");
+    const timeline = page.getByRole("region", { name: "Timeline" });
+    const search = timeline.getByLabel("Search all moments");
+    const query = "violet-no-such-memory";
+    await search.fill(query);
+
+    await expect(page).toHaveURL(
+      (url) =>
+        url.pathname === "/timeline" && url.searchParams.get("q") === query,
+    );
+    await expect(
+      timeline.getByText(`No moments match “${query}”`, { exact: true }),
+    ).toBeVisible();
+
+    await search.fill("");
+    await expect(page).toHaveURL(
+      (url) =>
+        url.pathname === "/timeline" &&
+        (url.searchParams.get("q") ?? "") === "",
+    );
+    await expect(
+      timeline.getByRole("link", { name: firstTitle }),
+    ).toBeVisible();
+    await expect(
+      timeline.getByRole("link", { name: secondTitle }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/timeline/timeline.spec.ts
+++ b/frontend/e2e/timeline/timeline.spec.ts
@@ -1,0 +1,131 @@
+import { freezeClock } from "../fixtures/determinism";
+import { expect, test } from "../fixtures/test";
+
+// `fullyParallel` workers can be reused for later test groups, along with their
+// account and its moments. A distinct worker-fixture pool gives TL-003 a fresh
+// worker while still using the one shared Journiv authentication mechanism.
+const freshAccountTest = test.extend<object, { freshAccountWorker: true }>({
+  freshAccountWorker: [
+    // Playwright requires a destructuring pattern for a fixture with no deps.
+    // biome-ignore lint/correctness/noEmptyPattern: required by Playwright's fixture API
+    async ({}, use) => {
+      await use(true);
+    },
+    { scope: "worker", auto: true },
+  ],
+});
+
+test.describe("timeline journeys", () => {
+  test("created moments appear under their logged day", async ({
+    page,
+    data,
+  }) => {
+    await freezeClock(page);
+    const journal = await data.journal();
+    const firstTitle = data.label("Morning entry");
+    const secondTitle = data.label("Evening entry");
+    await data.moment({ journalId: journal.id, title: firstTitle });
+    await data.moment({ journalId: journal.id, title: secondTitle });
+
+    await page.goto("/timeline");
+
+    const timeline = page.getByRole("region", { name: "Timeline" });
+    await expect(
+      timeline.getByRole("heading", { name: "Today", exact: true }),
+    ).toBeVisible();
+    await expect(
+      timeline.getByRole("link", { name: firstTitle }),
+    ).toBeVisible();
+    await expect(
+      timeline.getByRole("link", { name: secondTitle }),
+    ).toBeVisible();
+  });
+
+  test("selecting a moment opens it in the reader pane", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal();
+    const title = data.label("Reader entry");
+    const moment = await data.moment({ journalId: journal.id, title });
+
+    await page.goto("/timeline");
+    await page
+      .getByRole("region", { name: "Timeline" })
+      .getByRole("link", { name: title })
+      .click();
+
+    await expect(page).toHaveURL(
+      (url) => url.pathname === `/timeline/${moment.id}`,
+    );
+    await expect(
+      page
+        .getByRole("region", { name: "Moment detail" })
+        .getByRole("heading", { name: title }),
+    ).toBeVisible();
+  });
+
+  test("filtering by journal shows only that journal's moments", async ({
+    page,
+    data,
+  }) => {
+    const selectedJournal = await data.journal({
+      title: data.label("Selected journal"),
+    });
+    const otherJournal = await data.journal({
+      title: data.label("Other journal"),
+    });
+    const selectedTitle = data.label("Selected journal entry");
+    const otherTitle = data.label("Other journal entry");
+    await data.moment({
+      journalId: selectedJournal.id,
+      title: selectedTitle,
+    });
+    await data.moment({ journalId: otherJournal.id, title: otherTitle });
+
+    await page.goto("/timeline");
+    await page
+      .getByRole("navigation", { name: "Journals" })
+      .getByRole("link", { name: selectedJournal.title, exact: true })
+      .click();
+
+    await expect(page).toHaveURL(
+      (url) => url.pathname === `/journals/${selectedJournal.id}`,
+    );
+    const timeline = page.getByRole("region", { name: "Timeline" });
+    await expect(
+      timeline.getByRole("heading", {
+        name: selectedJournal.title,
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      timeline.getByRole("link", { name: selectedTitle }),
+    ).toBeVisible();
+    await expect(timeline.getByRole("link", { name: otherTitle })).toHaveCount(
+      0,
+    );
+  });
+});
+
+freshAccountTest.describe("timeline journeys", () => {
+  freshAccountTest(
+    "a new account shows the empty timeline state",
+    async ({ page }) => {
+      await page.goto("/timeline");
+
+      const timeline = page.getByRole("region", { name: "Timeline" });
+      await expect(
+        timeline.getByText("No moments yet", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        timeline.getByText("Your timeline will fill up as you write.", {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        timeline.getByRole("button", { name: "Write your first entry" }),
+      ).toBeVisible();
+    },
+  );
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for timeline creation, filtering, search, and empty states.
  * Added coverage for library entities, including moods, people, goals, and tags.
  * Added settings journey tests for overlays, display names, themes, and password changes.
  * Verified data persistence and UI updates across page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->