### PR TITLE
feat: add account deletion in ui v2

### DIFF
--- a/frontend/docs/features/settings.md
+++ b/frontend/docs/features/settings.md
@@ -39,7 +39,11 @@ confirmation only for actual confirmation.
 - Profile uses current-user and user-settings queries for display name and
   timezone; email and avatar remain read-only until API support exists.
 - Security is capability-aware: local accounts can change password, OIDC users
-  see provider guidance. Account deletion is not designed or stubbed.
+  see provider guidance. Every account type can permanently delete itself via
+  `DELETE /users/me`; deletion requires the exact typed `DELETE` confirmation,
+  clears the local session only after a success response, then returns to login.
+  An uncertain request stays open with an honest retry/sign-in message because
+  a failed response is not proof that deletion did not complete.
 - Appearance writes account theme defaults, time format, and first day together.
   It does not silently replace the existing per-device sidebar theme override.
 - Integrations is catalogue then detail, both routed. The frontend registry
@@ -59,6 +63,5 @@ confirmation only for actual confirmation.
   icons have no backend contract.
 - Admin user pagination exposes neither a total nor continuation token, so the
   complete collection is fetched before local search/paging.
-- Version administration, license registration/reset, and account deletion
-  remain intentionally undesigned; do not render dead links.
-
+- Version administration and license registration/reset remain intentionally
+  undesigned; do not render dead links.

--- a/frontend/src/api/client/api.ts
+++ b/frontend/src/api/client/api.ts
@@ -19,6 +19,7 @@ import {
   createUserApiV1AdminUsersPost,
   deleteActivityApiV1ActivitiesActivityIdDelete,
   deleteActivityGroupApiV1ActivityGroupsGroupIdDelete,
+  deleteCurrentUserApiV1UsersMeDelete,
   deleteEntryApiV1EntriesEntryIdDelete,
   deleteGoalCategoryApiV1GoalCategoriesCategoryIdDelete,
   deleteGoalPermanentlyApiV1GoalsGoalIdDelete,
@@ -180,6 +181,8 @@ export const api = {
       }),
     ),
   me: () => data(getCurrentUserInfoApiV1UsersMeGet(options())),
