### PR TITLE
feat: add support for markdown writing

### DIFF
--- a/frontend/docs/features/editor.md
+++ b/frontend/docs/features/editor.md
@@ -24,6 +24,53 @@ refresh ordering, and do not mark prose dirty. There is no arbitrary timezone
 selector. Date conversion helpers own DST behaviour; never persist the
 browser-local Date serialization.
 
+## Markdown input
+
+Markdown is an *input method*, never a stored format. Typed shorthand is
+rewritten into the same Delta the toolbar would produce; persisted content stays
+a Quill Delta. Two pieces cooperate:
+
+- **`markdownShortcuts.ts`** owns headings (`#`/`##`/`###`), the quote marker
+  (`>`) and the inline runs (`**b**`/`__b__`, `*i*`/`_i_`, `~~s~~`,
+  `[text](url)`). Its allowlist test pins it to the Gate-1 formats so a rule can
+  never widen what the editor saves. It is installed by `QuillSurface` on the
+  writing surface only; the read-only reader never rewrites. Rewrites apply
+  synchronously inside the triggering text-change — nothing is deferred, because
+  this module never performs a `<p>`→`<ol>` block-blot swap, which is the one
+  thing Quill will not do mid-text-change.
+- **Bullet and ordered lists are Quill's own `list autofill` keyboard binding**,
+  not this module. `QuillSurface` narrows that binding's prefix to
+  `^\s*?(1\.|-|\*)$`: `- ` / `* ` → bullet, `1. ` → ordered (Quill renumbers the
+  items itself). `2. `, `10. `, `[ ] ` and `[x] ` are dropped from the prefix so
+  they stay literal — Journiv has no checklist format, and an
+  `unchecked`/`checked` list value would make `getContents()` throw.
+
+These are typing shortcuts, not a CommonMark parser:
+
+- **Boundaries / escaping are positional.** A heading or quote marker fires only
+  when the text from line start to caret is *exactly* the marker plus one space,
+  so `\# `, `  # ` and `a > b ` stay literal. An inline run fires only when its
+  opening delimiter is at line start or right after whitespace, so `foo_bar_`,
+  `2*3*4`, `word**x**` and a delimiter after `(` stay literal. A `\` before a
+  delimiter blocks the match because it is non-whitespace; backslashes are never
+  consumed or interpreted. Four or more hashes, `***x***`, `**_x_**`, `****`,
+  `` `code` ``, `![img]()` and malformed or unsafe links (`[x]()`,
+  `[x](javascript:…)`, `[x](ftp:…)`) are left completely literal — never
+  partially transformed.
+- A line that already carries a block format is left alone.
+- Each `markdownShortcuts.ts` rewrite is one `"user"` change bracketed by
+  `history.cutoff()`, so a single undo of a bare marker restores the literal
+  characters; if content was already typed after the marker, the first undo
+  removes that content and the second reverts the format. Quill's list binding
+  brackets its transform the same way.
+- The toolbar's "Markdown shortcuts" control opens `MarkdownHelpDialog`, a
+  reference shown through the shared adaptive overlay. Formatting-toggle
+  `aria-pressed` state stays in sync because the rewrite re-emits editor state.
+
+Inline `code` and code blocks are deliberately out of scope: they need a Gate-1
+contract expansion (this document, `deltaProfile.ts`, the backend guard, prose
+styles, and the reader) before an input shortcut for them can exist.
+
 ## Attachments
 
 Server identity comes first. On a new Entry, the first media attachment or
@@ -145,9 +192,11 @@ fetch failure is a quiet retry state rather than a failed save.
 ## Quill boundary
 
 Prose styles target semantic elements, never Quill. The Quill adapter stylesheet
-and media blots are the only Quill-aware styling/code boundary. Reader and
-Editor share the same accepted-document guard. Every media kind accepted by the
-guard must be in EDITOR_FORMATS; a test protects this coupling.
+and media blots are the only Quill-aware styling/code boundary. `QuillSurface`,
+`QuillReader`, `deltaProfile.ts`, and `markdownShortcuts.ts` are the only
+Quill-aware code. Reader and Editor share the same accepted-document guard.
+Every media kind accepted by the guard must be in EDITOR_FORMATS; a test
+protects this coupling.
 
 ## Known gaps
 

--- a/frontend/src/features/editor/EditorToolbar.test.tsx
+++ b/frontend/src/features/editor/EditorToolbar.test.tsx
@@ -119,4 +119,15 @@ describe("EditorToolbar", () => {
     await userEvent.click(screen.getByRole("button", { name: "Remove" }));
     expect(surface.setLink).toHaveBeenCalledWith(false);
   });
+
+  it("opens the markdown shortcuts reference", async () => {
+    render(<EditorToolbar editor={editor()} state={state()} />);
+    const help = screen.getByRole("button", { name: "Markdown shortcuts" });
+    expect(help.getAttribute("aria-pressed")).toBeNull();
+
+    await userEvent.click(help);
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain("**bold**");
+    expect(dialog.textContent).toContain("Numbered list");
+  });
 });

--- a/frontend/src/features/editor/EditorToolbar.tsx
+++ b/frontend/src/features/editor/EditorToolbar.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../components/ui/dialog";
 import {
   Bold,
+  CircleHelp,
   Heading1,
   Heading2,
   Heading3,
@@ -36,6 +37,7 @@ import type {
   QuillSurfaceHandle,
 } from "./QuillSurface";
 import { validateLinkUrl } from "./linkPolicy";
+import { MarkdownHelpDialog } from "./MarkdownHelpDialog";
 import {
   MomentDetailsPopover,
   type MomentDetailsPanelProps,
@@ -74,6 +76,7 @@ export function EditorToolbar({
   const [linkOpen, setLinkOpen] = useState(false);
   const [linkValue, setLinkValue] = useState("");
   const [linkError, setLinkError] = useState("");
+  const [helpOpen, setHelpOpen] = useState(false);
   const linkActive = typeof state.formats.link === "string";
 
   const toggleInline = (name: InlineFormat) => editor?.toggleInline(name);
@@ -235,10 +238,19 @@ export function EditorToolbar({
             </span>
           </>
         )}
+        <span className="jv-toolbar__divider" aria-hidden="true" />
+        <ToolbarButton
+          label="Markdown shortcuts"
+          onClick={() => setHelpOpen(true)}
+        >
+          <CircleHelp aria-hidden="true" size={16} />
+        </ToolbarButton>
         <span className="jv-toolbar__count">
           {state.wordCount} {state.wordCount === 1 ? "word" : "words"}
         </span>
       </div>
+
+      <MarkdownHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
 
       <Dialog open={linkOpen} onOpenChange={setLinkOpen}>
         <DialogContent>

--- a/frontend/src/features/editor/MarkdownHelpDialog.test.tsx
+++ b/frontend/src/features/editor/MarkdownHelpDialog.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { setTestViewportWidth } from "../../test/viewport";
+import { MarkdownHelpDialog } from "./MarkdownHelpDialog";
+
+describe("MarkdownHelpDialog", () => {
+  it.each([
+    ["regular", 1440],
+    ["compact", 390],
+  ])("lists the supported shorthand (%s)", async (_name, width) => {
+    setTestViewportWidth(width);
+    render(<MarkdownHelpDialog open onOpenChange={() => {}} />);
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Markdown shortcuts",
+    });
+    for (const syntax of [
+      "# ",
+      "- ",
+      "1. ",
+      "> ",
+      "**bold**",
+      "[text](https://…)",
+    ]) {
+      expect(dialog.textContent).toContain(syntax);
+    }
+  });
+
+  it("closes on Escape", async () => {
+    setTestViewportWidth(1440);
+    const onOpenChange = vi.fn();
+    render(<MarkdownHelpDialog open onOpenChange={onOpenChange} />);
+    await screen.findByRole("dialog");
+
+    await userEvent.keyboard("{Escape}");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders nothing while closed", () => {
+    render(<MarkdownHelpDialog open={false} onOpenChange={() => {}} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/frontend/src/features/editor/MarkdownHelpDialog.tsx
+++ b/frontend/src/features/editor/MarkdownHelpDialog.tsx
@@ -1,0 +1,49 @@
+import { AppAdaptiveDialog } from "../../components/journiv/AppAdaptiveDialog";
+
+type MarkdownHelpDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * A quiet reference for the markdown input shortcuts the writing surface
+ * understands (markdownShortcuts.ts). It is informational only — no settings,
+ * nothing to save — so it uses the shared adaptive overlay (Drawer on compact,
+ * Dialog otherwise) rather than a bespoke surface, and carries no footer.
+ */
+const SHORTCUTS: ReadonlyArray<{ syntax: string; meaning: string }> = [
+  { syntax: "# ", meaning: "Heading (## and ### for smaller headings)" },
+  { syntax: "- ", meaning: "Bulleted list (* also works)" },
+  { syntax: "1. ", meaning: "Numbered list (start with 1.)" },
+  { syntax: "> ", meaning: "Quote" },
+  { syntax: "**bold**", meaning: "Bold (__bold__ also works)" },
+  { syntax: "*italic*", meaning: "Italic (_italic_ also works)" },
+  { syntax: "~~strike~~", meaning: "Strikethrough" },
+  { syntax: "[text](https://…)", meaning: "Link" },
+];
+
+export function MarkdownHelpDialog({
+  open,
+  onOpenChange,
+}: MarkdownHelpDialogProps) {
+  return (
+    <AppAdaptiveDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Markdown shortcuts"
+      description="Type these while writing and Journiv formats the text for you. Undo once to get the characters back."
+      size="sm"
+    >
+      <dl className="jv-markdown-help">
+        {SHORTCUTS.map((item) => (
+          <div className="jv-markdown-help__row" key={item.syntax}>
+            <dt>
+              <code>{item.syntax}</code>
+            </dt>
+            <dd>{item.meaning}</dd>
+          </div>
+        ))}
+      </dl>
+    </AppAdaptiveDialog>
+  );
+}

--- a/frontend/src/features/editor/QuillSurface.tsx
+++ b/frontend/src/features/editor/QuillSurface.tsx
@@ -18,6 +18,7 @@ import {
   JOURNIV_DELTA_FORMATS,
   stripUploadPlaceholders,
 } from "./deltaProfile";
+import { installMarkdownShortcuts } from "./markdownShortcuts";
 import "./mediaBlots";
 import "./quill-adapter.css";
 import {
@@ -562,6 +563,22 @@ export const QuillSurface = forwardRef<QuillSurfaceHandle, QuillSurfaceProps>(
       // Belt and braces: loading a document is not something to undo.
       quill.history.clear();
 
+      // Quill's built-in "list autofill" keyboard binding turns
+      // `1.`/`2.`/`- `/`* `/`[ ] `/`[x] ` into a list on space. Journiv keeps
+      // ordered lists to a `1.` trigger (Quill renumbers the items itself) and
+      // has no checklist format — an `unchecked`/`checked` value is outside the
+      // Gate-1 allowlist and makes `getContents()` throw — so the prefix is
+      // narrowed to the three kinds Journiv stores. Headings and quotes are
+      // handled separately by markdownShortcuts.ts.
+      for (const binding of quill.keyboard.bindings[" "] ?? []) {
+        if (
+          binding.prefix instanceof RegExp &&
+          binding.prefix.source.includes("\\[x\\]")
+        ) {
+          binding.prefix = /^\s*?(1\.|-|\*)$/;
+        }
+      }
+
       const getWordCount = () => {
         const text = quill.getText().trim();
         return text ? text.split(/\s+/u).length : 0;
@@ -683,7 +700,20 @@ export const QuillSurface = forwardRef<QuillSurfaceHandle, QuillSurfaceProps>(
       quill.root.addEventListener("compositionend", handleCompositionEnd);
       emitState(null);
 
+      // Markdown input shortcuts are a writing-surface affordance only; the
+      // read-only reader must never rewrite what it renders. The rewrite is a
+      // "user" change, so it re-enters handleTextChange like any edit —
+      // marking the body dirty and refreshing toolbar state.
+      const teardownMarkdown = readOnlyRef.current
+        ? undefined
+        : installMarkdownShortcuts(quill, {
+            isComposing: () => composingRef.current,
+            onApplied: (caretIndex) =>
+              emitState({ index: caretIndex, length: 0 }),
+          });
+
       return () => {
+        teardownMarkdown?.();
         quill.off("text-change", handleTextChange);
         quill.off("selection-change", handleSelectionChange);
         quill.root.removeEventListener(

--- a/frontend/src/features/editor/QuillSurface.tsx
+++ b/frontend/src/features/editor/QuillSurface.tsx
@@ -704,16 +704,14 @@ export const QuillSurface = forwardRef<QuillSurfaceHandle, QuillSurfaceProps>(
       // read-only reader must never rewrite what it renders. The rewrite is a
       // "user" change, so it re-enters handleTextChange like any edit —
       // marking the body dirty and refreshing toolbar state.
-      const teardownMarkdown = readOnlyRef.current
-        ? undefined
-        : installMarkdownShortcuts(quill, {
-            isComposing: () => composingRef.current,
-            onApplied: (caretIndex) =>
-              emitState({ index: caretIndex, length: 0 }),
-          });
+      const teardownMarkdown = installMarkdownShortcuts(quill, {
+        isEnabled: () => !readOnlyRef.current,
+        isComposing: () => composingRef.current,
+        onApplied: (caretIndex) => emitState({ index: caretIndex, length: 0 }),
+      });
 
       return () => {
-        teardownMarkdown?.();
+        teardownMarkdown();
         quill.off("text-change", handleTextChange);
         quill.off("selection-change", handleSelectionChange);
         quill.root.removeEventListener(

--- a/frontend/src/features/editor/editor.css
+++ b/frontend/src/features/editor/editor.css
@@ -309,6 +309,41 @@
    components/ui/ui.css (with its compact-width bottom-sheet override) since the
    Journals feature now uses it too. See docs/architecture/frontend.md. */
 
+/* Markdown shortcuts reference, opened from the toolbar's help control and
+   shown through the shared adaptive overlay (MarkdownHelpDialog). */
+.jv-markdown-help {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.jv-markdown-help__row {
+  display: grid;
+  grid-template-columns: minmax(6rem, max-content) 1fr;
+  gap: var(--space-2) var(--space-4);
+  align-items: baseline;
+}
+
+.jv-markdown-help__row dt {
+  margin: 0;
+}
+
+.jv-markdown-help__row dd {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+}
+
+.jv-markdown-help__row code {
+  padding: 0.1em var(--space-1);
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+  color: var(--foreground);
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+
 /* ---- moment details popover ----------------------------------------------
    Metadata editing (mood, location, weather, people, tags), opened from the
    toolbar's Insert group. Its own scroll container — it is an overlay, not the

--- a/frontend/src/features/editor/markdownShortcuts.integration.test.tsx
+++ b/frontend/src/features/editor/markdownShortcuts.integration.test.tsx
@@ -1,0 +1,284 @@
+import { act, createRef } from "react";
+import { render, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Quill from "quill";
+import { describe, expect, it, vi } from "vitest";
+import type { QuillDelta, QuillOp } from "../../api/generated/types.gen";
+import { isQuillDocumentDelta } from "./deltaProfile";
+import { QuillSurface, type QuillSurfaceHandle } from "./QuillSurface";
+
+/**
+ * `userEvent.type` reads `{` and `[` as the start of special key syntax;
+ * doubling them types the literal character. `*`, `_`, `~`, `>`, `]` and `)`
+ * are already literal.
+ */
+function literal(text: string) {
+  return text.replace(/\[/g, "[[").replace(/\{/g, "{{");
+}
+
+function mountEditor(initial = "\n") {
+  const ref = createRef<QuillSurfaceHandle>();
+  const onStateChange = vi.fn();
+  const view = render(
+    <QuillSurface
+      ref={ref}
+      editorId="markdown"
+      initialContent={{ ops: [{ insert: initial }] }}
+      onStateChange={onStateChange}
+    />,
+  );
+  const editor = within(view.container).getByLabelText("Entry body");
+  const quill = Quill.find(editor.closest(".jv-prose") as Element) as Quill;
+  const ops = (): QuillOp[] => {
+    const contents = ref.current?.getContents() as QuillDelta | undefined;
+    return contents?.ops ?? [];
+  };
+  return { ref, quill, editor, onStateChange, ops };
+}
+
+const attributedOp = (ops: QuillOp[], attr: string) =>
+  ops.find((op) => op.attributes?.[attr] != null);
+
+/** First op's text with any trailing newlines trimmed — jsdom's `userEvent`
+ *  leaves an extra empty paragraph that the product does not. */
+const firstText = (ops: QuillOp[]) => {
+  const value = ops[0]?.insert;
+  return (typeof value === "string" ? value : "").replace(/\n+$/, "");
+};
+
+describe("markdown shortcuts in the writing surface", () => {
+  it("rewrites a heading marker and keeps a saveable Delta", async () => {
+    const { ref, editor, ops } = mountEditor();
+    await userEvent.type(editor, "## Morning");
+
+    expect(ops()).toContainEqual({ insert: "\n", attributes: { header: 2 } });
+    expect(ops()[0]).toEqual({ insert: "Morning" });
+    expect(isQuillDocumentDelta(ref.current?.getContents())).toBe(true);
+    expect(editor.querySelector("h2")?.textContent).toBe("Morning");
+  });
+
+  it("maps headings 1-3 and the quote marker", async () => {
+    for (const [typed, selector] of [
+      ["# h", "h1"],
+      ["## h", "h2"],
+      ["### h", "h3"],
+      ["> q", "blockquote"],
+    ] as const) {
+      const { editor } = mountEditor();
+      await userEvent.type(editor, typed);
+      expect(editor.querySelector(selector), typed).not.toBeNull();
+    }
+  });
+
+  it("leaves four hashes, indented and mid-line markers literal", async () => {
+    const four = mountEditor();
+    await userEvent.type(four.editor, "#### h");
+    expect(four.editor.querySelector("h4,h5,h6")).toBeNull();
+    expect(firstText(four.ops())).toBe("#### h");
+
+    const prose = mountEditor();
+    await userEvent.type(prose.editor, "a > b then more");
+    expect(prose.editor.querySelector("blockquote")).toBeNull();
+    expect(firstText(prose.ops())).toBe("a > b then more");
+  });
+
+  it("restores the literal markdown with a single undo", async () => {
+    const { ref, quill, editor } = mountEditor();
+    await userEvent.type(editor, "## ");
+    expect(quill.getFormat(0).header).toBe(2);
+
+    act(() => ref.current?.undo());
+    expect(quill.getText(0, 3)).toBe("## ");
+    expect(quill.getFormat(0).header).toBeUndefined();
+  });
+
+  it("keeps toolbar state in sync after a heading rewrite", async () => {
+    const { editor, onStateChange } = mountEditor();
+    await userEvent.type(editor, "## ");
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        formats: expect.objectContaining({ header: 2 }),
+      }),
+    );
+  });
+
+  it("does not re-format a line that already has a block format", async () => {
+    const { editor, quill } = mountEditor();
+    await userEvent.type(editor, "> quote");
+    expect(editor.querySelector("blockquote")).not.toBeNull();
+
+    // "# " typed at the head of the existing quote line (driven directly so the
+    // caret lands there — userEvent would type at the document end).
+    act(() => {
+      quill.insertText(0, "#", "user");
+      quill.insertText(1, " ", "user");
+    });
+    expect(editor.querySelector("h1")).toBeNull();
+    expect(editor.querySelector("blockquote")).not.toBeNull();
+    expect(quill.getText(0, 2)).toBe("# ");
+  });
+
+  describe("inline runs", () => {
+    it("rewrites bold and ends the run so later text is unformatted", async () => {
+      const { editor, ops } = mountEditor();
+      await userEvent.type(editor, "see **bold** ok");
+
+      expect(attributedOp(ops(), "bold")?.insert).toBe("bold");
+      expect(
+        ops().some(
+          (op) =>
+            typeof op.insert === "string" &&
+            op.insert.includes("ok") &&
+            op.attributes?.bold == null,
+        ),
+      ).toBe(true);
+    });
+
+    it("restores an inline run with a single undo", async () => {
+      const { ref, quill, editor, ops } = mountEditor();
+      await userEvent.type(editor, "a ~~x~~");
+      expect(ops()).toContainEqual({
+        insert: "x",
+        attributes: { strike: true },
+      });
+      act(() => ref.current?.undo());
+      expect(quill.getText().trim()).toBe("a ~~x~~");
+    });
+
+    it("only fires at a whitespace or start-of-line boundary", async () => {
+      const intra = mountEditor();
+      await userEvent.type(intra.editor, "rename snake_case_name and 2*3*4");
+      expect(intra.ops().every((op) => op.attributes == null)).toBe(true);
+      expect(firstText(intra.ops())).toBe("rename snake_case_name and 2*3*4");
+    });
+
+    it("leaves nested and adjacent delimiters completely literal", async () => {
+      const nested = mountEditor();
+      await userEvent.type(nested.editor, "***whoa***");
+      expect(nested.ops().every((op) => op.attributes == null)).toBe(true);
+      expect(firstText(nested.ops())).toBe("***whoa***");
+    });
+
+    it("validates link URLs, leaving unsafe or malformed ones as text", async () => {
+      const safe = mountEditor();
+      await userEvent.type(safe.editor, literal("[Docs](https://journiv.com)"));
+      expect(safe.ops()).toContainEqual({
+        insert: "Docs",
+        attributes: { link: "https://journiv.com" },
+      });
+
+      const unsafe = mountEditor();
+      await userEvent.type(unsafe.editor, literal("[x](javascript:void)"));
+      expect(attributedOp(unsafe.ops(), "link")).toBeUndefined();
+      expect(firstText(unsafe.ops())).toBe("[x](javascript:void)");
+    });
+
+    it("does not fire while an IME composition is active", async () => {
+      const { editor, ops } = mountEditor();
+      act(() => {
+        editor.dispatchEvent(
+          new CompositionEvent("compositionstart", { bubbles: true }),
+        );
+      });
+      await userEvent.type(editor, "see **bold**");
+      expect(attributedOp(ops(), "bold")).toBeUndefined();
+      act(() => {
+        editor.dispatchEvent(
+          new CompositionEvent("compositionend", { bubbles: true }),
+        );
+      });
+    });
+  });
+
+  describe("list markers are Quill's, narrowed to what Journiv stores", () => {
+    it("makes `- `, `* ` and `1. ` lists that round-trip", async () => {
+      for (const [typed, list] of [
+        ["- one", "bullet"],
+        ["* one", "bullet"],
+        ["1. one", "ordered"],
+      ] as const) {
+        const { ref, editor } = mountEditor();
+        await userEvent.type(editor, typed);
+        expect(
+          editor.querySelector(`li[data-list="${list}"]`),
+          typed,
+        ).not.toBeNull();
+        expect(isQuillDocumentDelta(ref.current?.getContents()), typed).toBe(
+          true,
+        );
+      }
+    });
+
+    it("leaves `2. `, `10. ` and checkbox markers as literal text", async () => {
+      for (const marker of [
+        "2. two",
+        "10. ten",
+        literal("[ ] task"),
+        literal("[x] done"),
+      ]) {
+        const { ref, editor } = mountEditor();
+        await userEvent.type(editor, marker);
+        expect(editor.querySelector("li"), marker).toBeNull();
+        // The document is still saveable — no out-of-Gate-1 list value.
+        expect(isQuillDocumentDelta(ref.current?.getContents()), marker).toBe(
+          true,
+        );
+      }
+    });
+
+    it("a single undo of a bare `- ` restores the literal marker", async () => {
+      const { ref, quill, editor } = mountEditor();
+      await userEvent.type(editor, "- ");
+      expect(editor.querySelector('li[data-list="bullet"]')).not.toBeNull();
+      // Quill's list-autofill brackets the transform with history.cutoff() on
+      // both sides, like markdownShortcuts.ts does for headings, so one undo
+      // reverts exactly the transform.
+      act(() => ref.current?.undo());
+      expect(editor.querySelector("li")).toBeNull();
+      expect(quill.getText().replace(/\n+$/, "")).toBe("- ");
+    });
+  });
+
+  it("survives a save and reload round-trip", async () => {
+    const { ref, editor } = mountEditor();
+    await userEvent.type(editor, "# Title{enter}");
+    await userEvent.type(
+      editor,
+      literal("with **weight** and a [link](https://journiv.com){enter}- one"),
+    );
+    const saved = ref.current?.getContents();
+    expect(isQuillDocumentDelta(saved)).toBe(true);
+    expect(saved?.ops).toContainEqual({
+      insert: "\n",
+      attributes: { header: 1 },
+    });
+    expect(saved?.ops).toContainEqual({
+      insert: "weight",
+      attributes: { bold: true },
+    });
+
+    const reloaded = createRef<QuillSurfaceHandle>();
+    render(
+      <QuillSurface
+        ref={reloaded}
+        editorId="markdown-reload"
+        initialContent={saved as QuillDelta}
+      />,
+    );
+    expect(reloaded.current?.getContents()).toEqual(saved);
+  });
+
+  it("never rewrites in a read-only surface", () => {
+    const ref = createRef<QuillSurfaceHandle>();
+    render(
+      <QuillSurface
+        ref={ref}
+        editorId="ro"
+        initialContent={{ ops: [{ insert: "## not a heading\n" }] }}
+        readOnly
+      />,
+    );
+    const contents = ref.current?.getContents() as QuillDelta | undefined;
+    expect(contents?.ops?.[0]).toEqual({ insert: "## not a heading\n" });
+  });
+});

--- a/frontend/src/features/editor/markdownShortcuts.integration.test.tsx
+++ b/frontend/src/features/editor/markdownShortcuts.integration.test.tsx
@@ -281,4 +281,26 @@ describe("markdown shortcuts in the writing surface", () => {
     const contents = ref.current?.getContents() as QuillDelta | undefined;
     expect(contents?.ops?.[0]).toEqual({ insert: "## not a heading\n" });
   });
+
+  it("installs shortcuts when a read-only surface becomes editable", async () => {
+    const view = render(
+      <QuillSurface
+        editorId="read-only-transition"
+        initialContent={{ ops: [{ insert: "\n" }] }}
+        readOnly
+      />,
+    );
+    const editor = within(view.container).getByLabelText("Entry content");
+
+    view.rerender(
+      <QuillSurface
+        editorId="read-only-transition"
+        initialContent={{ ops: [{ insert: "\n" }] }}
+      />,
+    );
+    expect(within(view.container).getByLabelText("Entry body")).toBe(editor);
+
+    await userEvent.type(editor, "## Morning");
+    expect(editor.querySelector("h2")?.textContent).toBe("Morning");
+  });
 });

--- a/frontend/src/features/editor/markdownShortcuts.test.ts
+++ b/frontend/src/features/editor/markdownShortcuts.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { JOURNIV_DELTA_FORMATS } from "./deltaProfile";
+import {
+  detectBlockShortcut,
+  detectInlineShortcut,
+  MARKDOWN_SHORTCUT_FORMATS,
+  typedInsertion,
+} from "./markdownShortcuts";
+
+describe("detectBlockShortcut", () => {
+  it("maps hash markers to headings 1-3 only", () => {
+    expect(detectBlockShortcut("# ")).toEqual({
+      kind: "block",
+      format: "header",
+      value: 1,
+      markerLength: 2,
+    });
+    expect(detectBlockShortcut("## ")).toMatchObject({ value: 2 });
+    expect(detectBlockShortcut("### ")).toMatchObject({ value: 3 });
+    // Gate-1 has no h4-h6: left literal.
+    expect(detectBlockShortcut("#### ")).toBeNull();
+  });
+
+  it("maps the quote marker", () => {
+    expect(detectBlockShortcut("> ")).toEqual({
+      kind: "block",
+      format: "blockquote",
+      value: true,
+      markerLength: 2,
+    });
+  });
+
+  it("does not own list markers — Quill's list autofill handles those", () => {
+    expect(detectBlockShortcut("- ")).toBeNull();
+    expect(detectBlockShortcut("* ")).toBeNull();
+    expect(detectBlockShortcut("1. ")).toBeNull();
+  });
+
+  it("does not fire inside ordinary prose or on escaped markers", () => {
+    expect(detectBlockShortcut("a > b ")).toBeNull();
+    expect(detectBlockShortcut("text > ")).toBeNull();
+    expect(detectBlockShortcut("\\# ")).toBeNull();
+    expect(detectBlockShortcut("  # ")).toBeNull();
+    // Marker without exactly one trailing space is not complete.
+    expect(detectBlockShortcut("#")).toBeNull();
+    expect(detectBlockShortcut("#  ")).toBeNull();
+  });
+});
+
+describe("detectInlineShortcut", () => {
+  it("rewrites bold, italic and strikethrough runs at a word boundary", () => {
+    expect(detectInlineShortcut("say **hi**")).toEqual({
+      kind: "inline",
+      format: "bold",
+      start: 4,
+      end: 10,
+      text: "hi",
+    });
+    expect(detectInlineShortcut("__hi__")).toMatchObject({
+      format: "bold",
+      start: 0,
+      text: "hi",
+    });
+    expect(detectInlineShortcut("a *word*")).toMatchObject({
+      format: "italic",
+      start: 2,
+      text: "word",
+    });
+    expect(detectInlineShortcut("_word_")).toMatchObject({ format: "italic" });
+    expect(detectInlineShortcut("~~gone~~")).toMatchObject({
+      format: "strike",
+      text: "gone",
+    });
+    // A leading space is a boundary too.
+    expect(detectInlineShortcut(" _x_")).toMatchObject({
+      format: "italic",
+      start: 1,
+      text: "x",
+    });
+  });
+
+  it("prefers bold over italic for a double marker", () => {
+    expect(detectInlineShortcut("**x**")).toMatchObject({
+      format: "bold",
+      text: "x",
+    });
+  });
+
+  it("requires a whitespace or start-of-line boundary before the opener", () => {
+    // Intra-word emphasis: arithmetic and snake_case must survive.
+    expect(detectInlineShortcut("foo_bar_")).toBeNull();
+    expect(detectInlineShortcut("foo_bar_baz_")).toBeNull();
+    expect(detectInlineShortcut("2*3*")).toBeNull();
+    expect(detectInlineShortcut("a*b*")).toBeNull();
+    expect(detectInlineShortcut("word**bold**")).toBeNull();
+    expect(detectInlineShortcut("word~~s~~")).toBeNull();
+    // Underscores inside a URL fragment.
+    expect(
+      detectInlineShortcut("https://en.wikipedia.org/wiki/Foo_bar_"),
+    ).toBeNull();
+    // Punctuation is not a boundary — keep it predictable.
+    expect(detectInlineShortcut("(**x**")).toBeNull();
+  });
+
+  it("leaves nested, adjacent, padded and escaped delimiters literal", () => {
+    expect(detectInlineShortcut("***text***")).toBeNull();
+    expect(detectInlineShortcut("**_x_**")).toBeNull();
+    expect(detectInlineShortcut("____")).toBeNull();
+    expect(detectInlineShortcut("****")).toBeNull();
+    expect(detectInlineShortcut("* *")).toBeNull();
+    expect(detectInlineShortcut("** **")).toBeNull();
+    expect(detectInlineShortcut("**x **")).toBeNull();
+    expect(detectInlineShortcut("a ** b **")).toBeNull();
+    expect(detectInlineShortcut("~~~")).toBeNull();
+    expect(detectInlineShortcut("\\*x\\*")).toBeNull();
+    expect(detectInlineShortcut("\\*x*")).toBeNull();
+    expect(detectInlineShortcut("nothing here")).toBeNull();
+  });
+
+  it("validates link URLs and leaves unsafe or malformed ones as text", () => {
+    expect(detectInlineShortcut("[Journiv](https://journiv.com)")).toEqual({
+      kind: "inline",
+      format: "link",
+      start: 0,
+      end: 30,
+      text: "Journiv",
+      link: "https://journiv.com",
+    });
+    expect(detectInlineShortcut("[mail](mailto:a@b.com)")).toMatchObject({
+      link: "mailto:a@b.com",
+    });
+    expect(detectInlineShortcut("[u](https://x.com/a_b_c)")).toMatchObject({
+      link: "https://x.com/a_b_c",
+    });
+    expect(detectInlineShortcut("[x](javascript:void)")).toBeNull();
+    expect(detectInlineShortcut("[x](ftp://x.com)")).toBeNull();
+    expect(detectInlineShortcut("[x](/relative/path)")).toBeNull();
+    expect(detectInlineShortcut("[x]()")).toBeNull();
+    expect(detectInlineShortcut("[](https://x.com)")).toBeNull();
+    expect(detectInlineShortcut("[x](  )")).toBeNull();
+    expect(detectInlineShortcut("[x](https://x.com")).toBeNull();
+    expect(detectInlineShortcut("\\[x](https://x.com)")).toBeNull();
+  });
+});
+
+describe("typedInsertion", () => {
+  it("recognises a single typed character and its index", () => {
+    expect(typedInsertion({ ops: [{ insert: " " }] })).toEqual({
+      char: " ",
+      index: 0,
+    });
+    expect(typedInsertion({ ops: [{ retain: 12 }, { insert: "*" }] })).toEqual({
+      char: "*",
+      index: 12,
+    });
+  });
+
+  it("ignores pastes, IME multi-char commits, deletions, embeds and formatting", () => {
+    expect(typedInsertion({ ops: [{ insert: "hello" }] })).toBeNull();
+    expect(typedInsertion({ ops: [{ insert: "日本" }] })).toBeNull();
+    expect(typedInsertion({ ops: [{ delete: 1 }] })).toBeNull();
+    expect(
+      typedInsertion({ ops: [{ retain: 1 }, { insert: "x" }, { delete: 2 }] }),
+    ).toBeNull();
+    expect(typedInsertion({ ops: [{ insert: { image: "/x" } }] })).toBeNull();
+    expect(
+      typedInsertion({ ops: [{ retain: 3, attributes: { bold: true } }] }),
+    ).toBeNull();
+    expect(typedInsertion({ ops: [] })).toBeNull();
+  });
+});
+
+describe("format allowlist", () => {
+  it("only ever produces Gate-1 attributes", () => {
+    for (const format of MARKDOWN_SHORTCUT_FORMATS) {
+      expect(JOURNIV_DELTA_FORMATS).toContain(format);
+    }
+  });
+});

--- a/frontend/src/features/editor/markdownShortcuts.ts
+++ b/frontend/src/features/editor/markdownShortcuts.ts
@@ -219,6 +219,8 @@ export function typedInsertion(
 }
 
 type InstallOptions = {
+  /** Whether shortcuts may rewrite the current user change. */
+  isEnabled?: () => boolean;
   /** Suppress rewrites while an IME composition is active. */
   isComposing?: () => boolean;
   /**
@@ -305,6 +307,7 @@ export function installMarkdownShortcuts(
     source: string,
   ) => {
     if (applying || source !== "user") return;
+    if (options.isEnabled?.() === false) return;
     if (options.isComposing?.()) return;
 
     const typed = typedInsertion(delta);

--- a/frontend/src/features/editor/markdownShortcuts.ts
+++ b/frontend/src/features/editor/markdownShortcuts.ts
@@ -1,0 +1,360 @@
+import { Delta } from "quill";
+import type Quill from "quill";
+import type { JOURNIV_DELTA_FORMATS } from "./deltaProfile";
+import { validateLinkUrl } from "./linkPolicy";
+
+/**
+ * Markdown *input* shortcuts for the writing surface.
+ *
+ * This is an input method, not a storage format: typed shorthand is rewritten
+ * into exactly the same Delta the toolbar would have produced, and nothing here
+ * can emit an attribute outside the Gate-1 allowlist
+ * (`JOURNIV_DELTA_FORMATS`). Persisted content stays a Quill Delta — see
+ * docs/features/editor.md.
+ *
+ * Scope: this module owns the block markers Quill does **not** — `#`/`##`/`###`
+ * and `>` — plus inline `**`/`__`, `*`/`_`, `~~` and `[text](url)`. Bullet and
+ * ordered lists come from Quill's own `list autofill` keyboard binding (narrowed
+ * to `1.`/`-`/`*` in QuillSurface); this module deliberately does not duplicate
+ * them, which is also why nothing here is deferred — `#` and `>` apply cleanly
+ * inside the text-change, only a `<p>`→`<ol>` swap does not.
+ *
+ * These are typing shortcuts, not a CommonMark parser. The rules are
+ * deliberately narrow and never *partially* transform:
+ *
+ *   - Escaping is positional, not a backslash mechanism. A block marker fires
+ *     only when the text from line start to caret is *exactly* the marker plus
+ *     one space, so any preceding character — `\`, a space, other prose — leaves
+ *     it literal. An inline run fires only when its opening delimiter is at the
+ *     start of the line or right after whitespace, so `foo_bar_`, `2*3*`,
+ *     `word**x**` and `\*x\*` are all left as typed. Backslashes are never
+ *     consumed or interpreted; they simply sit before a delimiter and, being
+ *     non-whitespace, stop the match.
+ *   - Nested or multi-level markdown (`***x***`, `**_x_**`), adjacent delimiters
+ *     (`****`, `* *`), unsupported constructs (`` `code` ``, `![img]()`, `+ `,
+ *     `#### `, setext headings) and malformed or unsafe links (`[x]()`,
+ *     `[x](javascript:…)`) are left completely literal.
+ *
+ * Two halves:
+ *   - `detectBlockShortcut` / `detectInlineShortcut` are pure string logic and
+ *     carry the whole behaviour contract (boundaries, escaping, validation).
+ *   - `installMarkdownShortcuts` is the thin Quill binding that applies a match
+ *     as a single, undoable `"user"` change.
+ */
+
+export type BlockShortcut = {
+  kind: "block";
+  /** Gate-1 line format to apply across the line. */
+  format: "header" | "blockquote";
+  value: 1 | 2 | 3 | true;
+  /** Characters to remove from the start of the line (marker + its space). */
+  markerLength: number;
+};
+
+export type InlineShortcut = {
+  kind: "inline";
+  format: "bold" | "italic" | "strike" | "link";
+  /** Line offsets of the run to replace, `[start, end)`. `end` is the caret. */
+  start: number;
+  end: number;
+  /** Text that survives, with the marker characters stripped. */
+  text: string;
+  /** Present only for links; already passed `validateLinkUrl`. */
+  link?: string;
+};
+
+/** Characters whose insertion can complete a shortcut. */
+export const TRIGGER_CHARACTERS = [" ", "*", "_", "~", ")"] as const;
+
+const BLOCK_RULES: Array<{
+  pattern: RegExp;
+  build: (match: RegExpMatchArray) => BlockShortcut;
+}> = [
+  {
+    // #, ##, ### only. Four or more hashes is not a Journiv heading and stays
+    // literal.
+    pattern: /^(#{1,3}) $/,
+    build: (match) => ({
+      kind: "block",
+      format: "header",
+      value: match[1].length as 1 | 2 | 3,
+      markerLength: match[1].length + 1,
+    }),
+  },
+  {
+    pattern: /^> $/,
+    build: () => ({
+      kind: "block",
+      format: "blockquote",
+      value: true,
+      markerLength: 2,
+    }),
+  },
+];
+
+/**
+ * A block shortcut for `lineBeforeCaret`, or `null`.
+ *
+ * `lineBeforeCaret` is the text from the start of the current line up to the
+ * caret. A rule fires only when that whole slice is the marker followed by one
+ * space, so ordinary prose ("a > b ") is never rewritten and a leading
+ * backslash ("\\# ") keeps the text literal. Bullet and ordered lists are
+ * Quill's own keyboard binding, not this module.
+ */
+export function detectBlockShortcut(
+  lineBeforeCaret: string,
+): BlockShortcut | null {
+  for (const rule of BLOCK_RULES) {
+    const match = lineBeforeCaret.match(rule.pattern);
+    if (match) return rule.build(match);
+  }
+  return null;
+}
+
+// Inline runs: the opening delimiter must sit at the start of the slice or
+// right after whitespace (`(?<!\S)` — which also rejects a `\`-escaped
+// delimiter and a second delimiter of `**`/`__`), then a non-space/non-marker
+// first character, a lazy middle, a non-space/non-marker last character, and
+// the closing delimiter at the very end of the slice.
+const BOLD_PATTERN = /(?<!\S)(\*\*|__)([^\s*_](?:[^*_\n]*[^\s*_])?)\1$/;
+const ITALIC_PATTERN = /(?<!\S)([*_])([^\s*_](?:[^*_\n]*[^\s*_])?)\1$/;
+const STRIKE_PATTERN = /(?<!\S)(~~)([^\s~](?:[^~\n]*[^\s~])?)~~$/;
+// A link keeps only its `\`-escape guard: the `[text](url)` shape is specific
+// enough that a word boundary would just block legitimate uses like "note.[a](…)".
+const LINK_PATTERN = /(?<!\\)\[([^\]\n]+)\]\(([^)\s\n]+)\)$/;
+
+/**
+ * An inline shortcut ending at the caret, or `null`.
+ *
+ * Order matters: bold is tested before italic so `**x**` is not read as
+ * `*` + `x*`. A link whose URL is not http/https/mailto fails `validateLinkUrl`
+ * and is left as literal text rather than rewritten.
+ */
+export function detectInlineShortcut(
+  lineBeforeCaret: string,
+): InlineShortcut | null {
+  const caret = lineBeforeCaret.length;
+
+  const bold = lineBeforeCaret.match(BOLD_PATTERN);
+  if (bold) {
+    return {
+      kind: "inline",
+      format: "bold",
+      start: caret - bold[0].length,
+      end: caret,
+      text: bold[2],
+    };
+  }
+
+  const strike = lineBeforeCaret.match(STRIKE_PATTERN);
+  if (strike) {
+    return {
+      kind: "inline",
+      format: "strike",
+      start: caret - strike[0].length,
+      end: caret,
+      text: strike[2],
+    };
+  }
+
+  const italic = lineBeforeCaret.match(ITALIC_PATTERN);
+  if (italic) {
+    return {
+      kind: "inline",
+      format: "italic",
+      start: caret - italic[0].length,
+      end: caret,
+      text: italic[2],
+    };
+  }
+
+  const link = lineBeforeCaret.match(LINK_PATTERN);
+  if (link) {
+    const href = validateLinkUrl(link[2]);
+    if (!href) return null;
+    return {
+      kind: "inline",
+      format: "link",
+      start: caret - link[0].length,
+      end: caret,
+      text: link[1],
+      link: href,
+    };
+  }
+
+  return null;
+}
+
+type ChangeDelta = { ops?: ReadonlyArray<Record<string, unknown>> };
+
+/**
+ * The plain single-character type this change represents, or `null`.
+ *
+ * A shortcut only ever completes on a lone typed character. Anything else — a
+ * paste, a deletion, typing over a selection (which Quill emits as
+ * insert + delete), an embed, a formatting-only change, an IME commit of more
+ * than one character — returns `null` and is ignored, so shortcuts never fire
+ * unexpectedly.
+ */
+export function typedInsertion(
+  delta: ChangeDelta,
+): { char: string; index: number } | null {
+  const ops = delta.ops ?? [];
+  if (ops.length === 0 || ops.length > 2) return null;
+  let insert: unknown;
+  let index = 0;
+  for (const op of ops) {
+    if ("delete" in op || "attributes" in op) return null;
+    if ("retain" in op) {
+      if (typeof op.retain !== "number" || ops.length !== 2) return null;
+      index = op.retain;
+    }
+    if ("insert" in op) {
+      if (insert !== undefined) return null;
+      insert = op.insert;
+    }
+  }
+  if (typeof insert !== "string" || insert.length !== 1) return null;
+  return { char: insert, index };
+}
+
+type InstallOptions = {
+  /** Suppress rewrites while an IME composition is active. */
+  isComposing?: () => boolean;
+  /**
+   * Called after a rewrite, with the document index the caret was left at, so
+   * the host can re-emit editor state.
+   */
+  onApplied?: (caretIndex: number) => void;
+};
+
+/**
+ * Binds markdown input shortcuts to a Quill instance. Returns a teardown that
+ * removes the listener.
+ *
+ * A rewrite is one `"user"` change bracketed by `history.cutoff()`, so a single
+ * undo restores the literal markdown that triggered it and a second undo
+ * removes the text that was typed before it. Everything is synchronous: this
+ * module never touches lists, so there is no `<p>`→`<ol>` swap to defer.
+ */
+export function installMarkdownShortcuts(
+  quill: Quill,
+  options: InstallOptions = {},
+): () => void {
+  let applying = false;
+
+  /** Runs `mutate` as one undoable `"user"` change, isolated in history so a
+   *  single undo reverts exactly it. */
+  const asOneUndoStep = (mutate: () => void) => {
+    applying = true;
+    try {
+      quill.history.cutoff();
+      mutate();
+      quill.history.cutoff();
+    } finally {
+      applying = false;
+    }
+  };
+
+  const applyBlock = (
+    lineStart: number,
+    lineLength: number,
+    shortcut: BlockShortcut,
+  ) => {
+    // Everything after the marker, up to but not including the line's "\n".
+    const trailing = Math.max(lineLength - 1 - shortcut.markerLength, 0);
+    asOneUndoStep(() => {
+      quill.updateContents(
+        new Delta()
+          .retain(lineStart)
+          .delete(shortcut.markerLength)
+          .retain(trailing)
+          .retain(1, { [shortcut.format]: shortcut.value }),
+        "user",
+      );
+      quill.setSelection(lineStart, 0, "silent");
+    });
+    options.onApplied?.(lineStart);
+  };
+
+  const applyInline = (lineStart: number, shortcut: InlineShortcut) => {
+    const from = lineStart + shortcut.start;
+    const runLength = shortcut.end - shortcut.start;
+    const attributeValue = shortcut.format === "link" ? shortcut.link : true;
+    const caretAfter = from + shortcut.text.length;
+
+    asOneUndoStep(() => {
+      quill.updateContents(
+        new Delta()
+          .retain(from)
+          .delete(runLength)
+          .insert(shortcut.text, { [shortcut.format]: attributeValue }),
+        "user",
+      );
+      quill.setSelection(caretAfter, 0, "silent");
+      // Stop the run so the next keystroke is unformatted, matching what a
+      // toolbar toggle would leave behind.
+      quill.format(shortcut.format, false, "user");
+    });
+    options.onApplied?.(caretAfter);
+  };
+
+  const handleTextChange = (
+    delta: ChangeDelta,
+    _old: unknown,
+    source: string,
+  ) => {
+    if (applying || source !== "user") return;
+    if (options.isComposing?.()) return;
+
+    const typed = typedInsertion(delta);
+    if (
+      typed === null ||
+      !(TRIGGER_CHARACTERS as readonly string[]).includes(typed.char)
+    )
+      return;
+
+    // The caret is derived from the change itself, not `getSelection()`: this
+    // runs inside the synchronous text-change, before the browser selection has
+    // settled.
+    const caret = typed.index + 1;
+    const [line, offsetInLine] = quill.getLine(caret);
+    if (!line) return;
+    const lineStart = caret - offsetInLine;
+    const lineBeforeCaret = quill.getText(lineStart, offsetInLine);
+
+    if (typed.char === " ") {
+      const block = detectBlockShortcut(lineBeforeCaret);
+      if (!block) return;
+      // Never re-format a line that already carries a block format.
+      const existing = quill.getFormat(lineStart, Math.max(offsetInLine, 1));
+      if (
+        existing.header != null ||
+        existing.list != null ||
+        existing.blockquote != null
+      )
+        return;
+      applyBlock(lineStart, line.length(), block);
+      return;
+    }
+
+    const inline = detectInlineShortcut(lineBeforeCaret);
+    if (inline) applyInline(lineStart, inline);
+  };
+
+  quill.on("text-change", handleTextChange);
+  return () => quill.off("text-change", handleTextChange);
+}
+
+/**
+ * Every attribute this module can produce is in the Gate-1 allowlist. A test
+ * pins this so a future rule cannot quietly widen what the editor saves.
+ */
+export const MARKDOWN_SHORTCUT_FORMATS = [
+  "header",
+  "blockquote",
+  "bold",
+  "italic",
+  "strike",
+  "link",
+] as const satisfies ReadonlyArray<(typeof JOURNIV_DELTA_FORMATS)[number]>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Markdown typing shortcuts for headings, blockquotes, emphasis, strikethrough, links, and supported list markers.
  - Added a **Markdown shortcuts** help button and responsive dialog explaining available syntax.
  - Shortcut transformations support undo and are disabled in read-only mode.

- **Bug Fixes**
  - Improved list shortcut handling and validation for malformed or unsafe link syntax.

- **Tests**
  - Added comprehensive coverage for shortcut behavior, dialog interactions, undo, read-only mode, and responsive layouts.

- **Documentation**
  - Documented Markdown input behavior and editor boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->