### PR TITLE
feat: add pdf export in frontend v2

### DIFF
--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -135,6 +135,13 @@ Use StatusView for pane-level empty or error state. A bare sentence, unfiltered
 server error, or silent failed action is not acceptable. Loading skeletons
 mirror the eventual layout.
 
+Transient notifications (toast) report one-shot action outcomes that do not
+invalidate the current screen — a download, a background command. An error that
+prevents viewing or completing the current screen stays inline or pane-level
+with StatusView, never a toast. Error toasts announce assertively (Base UI
+Toast `priority: "high"`) and offer their retry as the toast action where the
+action can be retried.
+
 ## Icons, motion, and accessibility
 
 Use Lucide icons. Icon-only controls use IconButton with a label and a

--- a/frontend/docs/features/reader.md
+++ b/frontend/docs/features/reader.md
@@ -17,11 +17,23 @@ or deleted prompt is quiet supplementary context; it never blocks the Moment.
 Malformed stored content falls back visibly to plain text. An untitled Moment
 uses its date as h1. Reader does not edit metadata.
 
-## Delete Entry
+## Entry actions
 
-The reader shows one direct ghost delete icon immediately before Edit whenever
-the Moment has an Entry. Confirm with AppConfirmDialog and leave the surface
-open with a human error on failure.
+Reader PageBar actions are `Edit` (or `Write`) and, whenever the Moment has an
+Entry, an `Entry actions` overflow menu built from the shared `AppAdaptiveMenu`
+(anchored menu on regular widths, bottom action sheet when compact). The menu
+holds:
+
+- **Download PDF** — downloads the Entry as a PDF (`GET /entries/{entry_id}/pdf`)
+  and starts a browser download. Present only when the Moment has an actual
+  Entry. While the request is in flight the item is disabled; the menu closes on
+  select, so pending state is carried by a transient toast. The browser starting
+  the download is the only success signal. Failure surfaces as a transient error
+  toast with a Retry action that re-runs the same download and keeps the
+  in-flight guard.
+- **Delete entry…** — separated below Download and styled destructive. Opens the
+  existing `AppConfirmDialog` confirmation (open state owned by the reader); the
+  dialog stays open with a human error on failure.
 
 DELETE /entries/{entry_id} deletes writing, not Moment context. Refetch the
 Moment after success; it becomes the matching quick-log kind. If the backend
@@ -60,6 +72,13 @@ media needs one entry refetch because its URLs live in the document.
 
 ## Known gaps
 
+- PDF export (backend follow-up): `GET /entries/{entry_id}/pdf`
+  does not declare its binary `application/pdf` response, so the generated client
+  types the body as `unknown`; the client wrapper parses the Blob defensively as
+  a workaround. The endpoint should declare the response properly.
+- PDF export (backend follow-up): the owned endpoint renders
+  WeasyPrint synchronously inside an `async` handler, blocking the event loop for
+  the whole render. Offload the render (thread pool or worker).
 - Reader PageBar can be visually bare for journal-less quick logs.
 - No full-size media viewer; gallery images must stay uncropped until one exists.
 - Legacy absolute third-party media URLs intentionally fall back to plain text.

--- a/frontend/e2e/overlays/adaptive-overlays.spec.ts
+++ b/frontend/e2e/overlays/adaptive-overlays.spec.ts
@@ -132,7 +132,10 @@ for (const [name, viewport] of Object.entries(VIEWPORTS)) {
       });
       await page.goto(`/timeline/${moment.id}`);
 