+  /** Permanently deletes the signed-in account and all data it owns. */
+  deleteMe: () => data(deleteCurrentUserApiV1UsersMeDelete(options())),
   /**
    * Updates the signed-in user. `name` and `profile_picture_url` are profile
    * edits; `current_password` + `new_password` together are a password change

--- a/frontend/src/features/settings/security/AccountDeletionSection.tsx
+++ b/frontend/src/features/settings/security/AccountDeletionSection.tsx
@@ -1,0 +1,130 @@
+import { useId, useState } from "react";
+import { sessionStore } from "../../../api/auth/session";
+import { api } from "../../../api/client/api";
+import {
+  AppAdaptiveDialog,
+  useOverlayAutoFocus,
+} from "../../../components/journiv/AppAdaptiveDialog";
+import { Alert, AlertDescription } from "../../../components/ui/alert";
+import { Button } from "../../../components/ui/button";
+import { Field, FieldLabel } from "../../../components/ui/field";
+import { Input } from "../../../components/ui/input";
+import { Spinner } from "../../../components/ui/spinner";
+import { SettingsSection } from "../SettingsSection";
+
+const DELETE_CONFIRMATION = "DELETE";
+
+/**
+ * Account deletion is deliberately a typed, adaptive dialog rather than a
+ * yes/no confirmation. The server has no recovery window, so the client only
+ * clears its session after receiving a successful deletion response.
+ */
+export function AccountDeletionSection() {
+  const inputId = useId();
+  const shouldAutoFocus = useOverlayAutoFocus();
+  const [open, setOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [failure, setFailure] = useState<string>();
+  const matches = confirmation === DELETE_CONFIRMATION;
+
+  function close(nextOpen: boolean) {
+    if (!nextOpen) {
+      setConfirmation("");
+      setFailure(undefined);
+    }
+    setOpen(nextOpen);
+  }
+
+  async function deleteAccount() {
+    if (!matches || deleting) return;
+    setDeleting(true);
+    setFailure(undefined);
+    try {
+      await api.deleteMe();
+      sessionStore.clear();
+      window.location.assign("/login");
+    } catch {
+      // A failed response is not proof the account survived; the backend may
+      // have completed deletion before an infrastructure failure was reported.
+      setFailure(
+        "We couldn’t confirm that your account was deleted. Try signing in again before retrying.",
+      );
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <SettingsSection
+        title="Delete account"
+        intro="Permanently remove your account and everything stored in Journiv."
+        footer={
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => setOpen(true)}
+          >
+            Delete account
+          </Button>
+        }
+      >
+        <p className="jv-body text-muted-foreground">
+          This deletes your journals, entries, media, tags, moods, prompts, and
+          settings. This action cannot be undone.
+        </p>
+      </SettingsSection>
+
+      <AppAdaptiveDialog
+        open={open}
+        onOpenChange={close}
+        title="Delete your account?"
+        description="This permanently deletes your Journiv account and everything stored in it. This action cannot be undone."
+        size="md"
+        dismissible={!deleting}
+        footer={
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={deleting}
+              onClick={() => close(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={!matches || deleting}
+              onClick={() => void deleteAccount()}
+            >
+              {deleting && (
+                <Spinner data-icon="inline-start" aria-hidden="true" />
+              )}
+              {deleting ? "Deleting…" : "Delete account"}
+            </Button>
+          </>
+        }
+      >
+        <Field>
+          <FieldLabel htmlFor={inputId}>
+            Type <strong>{DELETE_CONFIRMATION}</strong> to confirm
+          </FieldLabel>
+          <Input
+            id={inputId}
+            value={confirmation}
+            autoComplete="off"
+            autoFocus={shouldAutoFocus}
+            onChange={(event) => setConfirmation(event.target.value)}
+          />
+        </Field>
+        {failure && (
+          <Alert variant="destructive" role="alert">
+            <AlertDescription>{failure}</AlertDescription>
+          </Alert>
+        )}
+      </AppAdaptiveDialog>
+    </>
+  );
+}

--- a/frontend/src/features/settings/security/SecurityPage.test.tsx
+++ b/frontend/src/features/settings/security/SecurityPage.test.tsx
@@ -15,6 +15,7 @@ vi.mock("../../../api/client/api", () => ({
     userSettings: vi.fn(),
     instanceConfig: vi.fn(),
     updateMe: vi.fn(),
+    deleteMe: vi.fn(),
     journals: vi.fn(),
     moments: vi.fn(),
   },
@@ -61,6 +62,9 @@ beforeEach(() => {
     },
   });
   vi.mocked(api.updateMe).mockResolvedValue(passwordUser);
+  vi.mocked(api.deleteMe).mockResolvedValue({
+    message: "User account deleted successfully",
+  });
   vi.mocked(api.journals).mockResolvedValue([]);
   vi.mocked(api.moments).mockResolvedValue({ items: [] });
 });
@@ -99,6 +103,7 @@ describe("Settings · Security", () => {
     expect(await view.findByText(/identity provider/i)).toBeTruthy();
     expect(view.queryByLabelText("New password")).toBeNull();
     expect(view.queryByRole("button", { name: "Change password" })).toBeNull();
+    expect(view.getByRole("button", { name: "Delete account" })).toBeTruthy();
   });
 
   it("rejects a weak new password and a mismatch before calling the API", async () => {
@@ -188,5 +193,51 @@ describe("Settings · Security", () => {
       { ...window.sessionStorage },
     ]);
     expect(dump).not.toContain("brand-new-2");
+  });
+
+  it("requires DELETE before permanently deleting the account", async () => {
+    const view = await renderSecurity();
+    await userEvent.click(view.getByRole("button", { name: "Delete account" }));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Delete your account?",
+    });
+    const confirmation = within(dialog).getByLabelText(
+      /Type DELETE to confirm/,
+    );
+    const remove = within(dialog).getByRole("button", {
+      name: "Delete account",
+    });
+    expect((remove as HTMLButtonElement).disabled).toBe(true);
+
+    await userEvent.type(confirmation, "delete");
+    expect((remove as HTMLButtonElement).disabled).toBe(true);
+    expect(api.deleteMe).not.toHaveBeenCalled();
+
+    await userEvent.clear(confirmation);
+    await userEvent.type(confirmation, "DELETE");
+    expect((remove as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("keeps the confirmation open when deletion cannot be confirmed", async () => {
+    vi.mocked(api.deleteMe).mockRejectedValueOnce(new Error("offline"));
+    const view = await renderSecurity();
+    await userEvent.click(view.getByRole("button", { name: "Delete account" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Delete your account?",
+    });
+    await userEvent.type(
+      within(dialog).getByLabelText(/Type DELETE to confirm/),
+      "DELETE",
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete account" }),
+    );
+
+    await waitFor(() => expect(api.deleteMe).toHaveBeenCalledTimes(1));
+    expect(
+      await within(dialog).findByText(/couldn’t confirm that your account/i),
+    ).toBeTruthy();
+    expect(sessionStore.read()).not.toBeNull();
   });
 });

--- a/frontend/src/features/settings/security/SecurityPage.tsx
+++ b/frontend/src/features/settings/security/SecurityPage.tsx
@@ -19,6 +19,7 @@ import { useSettingsDirty } from "../SettingsModal";
 import { SettingsSection } from "../SettingsSection";
 import { usePasswordForm } from "./usePasswordForm";
 import { Alert, AlertDescription } from "../../../components/ui/alert";
+import { AccountDeletionSection } from "./AccountDeletionSection";
 
 function SecuritySkeleton() {
   return (
@@ -156,9 +157,7 @@ function PasswordForm({ email }: { email: string }) {
         )}
       </SettingsSection>
 
-      {/* Danger zone — account deletion (`DELETE /users/me`) belongs here in a
-          later iteration behind a typed confirmation. Deliberately not built
-          now (out of scope); this is only the reserved location. */}
+      <AccountDeletionSection />
     </form>
   );
 }
@@ -175,6 +174,7 @@ function OidcNotice({ ssoEnabled }: { ssoEnabled: boolean }) {
           </AlertDescription>
         </Alert>
       </SettingsSection>
+      <AccountDeletionSection />
     </div>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added account deletion for all account types from the Security settings page.
  - Requires typing `DELETE` to confirm the action.
  - Successfully deleted accounts are signed out and redirected to the login page.
  - Failed or uncertain requests keep the confirmation dialog open and display a retry message.

- **Documentation**
  - Updated settings documentation to reflect account deletion availability and revised known gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->