### PR TITLE
feat: add update and license registration setting in frontend v2

### DIFF
--- a/app/api/v1/endpoints/license.py
+++ b/app/api/v1/endpoints/license.py
@@ -67,10 +67,16 @@ async def register_license(
                 request_id=getattr(http_request.state, 'request_id', None)
             )
 
+        # Preserve the service's rate-limit signal so the client can show a
+        # cooldown instead of a generic "check the key" message. The response
+        # schema already carries these fields; only the construction here was
+        # dropping them.
         return LicenseRegisterResponse(
             successful=result.get("successful", False),
             signed_license=result.get("signed_license"),
-            error_message=result.get("error_message")
+            error_message=result.get("error_message"),
+            rate_limited=result.get("rate_limited", False),
+            retry_after=result.get("retry_after"),
         )
 
     except HTTPException:

--- a/frontend/docs/features/settings.md
+++ b/frontend/docs/features/settings.md
@@ -52,7 +52,11 @@ confirmation only for actual confirmation.
   keeps secrets ephemeral, and invalidates status after mutation.
 - Import/export starts explicit background jobs, polls only while active, shows
   progress and human failure states, and never auto-downloads.
-- Support reads available public version/config/license information.
+- Support reads available public version/config/license information. Administration
+  owns version checking and Plus license registration: it shows cached update
+  state, controls automatic checks, permits a rate-limit-aware manual check,
+  and lets an administrator register a license. License reset/unbinding is a
+  separate destructive lifecycle flow and is intentionally not exposed here.
 - Admin Users is role-gated before its list query. It fetches the documented
   offset pages, searches/pages locally, sends only changed fields, respects
   last-admin protections, and refreshes user/session queries when needed.
@@ -63,5 +67,3 @@ confirmation only for actual confirmation.
   icons have no backend contract.
 - Admin user pagination exposes neither a total nor continuation token, so the
   complete collection is fetched before local search/paging.
-- Version administration and license registration/reset remain intentionally
-  undesigned; do not render dead links.