-      await page.getByRole("button", { name: "Delete entry" }).click();
+      await page.getByRole("button", { name: "Entry actions" }).click();
+      await page
+        .getByRole(compact ? "button" : "menuitem", { name: "Delete entry…" })
+        .click();
 
       if (compact) {
         // Base UI's Drawer never becomes an alertdialog — assert the honest

--- a/frontend/e2e/reader/actions.spec.ts
+++ b/frontend/e2e/reader/actions.spec.ts
@@ -1,0 +1,94 @@
+import { VIEWPORTS } from "../viewports";
+import { expect, test } from "../fixtures/test";
+
+for (const theme of ["light", "dark"] as const) {
+  for (const [name, viewport] of Object.entries(VIEWPORTS)) {
+    const compact = viewport.width <= 860;
+
+    test.describe(`reader actions · ${theme} · ${name} (${viewport.width}px)`, () => {
+      test.use({ viewport, theme });
+
+      test("keeps download and destructive delete in the adaptive overflow menu", async ({
+        page,
+        data,
+      }) => {
+        const journal = await data.journal({
+          title: data.label("Reader menu"),
+        });
+        const moment = await data.moment({
+          journalId: journal.id,
+          title: data.label("Reader entry"),
+        });
+        await page.goto(`/timeline/${moment.id}`);
+
+        await page.getByRole("button", { name: "Entry actions" }).click();
+        const surface = page.getByRole(compact ? "dialog" : "menu", {
+          name: compact ? "Entry actions" : undefined,
+        });
+        await expect(surface).toBeVisible();
+        await expect(
+          surface.getByRole(compact ? "button" : "menuitem", {
+            name: "Download PDF",
+          }),
+        ).toBeVisible();
+        await expect(
+          surface.getByRole(compact ? "button" : "menuitem", {
+            name: "Delete entry…",
+          }),
+        ).toBeVisible();
+
+        if (!compact) {
+          await expect(
+            surface.locator("[data-slot=dropdown-menu-separator]"),
+          ).toBeVisible();
+          await expect(
+            surface.getByRole("menuitem", { name: "Delete entry…" }),
+          ).toHaveAttribute("data-variant", "destructive");
+        }
+      });
+    });
+  }
+}
+
+test.describe("reader PDF feedback · dark mobile", () => {
+  test.use({ viewport: VIEWPORTS.mobile, theme: "dark" });
+
+  test("shows a pending action, then a failure toast", async ({
+    page,
+    data,
+  }) => {
+    const journal = await data.journal({ title: data.label("PDF feedback") });
+    const moment = await data.moment({ journalId: journal.id });
+    const pdfRoute = `**/api/v1/entries/${moment.entry?.id}/pdf`;
+    let failPdf: (() => void) | undefined;
+    const pendingPdf = new Promise<void>((resolve) => {
+      failPdf = resolve;
+    });
+    await page.route(pdfRoute, async (route) => {
+      await pendingPdf;
+      await route.fulfill({ status: 500 });
+    });
+    await page.goto(`/timeline/${moment.id}`);
+
+    await page.getByRole("button", { name: "Entry actions" }).click();
+    await page.getByRole("button", { name: "Download PDF" }).click();
+
+    // The action sheet closes on select, so the in-flight state lives in a
+    // pending toast rather than the (now unmounted) menu item.
+    await expect(page.getByText("Preparing your PDF…")).toBeVisible();
+
+    await page.getByRole("button", { name: "Entry actions" }).click();
+    const pending = page.getByRole("button", { name: "Downloading PDF…" });
+    await expect(pending).toBeDisabled();
+
+    failPdf?.();
+    // A high-priority error toast announces through an assertive live region;
+    // its retry lives on the visible surface (aria-hidden until focused).
+    await expect(
+      page.getByRole("alert").getByText("Couldn’t download PDF. Try again."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Retry", includeHidden: true }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/src/api/client/api.test.ts
+++ b/frontend/src/api/client/api.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { filenameFromContentDisposition } from "./api";
+
+describe("filenameFromContentDisposition", () => {
+  it("decodes an RFC 5987 filename* value", () => {
+    expect(
+      filenameFromContentDisposition(
+        "attachment; filename*=UTF-8''rainy%20morning.pdf",
+      ),
+    ).toBe("rainy morning.pdf");
+  });
+
+  it("decodes an RFC 8187 filename* value with a language tag", () => {
+    expect(
+      filenameFromContentDisposition(
+        "attachment; filename*=UTF-8'en'r%C3%A9sum%C3%A9.pdf",
+      ),
+    ).toBe("résumé.pdf");
+  });
+
+  it("reads a plain ASCII filename= value", () => {
+    expect(
+      filenameFromContentDisposition(
+        'attachment; filename="rainy-morning.pdf"',
+      ),
+    ).toBe("rainy-morning.pdf");
+  });
+
+  it("prefers the extended filename* when both are present", () => {
+    expect(
+      filenameFromContentDisposition(
+        "attachment; filename=\"resume.pdf\"; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf",
+      ),
+    ).toBe("résumé.pdf");
+  });
+
+  it("falls back to the ASCII filename when the extended encoding is malformed", () => {
+    expect(
+      filenameFromContentDisposition(
+        "attachment; filename=\"fallback.pdf\"; filename*=UTF-8''%E0%A4%A.pdf",
+      ),
+    ).toBe("fallback.pdf");
+  });
+
+  it("returns undefined when there is no usable filename", () => {
+    expect(filenameFromContentDisposition(null)).toBeUndefined();
+    expect(filenameFromContentDisposition("attachment")).toBeUndefined();
+  });
+});

--- a/frontend/src/api/client/api.ts
+++ b/frontend/src/api/client/api.ts
@@ -33,6 +33,7 @@ import {
   deleteUnusedTagsApiV1TagsUnusedDelete,
   deleteUserApiV1AdminUsersUserIdDelete,
   disconnectApiV1IntegrationsProviderDisconnectDelete,
+  downloadEntryPdfApiV1EntriesEntryIdPdfGet,
   fetchWeatherApiV1WeatherFetchPost,
   getActivitiesApiV1ActivitiesGet,
   getActivityGroupsApiV1ActivityGroupsGet,
@@ -168,6 +169,30 @@ const options = () => ({
 });
 const data = <T>(result: Promise<{ data: T }>) =>
   result.then((response) => response.data);
+
+export function filenameFromContentDisposition(value: string | null) {
+  if (!value) return undefined;
+  // RFC 8187 encodes extended parameters as `charset'language'value`; the
+  // language tag is optional, so accept both `UTF-8''...` and `UTF-8'en'...`.
+  const encoded = value.match(
+    /filename\*=UTF-8'(?:[A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*)?'([^;]+)/i,
+  )?.[1];
+  if (encoded) {
+    try {
+      return decodeURIComponent(encoded);
+    } catch {
+      // Fall through to the ASCII filename when a proxy corrupts the extended
+      // parameter. The browser download remains usable either way.
+    }
+  }
+  return value.match(/filename="?([^";]+)"?/i)?.[1];
+}
+
+export type DownloadedPdf = {
+  blob: Blob;
+  filename?: string;
+};
+
 export const api = {
   register: (body: UserCreate) =>
     data(registerApiV1AuthRegisterPost({ ...options(), body })),
@@ -897,6 +922,28 @@ export const api = {
         path: { entry_id },
       }),
     ),
+  /**
+   * The OpenAPI success schema currently says `unknown`, though the endpoint
+   * streams an authenticated `application/pdf` response. Keep the generated
+   * operation and configured client, but explicitly parse that response as a
+   * Blob so the caller can start a browser download and retain its filename.
+   */
+  downloadEntryPdf: async (entry_id: string): Promise<DownloadedPdf> => {
+    const result = await downloadEntryPdfApiV1EntriesEntryIdPdfGet({
+      ...options(),
+      path: { entry_id },
+      parseAs: "blob",
+    });
+    if (!(result.data instanceof Blob)) {
+      throw new Error("The PDF download did not return a file.");
+    }
+    return {
+      blob: result.data,
+      filename: filenameFromContentDisposition(
+        result.response.headers.get("Content-Disposition"),
+      ),
+    };
+  },
   createMoment: (body: MomentCreate) =>
     data(createMomentApiV1MomentsPost({ ...options(), body })),
   updateMoment: (moment_id: string, body: MomentUpdate) =>

--- a/frontend/src/app/router/routes.test.tsx
+++ b/frontend/src/app/router/routes.test.tsx
@@ -3,11 +3,12 @@ import { createMemoryHistory, RouterProvider } from "@tanstack/react-router";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAppRouter } from ".";
 import { sessionStore } from "../../api/auth/session";
 import { api } from "../../api/client/api";
 import { ApiError } from "../../api/client/errors";
+import { Toaster } from "../../components/ui/toast";
 import type {
   EntryResponse,
   InstanceConfigResponse,
@@ -30,6 +31,7 @@ vi.mock("../../api/client/api", () => ({
     mediaLibrary: vi.fn(),
     entry: vi.fn(),
     deleteEntry: vi.fn(),
+    downloadEntryPdf: vi.fn(),
     tags: vi.fn(),
     createMoment: vi.fn(),
     updateMoment: vi.fn(),
@@ -156,6 +158,10 @@ beforeEach(() => {
   vi.mocked(api.mediaLibrary).mockResolvedValue({ items: [] });
   vi.mocked(api.entry).mockResolvedValue(entry);
   vi.mocked(api.deleteEntry).mockResolvedValue(undefined);
+  vi.mocked(api.downloadEntryPdf).mockResolvedValue({
+    blob: new Blob(["pdf"], { type: "application/pdf" }),
+    filename: "rainy-morning.pdf",
+  });
   vi.mocked(api.tags).mockResolvedValue([]);
   vi.mocked(api.createMoment).mockResolvedValue({
     ...moment,
@@ -218,12 +224,74 @@ async function renderRoute(path: string) {
   const view = render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <Toaster>
+          <RouterProvider router={router} />
+        </Toaster>
       </QueryClientProvider>
     </StrictMode>,
   );
   await router.load();
   return { ...view, router };
+}
+
+async function openEntryDeleteMenu() {
+  await userEvent.click(
+    await screen.findByRole("button", { name: "Entry actions" }),
+  );
+  await userEvent.click(await screen.findByText("Delete entry…"));
+}
+
+// Restores registered by stubPdfDownloadDom(); run after every test so a stub
+// never leaks into the next one (vi.clearAllMocks in beforeEach clears call
+// data, not spy installation, and jsdom has no URL.createObjectURL to begin
+// with).
+const domRestores: Array<() => void> = [];
+afterEach(() => {
+  for (const restore of domRestores.splice(0)) restore();
+});
+
+/**
+ * Stub the DOM plumbing an anchor-click download reaches for, and register the
+ * teardown. Returns the spies so a test can assert on them.
+ */
+function stubPdfDownloadDom() {
+  const createObjectURL = vi.fn(() => "blob:entry-pdf");
+  const revokeObjectURL = vi.fn();
+  const nativeObjectUrl = Object.getOwnPropertyDescriptor(
+    URL,
+    "createObjectURL",
+  );
+  const nativeRevokeObjectUrl = Object.getOwnPropertyDescriptor(
+    URL,
+    "revokeObjectURL",
+  );
+  Object.defineProperties(URL, {
+    createObjectURL: {
+      configurable: true,
+      writable: true,
+      value: createObjectURL,
+    },
+    revokeObjectURL: {
+      configurable: true,
+      writable: true,
+      value: revokeObjectURL,
+    },
+  });
+  const click = vi
+    .spyOn(HTMLAnchorElement.prototype, "click")
+    .mockImplementation(() => undefined);
+
+  domRestores.push(() => {
+    click.mockRestore();
+    if (nativeObjectUrl)
+      Object.defineProperty(URL, "createObjectURL", nativeObjectUrl);
+    else Reflect.deleteProperty(URL, "createObjectURL");
+    if (nativeRevokeObjectUrl)
+      Object.defineProperty(URL, "revokeObjectURL", nativeRevokeObjectUrl);
+    else Reflect.deleteProperty(URL, "revokeObjectURL");
+  });
+
+  return { createObjectURL, revokeObjectURL, click };
 }
 
 describe("Phase B routes", () => {
@@ -270,9 +338,7 @@ describe("Phase B routes", () => {
       .mockRejectedValueOnce(new ApiError("Moment not found", { status: 404 }));
     const view = await renderRoute("/timeline/moment-1?q=rain&tag=tag-1");
 
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Delete entry" }),
-    );
+    await openEntryDeleteMenu();
     let dialog = screen.getByRole("alertdialog");
     expect(
       within(dialog).getByRole("heading", {
@@ -284,9 +350,7 @@ describe("Phase B routes", () => {
     );
     expect(api.deleteEntry).not.toHaveBeenCalled();
 
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Delete entry" }),
-    );
+    await openEntryDeleteMenu();
     dialog = screen.getByRole("alertdialog");
     await userEvent.click(
       within(dialog).getByRole("button", { name: "Delete entry" }),
@@ -313,9 +377,7 @@ describe("Phase B routes", () => {
       .mockResolvedValueOnce(quickLog);
     const view = await renderRoute("/timeline/moment-1?q=rain");
 
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Delete entry" }),
-    );
+    await openEntryDeleteMenu();
     await userEvent.click(
       within(screen.getByRole("alertdialog")).getByRole("button", {
         name: "Delete entry",
@@ -324,7 +386,7 @@ describe("Phase B routes", () => {
 
     expect(await screen.findByRole("button", { name: "Write" })).toBeTruthy();
     expect(view.router.state.location.pathname).toBe("/timeline/moment-1");
-    expect(screen.queryByRole("button", { name: "Delete entry" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Entry actions" })).toBeNull();
     expect(api.moment).toHaveBeenCalledTimes(2);
   });
 
@@ -332,9 +394,7 @@ describe("Phase B routes", () => {
     vi.mocked(api.deleteEntry).mockRejectedValueOnce(new Error("offline"));
     const view = await renderRoute("/timeline/moment-1");
 
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Delete entry" }),
-    );
+    await openEntryDeleteMenu();
     const dialog = screen.getByRole("alertdialog");
     await userEvent.click(
       within(dialog).getByRole("button", { name: "Delete entry" }),
@@ -347,6 +407,93 @@ describe("Phase B routes", () => {
     ).toBeTruthy();
     expect(view.router.state.location.pathname).toBe("/timeline/moment-1");
     expect(screen.getByRole("alertdialog")).toBeTruthy();
+  });
+
+  it("downloads an entry PDF from the reader action menu", async () => {
+    const { createObjectURL, click } = stubPdfDownloadDom();
+
+    await renderRoute("/timeline/moment-1");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Entry actions" }),
+    );
+    expect(
+      await screen.findByRole("menuitem", { name: "Download PDF" }),
+    ).toBeTruthy();
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Download PDF" }),
+    );
+
+    await waitFor(() =>
+      expect(api.downloadEntryPdf).toHaveBeenCalledWith("entry-1"),
+    );
+    expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(click).toHaveBeenCalledTimes(1);
+    expect((click.mock.instances[0] as HTMLAnchorElement).download).toBe(
+      "rainy-morning.pdf",
+    );
+  });
+
+  it("shows a transient toast when a PDF download fails", async () => {
+    vi.mocked(api.downloadEntryPdf).mockRejectedValueOnce(new Error("offline"));
+    await renderRoute("/timeline/moment-1");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Entry actions" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Download PDF" }),
+    );
+
+    // A high-priority toast announces through a visually-hidden assertive
+    // live region (Base UI keeps the visible surface out of the a11y tree
+    // until focused).
+    expect(
+      within(await screen.findByRole("alert")).getByText(
+        "Couldn’t download PDF. Try again.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("retries a failed PDF download from the toast action", async () => {
+    const { click } = stubPdfDownloadDom();
+    let resolveRetry: (() => void) | undefined;
+    const pendingRetry = new Promise<void>((resolve) => {
+      resolveRetry = resolve;
+    });
+    vi.mocked(api.downloadEntryPdf)
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockImplementationOnce(async () => {
+        await pendingRetry;
+        return {
+          blob: new Blob(["pdf"], { type: "application/pdf" }),
+          filename: "rainy-morning.pdf",
+        };
+      });
+
+    await renderRoute("/timeline/moment-1");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Entry actions" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Download PDF" }),
+    );
+
+    // The visible surface of a high-priority toast is aria-hidden until
+    // focused, so reach the action with `hidden`.
+    const toast = await screen.findByRole("alertdialog", { hidden: true });
+    await userEvent.click(
+      within(toast).getByRole("button", { name: "Retry", hidden: true }),
+    );
+    await userEvent.click(
+      within(toast).getByRole("button", { name: "Retry", hidden: true }),
+    );
+
+    expect(api.downloadEntryPdf).toHaveBeenCalledTimes(2);
+    if (!resolveRetry) throw new Error("The retry request did not start.");
+    resolveRetry();
+
+    await waitFor(() => expect(click).toHaveBeenCalledTimes(1));
+    expect(click).toHaveBeenCalledTimes(1);
   });
 
   it("debounces search into the URL and query policy", async () => {

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,215 @@
+import type * as React from "react";
+import { Toast as ToastPrimitive } from "@base-ui/react/toast";
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+  XIcon,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const toast = ToastPrimitive.createToastManager();
+
+function ToastProvider({ ...props }: ToastPrimitive.Provider.Props) {
+  return <ToastPrimitive.Provider {...props} />;
+}
+
+function ToastPortal({ ...props }: ToastPrimitive.Portal.Props) {
+  return <ToastPrimitive.Portal data-slot="toast-portal" {...props} />;
+}
+
+function ToastViewport({ className, ...props }: ToastPrimitive.Viewport.Props) {
+  return (
+    <ToastPrimitive.Viewport
+      data-slot="toast-viewport"
+      className={cn(
+        "pointer-events-none fixed inset-x-4 bottom-4 z-50 mx-auto w-auto max-w-sm outline-none sm:right-4 sm:left-auto sm:mx-0 sm:w-full",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function Toast({ className, ...props }: ToastPrimitive.Root.Props) {
+  return (
+    <ToastPrimitive.Root
+      data-slot="toast"
+      className={cn(
+        "group/toast pointer-events-auto absolute right-0 bottom-0 z-[calc(1000-var(--toast-index))] w-full origin-bottom rounded-2xl border bg-popover text-popover-foreground shadow-lg will-change-transform outline-none select-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "[--gap:0.75rem] [--height:var(--toast-frontmost-height,var(--toast-height))] [--offset-y:calc(var(--toast-offset-y)*-1+calc(var(--toast-index)*var(--gap)*-1)+var(--toast-swipe-movement-y))] [--peek:0.75rem] [--scale:calc(max(0,1-(var(--toast-index)*0.1)))] [--shrink:calc(1-var(--scale))]",
+        "h-(--height) [transform:translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)-(var(--toast-index)*var(--peek))-(var(--shrink)*var(--height))))_scale(var(--scale))] [transition:transform_500ms_cubic-bezier(0.22,1,0.36,1),opacity_500ms,height_150ms]",
+        "after:absolute after:top-full after:left-0 after:h-[calc(var(--gap)+1px)] after:w-full after:content-['']",
+        "data-expanded:h-(--toast-height) data-expanded:[transform:translateX(var(--toast-swipe-movement-x))_translateY(var(--offset-y))]",
+        "data-limited:opacity-0 data-starting-style:[transform:translateY(150%)]",
+        "[&[data-ending-style]:not([data-limited]):not([data-swipe-direction])]:[transform:translateY(150%)]",
+        "data-ending-style:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]",
+        "data-ending-style:data-[swipe-direction=left]:[transform:translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))]",
+        "data-ending-style:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]",
+        "data-ending-style:data-[swipe-direction=up]:[transform:translateY(calc(var(--toast-swipe-movement-y)-150%))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=left]:[transform:translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=up]:[transform:translateY(calc(var(--toast-swipe-movement-y)-150%))]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ToastContent({ className, ...props }: ToastPrimitive.Content.Props) {
+  return (
+    <ToastPrimitive.Content
+      data-slot="toast-content"
+      className={cn(
+        "flex h-full items-center gap-3 overflow-hidden p-4 transition-opacity duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] data-behind:opacity-0 data-expanded:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ToastTitle({ className, ...props }: ToastPrimitive.Title.Props) {
+  return (
+    <ToastPrimitive.Title
+      data-slot="toast-title"
+      className={cn("text-sm font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function ToastDescription({
+  className,
+  ...props
+}: ToastPrimitive.Description.Props) {
+  return (
+    <ToastPrimitive.Description
+      data-slot="toast-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function ToastAction({
+  className,
+  render = <Button variant="outline" size="sm" />,
+  ...props
+}: ToastPrimitive.Action.Props) {
+  return (
+    <ToastPrimitive.Action
+      data-slot="toast-action"
+      render={render}
+      className={cn("shrink-0", className)}
+      {...props}
+    />
+  );
+}
+
+function ToastClose({
+  className,
+  children,
+  render = <Button variant="ghost" size="icon-sm" />,
+  ...props
+}: ToastPrimitive.Close.Props) {
+  return (
+    <ToastPrimitive.Close
+      data-slot="toast-close"
+      aria-label="Close toast"
+      render={render}
+      className={cn(
+        "relative shrink-0 text-muted-foreground after:absolute after:-inset-2 after:content-[''] hover:text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? <XIcon aria-hidden="true" />}
+    </ToastPrimitive.Close>
+  );
+}
+
+function ToastIcon({ type }: { type: string | undefined }) {
+  let icon: React.ReactNode = null;
+
+  if (type === "success") icon = <CircleCheckIcon aria-hidden="true" />;
+  if (type === "info") icon = <InfoIcon aria-hidden="true" />;
+  if (type === "warning") icon = <TriangleAlertIcon aria-hidden="true" />;
+  if (type === "error") {
+    icon = <OctagonXIcon className="text-destructive" aria-hidden="true" />;
+  }
+  if (type === "loading") {
+    icon = <Loader2Icon className="animate-spin" aria-hidden="true" />;
+  }
+
+  if (!icon) return null;
+
+  return (
+    <span
+      data-slot="toast-icon"
+      className="shrink-0 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4"
+    >
+      {icon}
+    </span>
+  );
+}
+
+function ToastList() {
+  const { toasts } = ToastPrimitive.useToastManager();
+
+  return toasts.map((toastItem) => (
+    <Toast key={toastItem.id} toast={toastItem}>
+      <ToastContent>
+        <ToastIcon type={toastItem.type} />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <ToastTitle />
+          <ToastDescription />
+        </div>
+        <ToastAction />
+        <ToastClose />
+      </ToastContent>
+    </Toast>
+  ));
+}
+
+function Toaster({
+  children,
+  toastManager = toast,
+  ...props
+}: ToastPrimitive.Provider.Props) {
+  return (
+    <ToastProvider toastManager={toastManager} {...props}>
+      {children}
+      <ToastPortal>
+        <ToastViewport>
+          <ToastList />
+        </ToastViewport>
+      </ToastPortal>
+    </ToastProvider>
+  );
+}
+
+const createToastManager = ToastPrimitive.createToastManager;
+const useToastManager = ToastPrimitive.useToastManager;
+
+export {
+  Toaster,
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastContent,
+  ToastDescription,
+  ToastPortal,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+  createToastManager,
+  toast,
+  useToastManager,
+};

--- a/frontend/src/features/reader/DeleteEntryDialog.tsx
+++ b/frontend/src/features/reader/DeleteEntryDialog.tsx
@@ -1,59 +1,45 @@
-import { Trash2, TriangleAlert } from "lucide-react";
-import { useState } from "react";
+import { TriangleAlert } from "lucide-react";
 import { AppConfirmDialog } from "../../components/journiv/AppConfirmDialog";
 import { Alert, AlertDescription } from "../../components/ui/alert";
-import { IconButton } from "../../components/ui/icon-button";
 
 export function DeleteEntryDialog({
+  open,
+  onOpenChange,
   entryTitle,
   deleting,
   failed,
   onConfirm,
-  onReset,
 }: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   entryTitle?: string | null;
   deleting: boolean;
   failed: boolean;
   onConfirm: () => void;
-  onReset: () => void;
 }) {
-  const [open, setOpen] = useState(false);
-
   return (
-    <>
-      <IconButton
-        label="Delete entry"
-        onClick={() => {
-          onReset();
-          setOpen(true);
-        }}
-      >
-        <Trash2 aria-hidden="true" />
-      </IconButton>
-      <AppConfirmDialog
-        open={open}
-        onOpenChange={(next) => {
-          // Never strand the user mid-delete with the surface gone.
-          if (deleting) return;
-          setOpen(next);
-        }}
-        title={entryTitle ? `Delete “${entryTitle}”?` : "Delete entry?"}
-        description="The writing in this entry will be permanently removed. Photos, moods, tags, people and other logged details will stay with this moment. If no other details remain, the moment will be removed from the Timeline. This cannot be undone."
-        confirmLabel={deleting ? "Deleting…" : "Delete entry"}
-        destructive
-        pending={deleting}
-        onConfirm={onConfirm}
-      >
-        {failed && (
-          <Alert variant="destructive">
-            <TriangleAlert aria-hidden="true" />
-            <AlertDescription>
-              The entry couldn’t be deleted. Check your connection and try
-              again.
-            </AlertDescription>
-          </Alert>
-        )}
-      </AppConfirmDialog>
-    </>
+    <AppConfirmDialog
+      open={open}
+      onOpenChange={(next) => {
+        // Never strand the user mid-delete with the surface gone.
+        if (deleting) return;
+        onOpenChange(next);
+      }}
+      title={entryTitle ? `Delete “${entryTitle}”?` : "Delete entry?"}
+      description="The writing in this entry will be permanently removed. Photos, moods, tags, people and other logged details will stay with this moment. If no other details remain, the moment will be removed from the Timeline. This cannot be undone."
+      confirmLabel={deleting ? "Deleting…" : "Delete entry"}
+      destructive
+      pending={deleting}
+      onConfirm={onConfirm}
+    >
+      {failed && (
+        <Alert variant="destructive">
+          <TriangleAlert aria-hidden="true" />
+          <AlertDescription>
+            The entry couldn’t be deleted. Check your connection and try again.
+          </AlertDescription>
+        </Alert>
+      )}
+    </AppConfirmDialog>
   );
 }

--- a/frontend/src/features/reader/ReaderPage.tsx
+++ b/frontend/src/features/reader/ReaderPage.tsx
@@ -1,22 +1,30 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useRef, useState } from "react";
 import {
   ArrowLeft,
+  Download,
   Images,
   NotebookPen,
   Pencil,
+  Trash2,
   TriangleAlert,
 } from "lucide-react";
 import { api } from "../../api/client/api";
 import { entryQuery, momentQuery, promptQuery } from "../../api/query/options";
 import { queryKeys } from "../../api/query/keys";
 import { EntryHeader } from "../../components/journiv/EntryHeader";
+import {
+  AppAdaptiveMenu,
+  type AppMenuAction,
+} from "../../components/journiv/AppAdaptiveMenu";
 import { JournalBadge } from "../../components/journiv/JournalBadge";
 import { MomentChips } from "../../components/journiv/MomentChips";
 import { PageBar } from "../../components/journiv/PageBar";
 import { Button } from "../../components/ui/button";
 import { IconButton } from "../../components/ui/icon-button";
 import { Skeleton } from "../../components/ui/skeleton";
+import { toast } from "../../components/ui/toast";
 import { StatusView } from "../../components/journiv/StatusView";
 import { useJournalLookup } from "../../lib/useJournalLookup";
 import { momentKind, momentKindLabel, momentTitle } from "../../lib/moment";
@@ -28,6 +36,10 @@ import { DeleteEntryDialog } from "./DeleteEntryDialog";
 import { EntryMedia } from "./EntryMedia";
 import { useMomentMedia } from "./useMomentMedia";
 import "./reader.css";
+
+// One stable id so the pending toast can be resolved (closed) on settle rather
+// than lingering next to the outcome.
+const PDF_TOAST_ID = "reader-entry-pdf";
 
 export function ReaderPage() {
   const { momentId, journalId } = useParams({ strict: false }) as {
@@ -48,6 +60,8 @@ export function ReaderPage() {
   const { q = "", view, month, date } = search;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const isPdfRetryInFlight = useRef(false);
   // Carry the list-pane mode back so Back returns to the calendar or grid the
   // reader was opened from, not the plain list.
   const listSearch = {
@@ -135,6 +149,53 @@ export function ReaderPage() {
       if (!momentSurvived) goBack();
     },
   });
+  const download = useMutation({
+    mutationFn: async (entryId: string) => {
+      const { blob, filename } = await api.downloadEntryPdf(entryId);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename ?? "entry.pdf";
+      document.body.append(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+    },
+    onMutate: () => {
+      // The action menu closes on select, so its disabled "Downloading PDF…"
+      // item is not on screen while the PDF renders. A pending toast carries
+      // that state instead; the browser's own download is the success signal,
+      // so success just clears this toast.
+      toast.add({
+        id: PDF_TOAST_ID,
+        type: "loading",
+        description: "Preparing your PDF…",
+        timeout: 0,
+      });
+    },
+    onSuccess: () => {
+      toast.close(PDF_TOAST_ID);
+    },
+    onSettled: () => {
+      isPdfRetryInFlight.current = false;
+    },
+    onError: (_error, entryId) => {
+      toast.close(PDF_TOAST_ID);
+      toast.add({
+        type: "error",
+        priority: "high",
+        description: "Couldn’t download PDF. Try again.",
+        actionProps: {
+          children: "Retry",
+          onClick: () => {
+            if (isPdfRetryInFlight.current) return;
+            isPdfRetryInFlight.current = true;
+            download.mutate(entryId);
+          },
+        },
+      });
+    },
+  });
 
   if (moment.isLoading) return <ReaderSkeleton />;
   if (moment.isError || !moment.data) {
@@ -168,6 +229,30 @@ export function ReaderPage() {
   const journal = journals.get(data.entry?.journal_id ?? journalId);
   const hasWriting = Boolean(data.entry);
   const content = entry.data?.content_delta ?? EMPTY_DELTA;
+  const entryActions: AppMenuAction[] = entryId
+    ? [
+        {
+          kind: "command",
+          id: "download-pdf",
+          label: download.isPending ? "Downloading PDF…" : "Download PDF",
+          icon: Download,
+          disabled: download.isPending,
+          onSelect: () => download.mutate(entryId),
+        },
+        {
+          kind: "command",
+          id: "delete-entry",
+          label: "Delete entry…",
+          icon: Trash2,
+          destructive: true,
+          separatorBefore: true,
+          onSelect: () => {
+            remove.reset();
+            setDeleteOpen(true);
+          },
+        },
+      ]
+    : [];
   // Media shown inside the prose must not be repeated in the gallery.
   const inlinePaths = hasWriting
     ? planReaderContent(content).inlinePaths
@@ -184,15 +269,6 @@ export function ReaderPage() {
         title={<JournalBadge journal={journal} />}
         actions={
           <>
-            {entryId && (
-              <DeleteEntryDialog
-                entryTitle={title}
-                deleting={remove.isPending}
-                failed={remove.isError}
-                onConfirm={() => remove.mutate(entryId)}
-                onReset={remove.reset}
-              />
-            )}
             <Button
               variant={hasWriting ? "secondary" : "default"}
               onClick={edit}
@@ -209,9 +285,23 @@ export function ReaderPage() {
                 </>
               )}
             </Button>
+            {entryId && (
+              <AppAdaptiveMenu label="Entry actions" actions={entryActions} />
+            )}
           </>
         }
       />
+
+      {entryId && (
+        <DeleteEntryDialog
+          open={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          entryTitle={title}
+          deleting={remove.isPending}
+          failed={remove.isError}
+          onConfirm={() => remove.mutate(entryId)}
+        />
+      )}
 
       <div className="jv-reader__scroll">
         <div className="jv-reader__column">

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,6 +13,7 @@ import {
   readUiExperiment,
 } from "./features/theme/uiExperiment";
 import { retireRootFlutterWorker } from "./app/retireRootFlutterWorker";
+import { Toaster } from "./components/ui/toast";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing application root");
@@ -30,7 +31,9 @@ void retireRootFlutterWorker();
 createRoot(root).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <Toaster>
+        <RouterProvider router={router} />
+      </Toaster>
     </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added PDF downloads from the reader, including progress feedback, automatic filenames, error alerts, and retry support.
  - Consolidated reader actions into an adaptive overflow menu for downloading PDFs and deleting entries across screen sizes.
  - Added toast notifications for successful, loading, and failed operations.

- **Bug Fixes**
  - Improved deletion controls and confirmation behavior across compact and wide layouts.

- **Documentation**
  - Documented reader actions, PDF download behavior, and notification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->