--- a/frontend/src/api/client/api.ts
+++ b/frontend/src/api/client/api.ts
@@ -35,6 +35,7 @@ import {
   disconnectApiV1IntegrationsProviderDisconnectDelete,
   downloadEntryPdfApiV1EntriesEntryIdPdfGet,
   fetchWeatherApiV1WeatherFetchPost,
+  forceVersionCheckApiV1InstanceVersionCheckPost,
   getActivitiesApiV1ActivitiesGet,
   getActivityGroupsApiV1ActivityGroupsGet,
   getAllMoodsApiV1MoodsGet,
@@ -75,6 +76,7 @@ import {
   getUserJournalsApiV1JournalsGet,
   getUserTagsApiV1TagsGet,
   getVersionInfoApiV1InstanceVersionInfoGet,
+  getVersionCheckEnabledApiV1InstanceVersionCheckEnabledGet,
   getWritingPatternsApiV1AnalyticsWritingPatternsGet,
   getWritingStreakApiV1AnalyticsWritingStreakGet,
   importFromImmichAsyncApiV1MediaImportFromImmichAsyncPost,
@@ -88,6 +90,7 @@ import {
   oidcExchangeApiV1AuthOidcExchangePost,
   refreshTokenApiV1AuthRefreshPost,
   registerApiV1AuthRegisterPost,
+  registerLicenseApiV1InstanceLicenseRegisterPost,
   removePersonProfileImageApiV1PeoplePersonIdProfileImageDelete,
   removeTagFromMomentApiV1MomentsMomentIdTagsTagIdDelete,
   reorderJournalsApiV1JournalsReorderPut,
@@ -114,6 +117,7 @@ import {
   updateSettingsApiV1IntegrationsProviderSettingsPut,
   updateTagApiV1TagsTagIdPut,
   updateUserApiV1AdminUsersUserIdPatch,
+  updateVersionCheckEnabledApiV1InstanceVersionCheckEnabledPut,
   uploadImportApiV1ImportUploadPost,
   uploadPersonProfileImageApiV1PeoplePersonIdProfileImagePost,
 } from "../generated/sdk.gen";
@@ -142,6 +146,7 @@ import type {
   JournalCreate,
   JournalReorderRequest,
   JournalUpdate,
+  LicenseRegisterRequest,
   ListAssetsApiV1IntegrationsProviderAssetsGetData,
   MomentCreate,
   MomentUpdate,
@@ -159,6 +164,7 @@ import type {
   UserSettingsUpdate,
   UserCreate,
   UserUpdate,
+  VersionCheckEnabledUpdate,
   WeatherFetchRequest,
 } from "../generated/types.gen";
 import { configureApiClient } from "./config";
@@ -666,7 +672,22 @@ export const api = {
       }),
     ),
   versionInfo: () => data(getVersionInfoApiV1InstanceVersionInfoGet(options())),
+  forceVersionCheck: () =>
+    data(forceVersionCheckApiV1InstanceVersionCheckPost(options())),
+  versionCheckEnabled: () =>
+    data(getVersionCheckEnabledApiV1InstanceVersionCheckEnabledGet(options())),
+  updateVersionCheckEnabled: (body: VersionCheckEnabledUpdate) =>
+    data(
+      updateVersionCheckEnabledApiV1InstanceVersionCheckEnabledPut({
+        ...options(),
+        body,
+      }),
+    ),
   licenseInfo: () => data(getLicenseInfoApiV1InstanceLicenseInfoGet(options())),
+  registerLicense: (body: LicenseRegisterRequest) =>
+    data(
+      registerLicenseApiV1InstanceLicenseRegisterPost({ ...options(), body }),
+    ),
   integrationStatus: () =>
     data(
       getStatusApiV1IntegrationsProviderStatusGet({

--- a/frontend/src/api/client/errors.test.ts
+++ b/frontend/src/api/client/errors.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sessionStore } from "../auth/session";
 import { api } from "./api";
-import { ApiError, isConflict, isNotFound } from "./errors";
+import { ApiError, isConflict, isNotFound, retryTransient } from "./errors";
 import { resetAuthRefreshForTests } from "./config";
 
 describe("API errors keep the status", () => {
@@ -81,5 +81,25 @@ describe("API errors keep the status", () => {
     expect((caught as ApiError).status).toBeUndefined();
     expect(isNotFound(caught)).toBe(false);
     expect(isConflict(caught)).toBe(false);
+  });
+});
+
+describe("retryTransient", () => {
+  it("retries a failure that never got an answer, up to two attempts", () => {
+    const offline = new ApiError("Failed to fetch");
+    expect(retryTransient(0, offline)).toBe(true);
+    expect(retryTransient(1, offline)).toBe(true);
+    expect(retryTransient(2, offline)).toBe(false);
+  });
+
+  it("retries a 5xx", () => {
+    expect(retryTransient(0, new ApiError("boom", { status: 500 }))).toBe(true);
+    expect(retryTransient(0, new ApiError("down", { status: 503 }))).toBe(true);
+  });
+
+  it("does not retry a 4xx — it is the server's answer", () => {
+    for (const status of [400, 401, 403, 404, 409, 422, 429]) {
+      expect(retryTransient(0, new ApiError("no", { status }))).toBe(false);
+    }
   });
 });

--- a/frontend/src/api/client/errors.ts
+++ b/frontend/src/api/client/errors.ts
@@ -64,3 +64,19 @@ export function isNotFound(caught: unknown): boolean {
 export function isConflict(caught: unknown): boolean {
   return caught instanceof ApiError && caught.status === 409;
 }
+
+/**
+ * A TanStack Query `retry` predicate that only spins on failures a retry could
+ * actually clear: the request never got an answer (offline, DNS, timeout — no
+ * status) or the server said it broke (5xx). A 4xx is the server's considered
+ * answer — 401/403 capability, 404 absence, 422 validation — and the caller
+ * renders a state from it, so retrying only delays that state. Caps at two
+ * attempts, matching the app's default `retry: 1` budget for transient blips.
+ */
+export function retryTransient(failureCount: number, error: unknown): boolean {
+  if (failureCount >= 2) return false;
+  if (error instanceof ApiError && error.status !== undefined) {
+    return error.status >= 500;
+  }
+  return true;
+}

--- a/frontend/src/api/query/keys.ts
+++ b/frontend/src/api/query/keys.ts
@@ -75,6 +75,7 @@ export const queryKeys = {
    *  both. Do not flatten to a sibling key. */
   goalLogs: (id: string) => ["goals", id, "logs"] as const,
   versionInfo: ["instance", "version"] as const,
+  versionCheckEnabled: ["instance", "version", "enabled"] as const,
   licenseInfo: ["instance", "license"] as const,
   integrationStatus: (provider: string) =>
     ["integrations", provider, "status"] as const,

--- a/frontend/src/api/query/options.ts
+++ b/frontend/src/api/query/options.ts
@@ -4,6 +4,7 @@ import {
   queryOptions,
 } from "@tanstack/react-query";
 import { api } from "../client/api";
+import { retryTransient } from "../client/errors";
 import {
   normalizeMomentFilters,
   queryKeys,
@@ -111,11 +112,26 @@ export const versionInfoQuery = () =>
   queryOptions({
     queryKey: queryKeys.versionInfo,
     queryFn: () => api.versionInfo(),
+    staleTime: 60_000,
+    // Retry only genuine blips; a 403 (not an admin) is an answer, not a spinner.
+    retry: retryTransient,
+  });
+export const versionCheckEnabledQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.versionCheckEnabled,
+    queryFn: () => api.versionCheckEnabled(),
+    staleTime: 60_000,
+    retry: retryTransient,
   });
 export const licenseInfoQuery = () =>
   queryOptions({
     queryKey: queryKeys.licenseInfo,
     queryFn: () => api.licenseInfo(),
+    staleTime: 60_000,
+    // A 404 is the expected "no license registered" state and a 403/501 is a
+    // capability answer — none should delay the registration form. A 5xx or a
+    // dropped connection still gets the standard couple of retries.
+    retry: retryTransient,
   });
 export const integrationStatusQuery = () =>
   queryOptions({

--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -348,6 +348,13 @@ const settingsUsersRoute = createRoute({
   staticData: { settings: "users" },
   component: SettingsBackground,
 });
+const settingsUpdatesLicenseRoute = createRoute({
+  getParentRoute: () => protectedRoute,
+  path: "/settings/admin/updates-license",
+  validateSearch: timelineSearch,
+  staticData: { settings: "updatesLicense" },
+  component: SettingsBackground,
+});
 /** Tags graduated from the legacy `/settings/journaling/*` prefix to its own
  *  Library workspace. Keep the old URL working. */
 const settingsTagsRedirectRoute = createRoute({
@@ -571,6 +578,7 @@ const routeTree = rootRoute.addChildren([
     settingsSecurityRoute,
     settingsAppearanceRoute,
     settingsUsersRoute,
+    settingsUpdatesLicenseRoute,
     settingsTagsRedirectRoute,
     libraryTagsRoute,
     libraryTagRoute,
@@ -616,6 +624,7 @@ declare module "@tanstack/react-router" {
       | "security"
       | "appearance"
       | "users"
+      | "updatesLicense"
       | "integrations"
       | "import"
       | "export"

--- a/frontend/src/features/settings/SettingsModal.tsx
+++ b/frontend/src/features/settings/SettingsModal.tsx
@@ -28,6 +28,7 @@ import { HelpPage } from "./support/HelpPage";
 import { AboutPage } from "./support/AboutPage";
 import { currentUserQuery } from "../../api/query/options";
 import { UsersPage } from "./admin/UsersPage";
+import { UpdatesLicensePage } from "./admin/UpdatesLicensePage";
 import "./settings.css";
 
 /** The route the modal knows how to show. `AppShell` reads it from route
@@ -117,7 +118,11 @@ export function SettingsModal({ section }: { section: SettingsSection }) {
   // Administration is absent from navigation for ordinary users. A direct
   // deep link is also returned to Profile before the admin query can mount.
   useEffect(() => {
-    if (section === "users" && currentUser.data && !isAdmin) {
+    if (
+      (section === "users" || section === "updatesLicense") &&
+      currentUser.data &&
+      !isAdmin
+    ) {
       navigate({
         to: "/settings/profile",
         search: { q: "" },
@@ -203,6 +208,9 @@ export function SettingsModal({ section }: { section: SettingsSection }) {
                   {section === "appearance" && <AppearancePage />}
                   {section === "integrations" && <IntegrationsPage />}
                   {section === "users" && isAdmin && <UsersPage />}
+                  {section === "updatesLicense" && isAdmin && (
+                    <UpdatesLicensePage />
+                  )}
                   {section === "import" && <ImportPage />}
                   {section === "export" && <ExportPage />}
                   {section === "help" && <HelpPage />}

--- a/frontend/src/features/settings/admin/UpdatesLicensePage.test.tsx
+++ b/frontend/src/features/settings/admin/UpdatesLicensePage.test.tsx
@@ -1,0 +1,283 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../../api/client/errors";
+import { createAppQueryClient } from "../../../app/queryClient";
+import { UpdatesLicensePage } from "./UpdatesLicensePage";
+
+vi.mock("../../../api/client/api", () => ({
+  api: {
+    me: vi.fn(),
+    versionInfo: vi.fn(),
+    versionCheckEnabled: vi.fn(),
+    updateVersionCheckEnabled: vi.fn(),
+    forceVersionCheck: vi.fn(),
+    licenseInfo: vi.fn(),
+    registerLicense: vi.fn(),
+    instanceConfig: vi.fn(),
+  },
+}));
+
+import { api } from "../../../api/client/api";
+
+const now = "2026-09-05T16:30:00Z";
+const admin = {
+  id: "admin-1",
+  email: "admin@example.com",
+  name: "Admin",
+  role: "admin" as const,
+  is_active: true,
+  time_zone: "America/Los_Angeles",
+  is_oidc_user: false,
+  created_at: now,
+  updated_at: now,
+};
+
+const version = {
+  current_version: "1.2.0",
+  install_id: "install-1",
+  latest_version: "1.2.0",
+  update_available: false,
+  last_checked: now,
+  last_check_success: true,
+};
+
+function renderPage() {
+  const queryClient = createAppQueryClient();
+  queryClient.setDefaultOptions({ queries: { retry: false } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UpdatesLicensePage />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(api.me).mockResolvedValue(admin);
+  vi.mocked(api.versionInfo).mockResolvedValue(version);
+  vi.mocked(api.versionCheckEnabled).mockResolvedValue({ enabled: true });
+  vi.mocked(api.updateVersionCheckEnabled).mockImplementation(
+    async ({ enabled }) => ({ enabled }),
+  );
+  vi.mocked(api.forceVersionCheck).mockResolvedValue({
+    success: true,
+    message: "Version check completed successfully",
+    version_info: version,
+  });
+  vi.mocked(api.licenseInfo).mockRejectedValue(
+    new ApiError("No license", { status: 404 }),
+  );
+  vi.mocked(api.registerLicense).mockResolvedValue({ successful: true });
+  vi.mocked(api.instanceConfig).mockResolvedValue({
+    import_export_max_file_size_mb: 100,
+    max_file_size_mb: 50,
+    disable_signup: false,
+    oidc_enabled: false,
+    oidc_only: false,
+    plus: {
+      available: false,
+      tier: "member",
+      upgrade_url: "https://journiv.com/plus",
+    },
+  });
+});
+
+describe("UpdatesLicensePage", () => {
+  it("shows cached version state and a prefilled registration form when no license exists", async () => {
+    renderPage();
+
+    expect(await screen.findByText("1.2.0")).toBeTruthy();
+    expect(screen.getByText("Up to date")).toBeTruthy();
+    expect(
+      screen
+        .getByRole("switch", { name: "Automatic version checking" })
+        .getAttribute("data-checked"),
+    ).not.toBeNull();
+    expect(screen.getByDisplayValue("admin@example.com")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Register license" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps a rate-limited manual check inline and prevents another immediate request", async () => {
+    vi.mocked(api.forceVersionCheck).mockResolvedValue({
+      success: false,
+      message: "Rate limited",
+      retry_after_seconds: 120,
+    });
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Check for updates" }),
+    );
+
+    expect(
+      await screen.findByText(/release service is rate limiting/i),
+    ).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /try again in/i,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(api.forceVersionCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the backend toggle endpoint and refreshes cached version data after enabling", async () => {
+    vi.mocked(api.versionCheckEnabled).mockResolvedValue({ enabled: false });
+    renderPage();
+
+    const automatic = await screen.findByRole("switch", {
+      name: "Automatic version checking",
+    });
+    await userEvent.click(automatic);
+
+    await waitFor(() =>
+      expect(api.updateVersionCheckEnabled).toHaveBeenCalledWith({
+        enabled: true,
+      }),
+    );
+    expect(api.forceVersionCheck).not.toHaveBeenCalled();
+  });
+
+  it("shows an expired license and offers registration without an unbind action", async () => {
+    vi.mocked(api.licenseInfo).mockResolvedValue({
+      is_active: false,
+      tier: "supporter",
+      license_type: "subscription",
+      subscription_expires_at: "2026-01-01T00:00:00Z",
+      install_id: "install-1",
+      registered_email: "buyer@example.com",
+    });
+    renderPage();
+
+    expect((await screen.findAllByText("Expired")).length).toBeGreaterThan(0);
+    expect(screen.getByText("buyer@example.com")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Register license" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /unbind|reset/i })).toBeNull();
+  });
+
+  it.each([403, 500, 501, 503])(
+    "shows the load-error state, not the registration form, when license info fails with %i",
+    async (status) => {
+      vi.mocked(api.licenseInfo).mockRejectedValue(
+        new ApiError("nope", { status }),
+      );
+      renderPage();
+
+      // A non-404 is an error/capability answer — never a cue to register.
+      // `retryTransient` may retry a 5xx a couple of times first; the settled
+      // state is a load error, and the registration form must never appear.
+      await waitFor(
+        () =>
+          expect(
+            screen.getByText(/license details couldn.t be loaded/i),
+          ).toBeTruthy(),
+        { timeout: 6000 },
+      );
+      expect(
+        screen.queryByRole("button", { name: "Register license" }),
+      ).toBeNull();
+      expect(screen.queryByLabelText("License key")).toBeNull();
+    },
+  );
+
+  it("registers a license with the editable email and then refreshes status", async () => {
+    vi.mocked(api.licenseInfo)
+      .mockRejectedValueOnce(new ApiError("No license", { status: 404 }))
+      .mockResolvedValue({
+        is_active: true,
+        tier: "supporter",
+        license_type: "lifetime",
+        install_id: "install-1",
+      });
+    renderPage();
+
+    const license = await screen.findByLabelText("License key");
+    const email = screen.getByLabelText("Admin email");
+    await userEvent.type(license, "lic_abcdefghijklmnopqrstuvwxyz123456");
+    await userEvent.clear(email);
+    await userEvent.type(email, "buyer@example.com");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Register license" }),
+    );
+
+    await waitFor(() =>
+      expect(api.registerLicense).toHaveBeenCalledWith({
+        license: "lic_abcdefghijklmnopqrstuvwxyz123456",
+        email: "buyer@example.com",
+      }),
+    );
+    expect(await screen.findByText("Active")).toBeTruthy();
+  });
+
+  it("surfaces the backend's failure reason instead of the generic message", async () => {
+    vi.mocked(api.registerLicense).mockResolvedValue({
+      successful: false,
+      error_message: "License already bound to another installation.",
+    });
+    renderPage();
+
+    await userEvent.type(
+      await screen.findByLabelText("License key"),
+      "lic_abcdefghijklmnopqrstuvwxyz123456",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Register license" }),
+    );
+
+    expect(
+      await screen.findByText("License already bound to another installation."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/check the key and email/i)).toBeNull();
+  });
+
+  it("surfaces a rate-limited registration with the server's cooldown message", async () => {
+    vi.mocked(api.registerLicense).mockResolvedValue({
+      successful: false,
+      rate_limited: true,
+      retry_after: 120,
+      error_message: "Rate limit exceeded. Please try again in 2 minutes.",
+    });
+    renderPage();
+
+    await userEvent.type(
+      await screen.findByLabelText("License key"),
+      "lic_abcdefghijklmnopqrstuvwxyz123456",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Register license" }),
+    );
+
+    expect(await screen.findByText(/rate limit exceeded/i)).toBeTruthy();
+  });
+
+  it("keeps a typed admin email when the current user query resolves late", async () => {
+    let resolveMe: (value: typeof admin) => void = () => {};
+    vi.mocked(api.me).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveMe = resolve;
+        }),
+    );
+    renderPage();
+
+    const email = await screen.findByLabelText("Admin email");
+    await userEvent.type(email, "someone.else@example.com");
+
+    // The signed-in admin's email arrives only now, after typing has started.
+    resolveMe(admin);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Admin email")).toHaveProperty(
+        "value",
+        "someone.else@example.com",
+      ),
+    );
+    expect(screen.queryByDisplayValue("admin@example.com")).toBeNull();
+  });
+});

--- a/frontend/src/features/settings/admin/UpdatesLicensePage.tsx
+++ b/frontend/src/features/settings/admin/UpdatesLicensePage.tsx
@@ -1,0 +1,525 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useId, useRef, useState } from "react";
+import { api } from "../../../api/client/api";
+import { ApiError, isNotFound } from "../../../api/client/errors";
+import type { LicenseRegisterRequest } from "../../../api/generated/types.gen";
+import { queryKeys } from "../../../api/query/keys";
+import {
+  currentUserQuery,
+  licenseInfoQuery,
+  versionCheckEnabledQuery,
+  versionInfoQuery,
+} from "../../../api/query/options";
+import { Alert, AlertDescription } from "../../../components/ui/alert";
+import { Button } from "../../../components/ui/button";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "../../../components/ui/field";
+import { Input } from "../../../components/ui/input";
+import { Skeleton } from "../../../components/ui/skeleton";
+import { Spinner } from "../../../components/ui/spinner";
+import { Switch } from "../../../components/ui/switch";
+import { useSettingsDirty } from "../SettingsModal";
+import { SettingsRow, SettingsSection } from "../SettingsSection";
+import { useCheckCooldown } from "./useCheckCooldown";
+
+const LICENSE_KEY_PATTERN = /^lic_[A-Za-z0-9]{32}$/;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type CheckFeedback = "success" | "failed" | "rate-limited" | undefined;
+
+function dateTime(value: string | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function retryDuration(seconds: number) {
+  if (seconds < 60) return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+  const minutes = Math.ceil(seconds / 60);
+  return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+}
+
+function VersionManagement() {
+  const queryClient = useQueryClient();
+  const version = useQuery(versionInfoQuery());
+  const enabled = useQuery(versionCheckEnabledQuery());
+  const cooldown = useCheckCooldown();
+  const [feedback, setFeedback] = useState<CheckFeedback>();
+
+  const check = useMutation({
+    mutationFn: () => api.forceVersionCheck(),
+    onSuccess: (result) => {
+      if (result.version_info)
+        queryClient.setQueryData(queryKeys.versionInfo, result.version_info);
+
+      if (result.success) {
+        cooldown.clear();
+        setFeedback("success");
+        return;
+      }
+
+      if (result.retry_after_seconds) {
+        cooldown.begin(result.retry_after_seconds);
+        setFeedback("rate-limited");
+        return;
+      }
+
+      setFeedback("failed");
+    },
+    onError: () => setFeedback("failed"),
+  });
+
+  const automaticChecks = useMutation({
+    mutationFn: (nextEnabled: boolean) =>
+      api.updateVersionCheckEnabled({ enabled: nextEnabled }),
+    onSuccess: async (result) => {
+      queryClient.setQueryData(queryKeys.versionCheckEnabled, result);
+      // Enabling performs an immediate check on the backend. Refetch its cached
+      // result instead of issuing another manual check from the browser.
+      await queryClient.invalidateQueries({ queryKey: queryKeys.versionInfo });
+    },
+  });
+
+  if (version.isLoading || enabled.isLoading)
+    return <Skeleton className="jv-settings__skeleton" />;
+
+  if (version.isError || !version.data || enabled.isError || !enabled.data)
+    return (
+      <SettingsSection
+        title="Version checking"
+        intro="Keep this installation informed about Journiv releases."
+        footer={
+          <Button
+            variant="secondary"
+            onClick={() => {
+              void version.refetch();
+              void enabled.refetch();
+            }}
+          >
+            Try again
+          </Button>
+        }
+      >
+        <Alert variant="destructive">
+          <AlertDescription>
+            Version management couldn’t be loaded. Check the connection and try
+            again.
+          </AlertDescription>
+        </Alert>
+      </SettingsSection>
+    );
+
+  const info = version.data;
+  const lastChecked = dateTime(info.last_checked);
+  const updateAvailable = Boolean(info.update_available);
+  const latestVersion = info.latest_version;
+  const versionStatus = updateAvailable
+    ? `Update available${latestVersion ? `: ${latestVersion}` : ""}`
+    : latestVersion
+      ? "Up to date"
+      : enabled.data.enabled
+        ? "No update information yet"
+        : "Automatic checks are off";
+  const lastCheckStatus = !lastChecked
+    ? "Not checked yet"
+    : info.last_check_success === false
+      ? `Couldn’t complete ${lastChecked}`
+      : `Checked ${lastChecked}`;
+
+  return (
+    <SettingsSection
+      title="Version checking"
+      intro="Manage release checks for this Journiv installation."
+      footer={
+        <Button
+          variant="default"
+          disabled={check.isPending || cooldown.seconds > 0}
+          onClick={() => {
+            setFeedback(undefined);
+            check.mutate();
+          }}
+        >
+          {check.isPending ? (
+            <Spinner aria-hidden="true" data-icon="inline-start" />
+          ) : null}
+          {check.isPending
+            ? "Checking…"
+            : cooldown.seconds > 0
+              ? `Try again in ${retryDuration(cooldown.seconds)}`
+              : "Check for updates"}
+        </Button>
+      }
+    >
+      <SettingsRow label="Installed version">
+        <p className="jv-settings-row__readonly">{info.current_version}</p>
+      </SettingsRow>
+      <SettingsRow label="Update status">
+        <p className="jv-settings-row__readonly">{versionStatus}</p>
+        {updateAvailable && info.update_url ? (
+          <a href={info.update_url} target="_blank" rel="noreferrer">
+            View update
+          </a>
+        ) : null}
+        {info.changelog_url ? (
+          <a href={info.changelog_url} target="_blank" rel="noreferrer">
+            View changelog
+          </a>
+        ) : null}
+      </SettingsRow>
+      <SettingsRow label="Last check">
+        <p className="jv-settings-row__readonly">{lastCheckStatus}</p>
+      </SettingsRow>
+      <SettingsRow
+        label="Automatic version checking"
+        htmlFor="automatic-version-checking"
+        description={
+          enabled.data.enabled
+            ? "Journiv checks for updates automatically."
+            : "Automatic checks are off. You can still check manually."
+        }
+      >
+        <Switch
+          id="automatic-version-checking"
+          checked={enabled.data.enabled}
+          disabled={automaticChecks.isPending}
+          onCheckedChange={(nextEnabled) => {
+            automaticChecks.mutate(nextEnabled);
+          }}
+        />
+        {automaticChecks.isError ? (
+          <FieldError>
+            Automatic version checking couldn’t be updated. Try again.
+          </FieldError>
+        ) : null}
+      </SettingsRow>
+      <SettingsRow
+        label="Check now"
+        description="Checks the release service immediately. It may be rate limited."
+      >
+        {feedback === "success" ? (
+          <FieldDescription role="status">
+            Update check complete.
+          </FieldDescription>
+        ) : null}
+        {feedback === "rate-limited" && cooldown.seconds > 0 ? (
+          <FieldDescription role="status">
+            The release service is rate limiting this installation. Try again in
+            {` ${retryDuration(cooldown.seconds)}.`}
+          </FieldDescription>
+        ) : null}
+        {feedback === "failed" ? (
+          <FieldError>
+            Journiv couldn’t check for updates. The cached version details are
+            still shown above.
+          </FieldError>
+        ) : null}
+      </SettingsRow>
+    </SettingsSection>
+  );
+}
+
+function RegistrationForm({
+  defaultEmail,
+  onRegistered,
+}: {
+  defaultEmail: string;
+  onRegistered: () => Promise<void>;
+}) {
+  const licenseId = useId();
+  const emailId = useId();
+  const discordId = useId();
+  const initialEmail = useRef(defaultEmail);
+  const emailEdited = useRef(false);
+  const [license, setLicense] = useState("");
+  const [email, setEmail] = useState(defaultEmail);
+  const [discord, setDiscord] = useState("");
+  const [touched, setTouched] = useState(false);
+  const [succeeded, setSucceeded] = useState(false);
+  const [failure, setFailure] = useState<string>();
+
+  // Prefill from the signed-in admin, but only while the field is still
+  // pristine. `currentUserQuery` can resolve after this form has mounted with an
+  // empty default, and a late fill must never overwrite an address the admin has
+  // already begun typing.
+  useEffect(() => {
+    if (emailEdited.current || email.length > 0 || !defaultEmail) return;
+    initialEmail.current = defaultEmail;
+    setEmail(defaultEmail);
+  }, [defaultEmail, email]);
+
+  const licenseIssue = LICENSE_KEY_PATTERN.test(license.trim())
+    ? null
+    : "Enter the license key beginning with lic_.";
+  const emailIssue = EMAIL_PATTERN.test(email.trim())
+    ? null
+    : "Enter a valid email address.";
+  const valid = !licenseIssue && !emailIssue;
+  const dirty =
+    !succeeded &&
+    (license.length > 0 ||
+      email !== initialEmail.current ||
+      discord.length > 0);
+  useSettingsDirty(dirty);
+
+  const registration = useMutation({
+    mutationFn: () => {
+      const body: LicenseRegisterRequest = {
+        license: license.trim(),
+        email: email.trim(),
+        ...(discord.trim() ? { discord_id: discord.trim() } : {}),
+      };
+      return api.registerLicense(body);
+    },
+    onSuccess: async (result) => {
+      if (!result.successful) {
+        // `error_message` is the endpoint's user-facing reason (already bound,
+        // email mismatch, rate limited, …). Prefer it; fall back to a generic
+        // per-case string when the server sent nothing usable.
+        const reason = result.error_message?.trim();
+        setFailure(
+          reason ||
+            (result.rate_limited
+              ? "License registration is temporarily rate limited. Try again later."
+              : "This license couldn’t be registered. Check the key and email, then try again."),
+        );
+        return;
+      }
+      setLicense("");
+      setDiscord("");
+      setTouched(false);
+      setSucceeded(true);
+      await onRegistered();
+    },
+    onError: (error) => {
+      const clientError = error instanceof ApiError && error.status;
+      setFailure(
+        clientError && clientError >= 400 && clientError < 500
+          ? "This license couldn’t be registered. Check the key and email, then try again."
+          : "License registration couldn’t be completed. Check the connection and try again.",
+      );
+    },
+  });
+
+  function update(set: (value: string) => void, value: string) {
+    setSucceeded(false);
+    setFailure(undefined);
+    set(value);
+  }
+
+  function submit() {
+    setTouched(true);
+    setSucceeded(false);
+    setFailure(undefined);
+    if (!valid || registration.isPending) return;
+    registration.mutate();
+  }
+
+  return (
+    <SettingsSection
+      title="Register a license"
+      intro="Add a Journiv Plus license to this installation."
+      footer={
+        <Button
+          type="submit"
+          form="license-registration"
+          disabled={registration.isPending}
+        >
+          {registration.isPending ? (
+            <Spinner aria-hidden="true" data-icon="inline-start" />
+          ) : null}
+          {registration.isPending ? "Registering…" : "Register license"}
+        </Button>
+      }
+    >
+      {succeeded ? (
+        <Alert role="status">
+          <AlertDescription>
+            License registered. Refreshing its installation details…
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {failure ? (
+        <Alert variant="destructive">
+          <AlertDescription>{failure}</AlertDescription>
+        </Alert>
+      ) : null}
+      <form
+        id="license-registration"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+      >
+        <FieldGroup className="jv-settings-form">
+          <Field data-invalid={touched && Boolean(licenseIssue)}>
+            <FieldLabel htmlFor={licenseId}>License key</FieldLabel>
+            <Input
+              id={licenseId}
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              value={license}
+              onChange={(event) => update(setLicense, event.target.value)}
+              aria-invalid={touched && Boolean(licenseIssue)}
+              aria-describedby={
+                touched && licenseIssue ? `${licenseId}-error` : undefined
+              }
+            />
+            {touched && licenseIssue ? (
+              <FieldError id={`${licenseId}-error`}>{licenseIssue}</FieldError>
+            ) : null}
+          </Field>
+          <Field data-invalid={touched && Boolean(emailIssue)}>
+            <FieldLabel htmlFor={emailId}>Admin email</FieldLabel>
+            <Input
+              id={emailId}
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => {
+                emailEdited.current = true;
+                update(setEmail, event.target.value);
+              }}
+              aria-invalid={touched && Boolean(emailIssue)}
+              aria-describedby={
+                touched && emailIssue ? `${emailId}-error` : undefined
+              }
+            />
+            {touched && emailIssue ? (
+              <FieldError id={`${emailId}-error`}>{emailIssue}</FieldError>
+            ) : null}
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={discordId}>Discord ID (optional)</FieldLabel>
+            <Input
+              id={discordId}
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              value={discord}
+              onChange={(event) => update(setDiscord, event.target.value)}
+              aria-describedby={`${discordId}-description`}
+            />
+            <FieldDescription id={`${discordId}-description`}>
+              Add the Discord ID associated with your Plus membership, if you
+              have one.
+            </FieldDescription>
+          </Field>
+        </FieldGroup>
+      </form>
+    </SettingsSection>
+  );
+}
+
+function LicenseManagement() {
+  const queryClient = useQueryClient();
+  const user = useQuery(currentUserQuery());
+  const license = useQuery(licenseInfoQuery());
+  const noLicense = license.isError && isNotFound(license.error);
+
+  async function refreshLicense() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.licenseInfo }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.instanceConfig }),
+    ]);
+  }
+
+  if (license.isLoading) return <Skeleton className="jv-settings__skeleton" />;
+
+  if (noLicense)
+    return (
+      <RegistrationForm
+        defaultEmail={user.data?.email ?? ""}
+        onRegistered={refreshLicense}
+      />
+    );
+
+  if (license.isError || !license.data)
+    return (
+      <SettingsSection
+        title="Journiv Plus"
+        intro="View the license registered to this installation."
+        footer={
+          <Button variant="secondary" onClick={() => void license.refetch()}>
+            Try again
+          </Button>
+        }
+      >
+        <Alert variant="destructive">
+          <AlertDescription>
+            License details couldn’t be loaded. Check the connection and try
+            again.
+          </AlertDescription>
+        </Alert>
+      </SettingsSection>
+    );
+
+  const info = license.data;
+  const expiresAt = dateTime(info.subscription_expires_at);
+  const expired =
+    Boolean(info.subscription_expires_at) &&
+    new Date(info.subscription_expires_at as string).getTime() < Date.now();
+  const status = info.is_active ? "Active" : expired ? "Expired" : "Inactive";
+
+  return (
+    <>
+      <SettingsSection
+        title="Journiv Plus"
+        intro="This license is registered to the current installation."
+      >
+        <SettingsRow label="Status">
+          <p className="jv-settings-row__readonly">{status}</p>
+        </SettingsRow>
+        <SettingsRow label="Tier">
+          <p className="jv-settings-row__readonly">
+            {info.tier ?? "No tier reported"}
+          </p>
+        </SettingsRow>
+        <SettingsRow label="License type">
+          <p className="jv-settings-row__readonly">
+            {info.license_type === "lifetime" ? "Lifetime" : "Subscription"}
+          </p>
+        </SettingsRow>
+        {expiresAt ? (
+          <SettingsRow label={expired ? "Expired" : "Expires"}>
+            <p className="jv-settings-row__readonly">{expiresAt}</p>
+          </SettingsRow>
+        ) : null}
+        {info.registered_email ? (
+          <SettingsRow label="Registered email">
+            <p className="jv-settings-row__readonly">{info.registered_email}</p>
+          </SettingsRow>
+        ) : null}
+        {info.discord_id ? (
+          <SettingsRow label="Discord ID">
+            <p className="jv-settings-row__readonly">{info.discord_id}</p>
+          </SettingsRow>
+        ) : null}
+      </SettingsSection>
+      {!info.is_active ? (
+        <RegistrationForm
+          defaultEmail={user.data?.email ?? ""}
+          onRegistered={refreshLicense}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export function UpdatesLicensePage() {
+  return (
+    <div className="jv-settings__body">
+      <VersionManagement />
+      <LicenseManagement />
+    </div>
+  );
+}

--- a/frontend/src/features/settings/admin/useCheckCooldown.test.ts
+++ b/frontend/src/features/settings/admin/useCheckCooldown.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCheckCooldown } from "./useCheckCooldown";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useCheckCooldown", () => {
+  it("measures the countdown from begin(), not from mount", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useCheckCooldown());
+    expect(result.current.seconds).toBe(0);
+
+    // The screen sat open for five minutes before the rate limit came back.
+    act(() => {
+      vi.advanceTimersByTime(5 * 60_000);
+    });
+    act(() => {
+      result.current.begin(120);
+    });
+
+    // 120s exactly — not 120 plus the stale five minutes since mount.
+    expect(result.current.seconds).toBe(120);
+  });
+
+  it("ticks down every second and clears itself when the window elapses", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useCheckCooldown());
+
+    act(() => {
+      result.current.begin(3);
+    });
+    expect(result.current.seconds).toBe(3);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.seconds).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.seconds).toBe(0);
+  });
+
+  it("clear() ends the cooldown immediately", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useCheckCooldown());
+
+    act(() => {
+      result.current.begin(60);
+    });
+    expect(result.current.seconds).toBe(60);
+
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.seconds).toBe(0);
+  });
+});

--- a/frontend/src/features/settings/admin/useCheckCooldown.ts
+++ b/frontend/src/features/settings/admin/useCheckCooldown.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Keeps a server-supplied rate limit visible and prevents accidental repeated
+ * version checks locally; the backend remains authoritative when this screen is
+ * reopened.
+ *
+ * `begin()` re-seeds `now` with the current time so the first render after a
+ * rate-limited response measures the countdown against the moment the limit was
+ * received, never against a stale mount-time value.
+ */
+export function useCheckCooldown() {
+  const [until, setUntil] = useState<number>();
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!until) return;
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [until]);
+
+  const seconds = until ? Math.max(0, Math.ceil((until - now) / 1000)) : 0;
+
+  useEffect(() => {
+    if (until && seconds === 0) setUntil(undefined);
+  }, [seconds, until]);
+
+  return {
+    seconds,
+    begin: (retryAfterSeconds: number) => {
+      const start = Date.now();
+      setNow(start);
+      setUntil(start + retryAfterSeconds * 1000);
+    },
+    clear: () => setUntil(undefined),
+  };
+}

--- a/frontend/src/features/settings/settings.routing.test.tsx
+++ b/frontend/src/features/settings/settings.routing.test.tsx
@@ -33,7 +33,11 @@ vi.mock("../../api/client/api", () => ({
     activities: vi.fn(),
     goals: vi.fn(),
     versionInfo: vi.fn(),
+    versionCheckEnabled: vi.fn(),
+    updateVersionCheckEnabled: vi.fn(),
+    forceVersionCheck: vi.fn(),
     licenseInfo: vi.fn(),
+    registerLicense: vi.fn(),
     integrationStatus: vi.fn(),
     adminUsers: vi.fn(),
     createAdminUser: vi.fn(),
@@ -142,11 +146,24 @@ beforeEach(() => {
     current_version: "1.0.0",
     install_id: "install-1",
   });
+  vi.mocked(api.versionCheckEnabled).mockResolvedValue({ enabled: true });
+  vi.mocked(api.updateVersionCheckEnabled).mockImplementation(
+    async ({ enabled }) => ({ enabled }),
+  );
+  vi.mocked(api.forceVersionCheck).mockResolvedValue({
+    success: true,
+    message: "Version check completed successfully",
+    version_info: {
+      current_version: "1.0.0",
+      install_id: "install-1",
+    },
+  });
   vi.mocked(api.licenseInfo).mockResolvedValue({
     is_active: false,
     license_type: "lifetime",
     install_id: "install-1",
   });
+  vi.mocked(api.registerLicense).mockResolvedValue({ successful: true });
   vi.mocked(api.integrationStatus).mockResolvedValue({
     provider: "immich",
     status: "disconnected",
@@ -228,6 +245,24 @@ describe("Settings routing and modal", () => {
     ).toBe("page");
   });
 
+  it("shows Updates & license only to admins and mounts its routed page", async () => {
+    vi.mocked(api.me).mockResolvedValue(adminUser);
+    const view = await renderRoute("/settings/admin/updates-license");
+    const dialog = await screen.findByRole("dialog");
+
+    expect(view.router.state.location.pathname).toBe(
+      "/settings/admin/updates-license",
+    );
+    expect(
+      await within(dialog).findByRole("heading", { name: "Version checking" }),
+    ).toBeTruthy();
+    expect(
+      within(dialog)
+        .getByRole("link", { name: "Updates & license" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+  });
+
   it("redirects a non-admin deep link before mounting the admin list", async () => {
     const view = await renderRoute("/settings/admin/users");
 
@@ -236,6 +271,15 @@ describe("Settings routing and modal", () => {
     );
     expect(api.adminUsers).not.toHaveBeenCalled();
     expect(screen.queryByRole("link", { name: "Users" })).toBeNull();
+  });
+
+  it("redirects a non-admin updates and license deep link", async () => {
+    const view = await renderRoute("/settings/admin/updates-license");
+
+    await waitFor(() =>
+      expect(view.router.state.location.pathname).toBe("/settings/profile"),
+    );
+    expect(api.versionCheckEnabled).not.toHaveBeenCalled();
   });
 
   it("switches section from the in-modal navigation without closing", async () => {

--- a/frontend/src/features/settings/settingsNav.ts
+++ b/frontend/src/features/settings/settingsNav.ts
@@ -16,6 +16,7 @@ export type SettingsRouteTo =
   | "/settings/security"
   | "/settings/appearance"
   | "/settings/admin/users"
+  | "/settings/admin/updates-license"
   | "/settings/integrations"
   | "/settings/data/import"
   | "/settings/data/export"
@@ -29,6 +30,7 @@ export type SettingsNavItem = {
     | "security"
     | "appearance"
     | "users"
+    | "updatesLicense"
     | "integrations"
     | "import"
     | "export"
@@ -70,7 +72,14 @@ export const SETTINGS_NAV: SettingsNavGroup[] = [
   {
     label: "Administration",
     adminOnly: true,
-    items: [{ id: "users", label: "Users", to: "/settings/admin/users" }],
+    items: [
+      { id: "users", label: "Users", to: "/settings/admin/users" },
+      {
+        id: "updatesLicense",
+        label: "Updates & license",
+        to: "/settings/admin/updates-license",
+      },
+    ],
   },
   {
     label: "Data & backup",

--- a/tests/unit/test_license_endpoints.py
+++ b/tests/unit/test_license_endpoints.py
@@ -1,0 +1,97 @@
+"""Unit tests for the license management endpoints."""
+import pytest
+
+from app.api.v1.endpoints import license
+from app.models.user import User
+from app.schemas.license import LicenseRegisterRequest, LicenseRegisterResponse
+
+
+class _FakeRequestState:
+    request_id = "test-request-id"
+
+
+class _FakeRequest:
+    state = _FakeRequestState()
+
+
+def _admin() -> User:
+    return User(
+        email="admin@example.com",
+        password="hashed-password",
+        name="Admin",
+        role="admin",
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_license_propagates_rate_limit(monkeypatch):
+    """A rate-limited registration must surface `rate_limited` / `retry_after`.
+
+    The service returns these fields on `PlusRateLimitError`; the endpoint used
+    to rebuild the response without them, so the client could never show a
+    cooldown and told the admin to check their key instead.
+    """
+
+    class RateLimitedService:
+        def __init__(self, _db):
+            pass
+
+        async def register_license(self, **_kwargs):
+            return {
+                "successful": False,
+                "signed_license": None,
+                "error_message": "Rate limit exceeded. Please try again in 2 minutes.",
+                "rate_limited": True,
+                "retry_after": 120,
+            }
+
+    monkeypatch.setattr(license, "LicenseService", RateLimitedService)
+
+    result = await license.register_license(
+        http_request=_FakeRequest(),
+        request=LicenseRegisterRequest(
+            license="lic_abcdefghijklmnopqrstuvwxyz123456",
+            email="admin@example.com",
+        ),
+        db=object(),
+        current_user=_admin(),
+    )
+
+    assert isinstance(result, LicenseRegisterResponse)
+    assert result.successful is False
+    assert result.rate_limited is True
+    assert result.retry_after == 120
+    assert result.error_message == "Rate limit exceeded. Please try again in 2 minutes."
+
+
+@pytest.mark.asyncio
+async def test_register_license_preserves_server_failure_reason(monkeypatch):
+    """A non-rate-limited failure must keep the server's `error_message`."""
+
+    class RejectingService:
+        def __init__(self, _db):
+            pass
+
+        async def register_license(self, **_kwargs):
+            return {
+                "successful": False,
+                "signed_license": None,
+                "error_message": "License already bound to another installation.",
+            }
+
+    monkeypatch.setattr(license, "LicenseService", RejectingService)
+
+    result = await license.register_license(
+        http_request=_FakeRequest(),
+        request=LicenseRegisterRequest(
+            license="lic_abcdefghijklmnopqrstuvwxyz123456",
+            email="admin@example.com",
+        ),
+        db=object(),
+        current_user=_admin(),
+    )
+
+    assert result.successful is False
+    assert result.rate_limited is False
+    assert result.retry_after is None
+    assert result.error_message == "License already bound to another installation."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only **Updates & license** settings page.
  * Admins can view version and license status, check for updates, enable automatic checks, and register a license.
  * Added clear handling for rate limits, cooldowns, and server-provided registration errors.
  * Added retry behavior for temporary network and server failures.

* **Documentation**
  * Updated Support documentation to describe version checks, automatic updates, license registration, and rate-limit handling.

* **Bug Fixes**
  * License registration responses now preserve rate-limit details for accurate user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->